### PR TITLE
Avoid node APIs in browser package 

### DIFF
--- a/.jest/set-environment-variables.ts
+++ b/.jest/set-environment-variables.ts
@@ -1,1 +1,0 @@
-process.env.PACKAGE_VERSION = '1.2.3-jest'

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  setupFilesAfterEnv: ['<rootDir>/.jest/matchers.ts', '<rootDir>/.jest/set-environment-variables.ts'],
+  setupFilesAfterEnv: ['<rootDir>/.jest/matchers.ts'],
   reporters: process.env.CI
     ? [['github-actions', { silent: false }], 'summary']
     : ['default']

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -10,7 +10,7 @@ const BugsnagPerformance = createClient({
   resourceAttributesSource: createResourceAttributesSource(navigator),
   spanAttributesSource,
   idGenerator,
-  processorFactory: new BrowserProcessorFactory(global.fetch, navigator)
+  processorFactory: new BrowserProcessorFactory(window.fetch, navigator)
 })
 
 export default BugsnagPerformance

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -1,13 +1,11 @@
 import type { ResourceAttributes } from '@bugsnag/js-performance-core/lib/attributes'
 
-const version = process.env.PACKAGE_VERSION || '__VERSION__'
-
 function createResourceAttributesSource (navigator: Navigator): () => ResourceAttributes {
   return function resourceAttributesSource () {
     return {
-      releaseStage: process.env.NODE_ENV || 'production',
+      releaseStage: 'production',
       sdkName: 'bugsnag.performance.browser',
-      sdkVersion: version,
+      sdkVersion: '__VERSION__',
       userAgent: navigator.userAgent,
       // chromium only
       ...(navigator.userAgentData

--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -39,9 +39,9 @@ describe('BrowserProcessor', () => {
         resourceSpans: [{
           resource: {
             attributes: [
-              { key: 'releaseStage', value: { stringValue: 'test' } },
+              { key: 'releaseStage', value: { stringValue: 'production' } },
               { key: 'sdkName', value: { stringValue: 'bugsnag.performance.browser' } },
-              { key: 'sdkVersion', value: { stringValue: '1.2.3-jest' } },
+              { key: 'sdkVersion', value: { stringValue: '__VERSION__' } },
               { key: 'userAgent', value: { stringValue: expect.stringMatching(/\((?<info>.*?)\)(\s|$)|(?<name>.*?)\/(?<version>.*?)(\s|$)/gm) } }
             ]
           },

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -9,9 +9,9 @@ describe('resourceAttributesSource', () => {
     const resourceAttributesSource = createResourceAttributesSource(navigator)
     expect(resourceAttributesSource()).toEqual({
       userAgent: expect.stringMatching(/\((?<info>.*?)\)(\s|$)|(?<name>.*?)\/(?<version>.*?)(\s|$)/g),
-      releaseStage: 'test',
+      releaseStage: 'production',
       sdkName: 'bugsnag.performance.browser',
-      sdkVersion: '1.2.3-jest'
+      sdkVersion: '__VERSION__'
     })
   })
 })


### PR DESCRIPTION
## Goal

This removes uses of `process.env` and `global`, which allows us to remove the `node` type definitions from the browser package