### PR TITLE
Create index files for exporting public APIs

### DIFF
--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -1,0 +1,7 @@
+export * from './attributes'
+export * from './clock'
+export * from './core'
+export * from './delivery'
+export * from './id-generator'
+export * from './processor'
+export * from './span'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,8 +11,8 @@
   "homepage": "https://github.com/bugsnag/bugsnag-js-performance",
   "author": "Ben Wilson <ben.wilson@smartbear.com>",
   "license": "MIT",
-  "main": "lib/core.ts",
-  "browser": "dist/core.js",
+  "main": "lib/index.ts",
+  "browser": "dist/index.js",
   "directories": {
     "lib": "lib",
     "test": "tests"

--- a/packages/platforms/browser/lib/BrowserProcessor.ts
+++ b/packages/platforms/browser/lib/BrowserProcessor.ts
@@ -1,9 +1,15 @@
-import { type Configuration } from '@bugsnag/js-performance-core'
-import { attributeToJson, type ResourceAttributeSource } from '@bugsnag/js-performance-core/lib/attributes'
-import { type Clock } from '@bugsnag/js-performance-core/lib/clock'
-import { type Delivery, type DeliveryPayload } from '@bugsnag/js-performance-core/lib/delivery'
-import { type Processor, type ProcessorFactory } from '@bugsnag/js-performance-core/lib/processor'
-import { spanToJson, type SpanEnded } from '@bugsnag/js-performance-core/lib/span'
+import {
+  type Clock,
+  type Configuration,
+  type Delivery,
+  type DeliveryPayload,
+  type Processor,
+  type ProcessorFactory,
+  type ResourceAttributeSource,
+  type SpanEnded,
+  attributeToJson,
+  spanToJson
+} from '@bugsnag/js-performance-core'
 import clock from './clock'
 import browserDelivery, { type Fetch } from './delivery'
 import createResourceAttributesSource from './resource-attributes-source'

--- a/packages/platforms/browser/lib/clock.ts
+++ b/packages/platforms/browser/lib/clock.ts
@@ -1,4 +1,4 @@
-import { type Clock } from '@bugsnag/js-performance-core/lib/clock'
+import { type Clock } from '@bugsnag/js-performance-core'
 
 const NANOSECONDS_IN_MILLISECONDS = 1_000_000
 

--- a/packages/platforms/browser/lib/delivery.ts
+++ b/packages/platforms/browser/lib/delivery.ts
@@ -1,4 +1,4 @@
-import type { Delivery } from '@bugsnag/js-performance-core/lib/delivery'
+import type { Delivery } from '@bugsnag/js-performance-core'
 
 export type Fetch = typeof fetch
 

--- a/packages/platforms/browser/lib/id-generator.ts
+++ b/packages/platforms/browser/lib/id-generator.ts
@@ -1,4 +1,4 @@
-import type { BitLength, IdGenerator } from '@bugsnag/js-performance-core/lib/id-generator'
+import type { BitLength, IdGenerator } from '@bugsnag/js-performance-core'
 
 function toHex (value: number): string {
   return value.toString(16).padStart(2, '0')

--- a/packages/platforms/browser/lib/index.ts
+++ b/packages/platforms/browser/lib/index.ts
@@ -1,0 +1,2 @@
+export { default } from './browser'
+export { type Configuration } from '@bugsnag/js-performance-core'

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -1,4 +1,4 @@
-import type { ResourceAttributes } from '@bugsnag/js-performance-core/lib/attributes'
+import type { ResourceAttributes } from '@bugsnag/js-performance-core'
 
 const version = process.env.PACKAGE_VERSION || '__VERSION__'
 

--- a/packages/platforms/browser/lib/span-attributes-source.ts
+++ b/packages/platforms/browser/lib/span-attributes-source.ts
@@ -1,4 +1,4 @@
-import type { SpanAttribute, SpanAttributesSource } from '@bugsnag/js-performance-core/lib/attributes'
+import type { SpanAttribute, SpanAttributesSource } from '@bugsnag/js-performance-core'
 
 const spanAttributesSource: SpanAttributesSource = () => {
   const spanAttributes = new Map<string, SpanAttribute>()

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -5,8 +5,8 @@
   "author": "Ben Wilson <ben.wilson@smartbear.com>",
   "homepage": "https://github.com/bugsnag/bugsnag-js-performance#readme",
   "license": "MIT",
-  "main": "dist/browser.js",
-  "types": "dist/browser.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "directories": {
     "lib": "lib",
     "test": "tests"

--- a/packages/platforms/browser/webpack.config.js
+++ b/packages/platforms/browser/webpack.config.js
@@ -3,7 +3,7 @@ const pkg = require('./package.json')
 const { DefinePlugin } = require('webpack')
 
 module.exports = {
-  entry: './lib/browser.ts',
+  entry: './lib/index.ts',
   mode: 'production',
   devtool: 'source-map',
   optimization: {


### PR DESCRIPTION
## Goal

This PR adds `index.ts` files that re-export public APIs from other files so that we can import from our packages directly, without having to dig into `lib`

e.g. rather than importing from `@bugsnag/js-performance-core/lib/some-file` we can now import from `@bugsnag/js-performance-core`