### PR TITLE
Add 'createNoopClient' to core

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -121,4 +121,11 @@ export function createClient (options: ClientOptions): BugsnagPerformance {
   }
 }
 
-export default createClient
+export function createNoopClient (): BugsnagPerformance {
+  const noop = () => {}
+
+  return {
+    start: noop,
+    startSpan: () => ({ end: noop })
+  }
+}

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -1,4 +1,4 @@
-import { createClient } from '../lib/core'
+import { createClient, createNoopClient } from '../lib/core'
 import { InMemoryProcessor, StableIdGenerator, IncrementingClock } from './utilities'
 
 describe('Core', () => {
@@ -180,6 +180,32 @@ describe('Core', () => {
           expect(() => { client.start(config) }).toThrow('No Bugsnag API Key set')
         })
       })
+    })
+  })
+
+  describe('createNoopClient', () => {
+    it('implements the expected API (minimal arguments)', () => {
+      expect(() => {
+        const client = createNoopClient()
+        client.start('api key')
+
+        const span = client.startSpan('name')
+        span.end()
+      }).not.toThrow()
+    })
+
+    it('implements the expected API (all arguments)', () => {
+      expect(() => {
+        const client = createNoopClient()
+        client.start({
+          apiKey: '1234',
+          endpoint: 'https://example.bugsnag.com',
+          releaseStage: 'staging'
+        })
+
+        const span = client.startSpan('name', new Date())
+        span.end()
+      }).not.toThrow()
     })
   })
 })


### PR DESCRIPTION
## Goal

This will be used in various platforms to avoid crashing if we can't run, e.g. in browsers we don't support

This will need extending in future, e.g. when adding platform specific methods, but I think it makes sense to add early so we can augment it over time instead of trying to do everything all at once