### PR TITLE
Fix ts-jest using the 'dist' directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,33 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 
+// these paths must be specified because otherwise typescript relies on the
+// "main" field in each package.json file, which points to the compiled JS and
+// we want to run Jest against the TS source
+const paths = {
+  '@bugsnag/js-performance-core': ['./packages/core/lib/index.ts'],
+  '@bugsnag/js-performance-browser': ['./packages/platforms/browser/lib/index.ts']
+}
+
+// convert the tsconfig "paths" option into Jest's "moduleNameMapper" option
+// e.g.: "{ 'path': ['./a/b'] }" -> "{ '^path$': ['<rootDir>/a/b'] }"
+const moduleNameMapper = Object.fromEntries(
+  Object.entries(paths)
+    .map(([name, directories]) => [
+      `^${name}$`,
+      directories.map(directory => directory.replace('./', '<rootDir>/'))
+    ])
+)
+
 module.exports = {
-  preset: 'ts-jest',
+  transform: {
+    '^.+\\.m?[tj]sx?$': [
+      'ts-jest',
+      { tsconfig: { paths } }
+    ]
+  },
   testEnvironment: 'node',
   setupFilesAfterEnv: ['<rootDir>/.jest/matchers.ts'],
+  moduleNameMapper,
   reporters: process.env.CI
     ? [['github-actions', { silent: false }], 'summary']
     : ['default']


### PR DESCRIPTION
## Goal

We don't want TypeScript to look at the files in 'dist' when resolving modules because we want to run the unit tests against the source files — otherwise we'll have to build between test runs

To do this we have to manually tell TS where to look using the 'paths' compiler option. Jest then needs to know about these paths as well, using the 'moduleNameMapper' option

AFAICT this must happen _only_ in Jest's configuration as otherwise TS will get confused when compiling packages that depend on core — it will look at both `dist` _and_ `lib`, which makes it think the types are not compatible as they are defined in different files
