### PR TITLE
Avoid directly using globals in browser clock

### DIFF
--- a/packages/platforms/browser/lib/BrowserProcessor.ts
+++ b/packages/platforms/browser/lib/BrowserProcessor.ts
@@ -10,7 +10,6 @@ import {
   attributeToJson,
   spanToJson
 } from '@bugsnag/js-performance-core'
-import clock from './clock'
 import browserDelivery, { type Fetch } from './delivery'
 import createResourceAttributesSource from './resource-attributes-source'
 
@@ -65,10 +64,12 @@ export class BrowserProcessor implements Processor {
 export class BrowserProcessorFactory implements ProcessorFactory {
   private fetch: Fetch
   private navigator: Navigator
+  private clock: Clock
 
-  constructor (fetch: Fetch, navigator: Navigator) {
+  constructor (fetch: Fetch, navigator: Navigator, clock: Clock) {
     this.fetch = fetch
     this.navigator = navigator
+    this.clock = clock
   }
 
   create (
@@ -78,7 +79,7 @@ export class BrowserProcessorFactory implements ProcessorFactory {
       configuration.apiKey,
       configuration.endpoint,
       browserDelivery(this.fetch),
-      clock,
+      this.clock,
       createResourceAttributesSource(this.navigator)
     )
   }

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -1,16 +1,18 @@
 import { createClient } from '@bugsnag/js-performance-core'
 import { BrowserProcessorFactory } from './BrowserProcessor'
-import clock from './clock'
+import createClock from './clock'
 import idGenerator from './id-generator'
 import createResourceAttributesSource from './resource-attributes-source'
 import spanAttributesSource from './span-attributes-source'
+
+const clock = createClock(performance)
 
 const BugsnagPerformance = createClient({
   clock,
   resourceAttributesSource: createResourceAttributesSource(navigator),
   spanAttributesSource,
   idGenerator,
-  processorFactory: new BrowserProcessorFactory(window.fetch, navigator)
+  processorFactory: new BrowserProcessorFactory(window.fetch, navigator, clock)
 })
 
 export default BugsnagPerformance

--- a/packages/platforms/browser/lib/clock.ts
+++ b/packages/platforms/browser/lib/clock.ts
@@ -2,14 +2,17 @@ import { type Clock } from '@bugsnag/js-performance-core'
 
 const NANOSECONDS_IN_MILLISECONDS = 1_000_000
 
-export function millisecondsToNanoseconds (milliseconds: number): number {
+function millisecondsToNanoseconds (milliseconds: number): number {
   return milliseconds * NANOSECONDS_IN_MILLISECONDS
 }
 
-export const clock: Clock = {
-  now: () => performance.now(), // nanoseconds passed since performance.timeOrigin
-  convert: (date) => millisecondsToNanoseconds(date.getTime() - performance.timeOrigin),
-  toUnixTimestampNanoseconds: (time: number) => time + performance.timeOrigin // convert nanoseconds since timeOrigin to full timeStamp
+function createClock (performance: Performance): Clock {
+  return {
+    now: () => performance.now(),
+    convert: (date) => millisecondsToNanoseconds(date.getTime() - performance.timeOrigin),
+    // convert nanoseconds since timeOrigin to full timestamp
+    toUnixTimestampNanoseconds: (time: number) => time + performance.timeOrigin
+  }
 }
 
-export default clock
+export default createClock

--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -9,8 +9,18 @@ import resourceAttributesSource from '../lib/resource-attributes-source'
 describe('BrowserProcessorFactory', () => {
   it('returns an instance of BrowserProcessor', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
-    const mockLogger = { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() }
-    const processor = new BrowserProcessorFactory(fetch, navigator).create({ apiKey: 'test-api-key', endpoint: '/traces', releaseStage: 'test', logger: mockLogger })
+    const logger = { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() }
+    const clock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => 50_000 }
+
+    const factory = new BrowserProcessorFactory(fetch, navigator, clock)
+
+    const processor = factory.create({
+      apiKey: 'test-api-key',
+      endpoint: '/traces',
+      releaseStage: 'test',
+      logger
+    })
+
     expect(processor).toBeInstanceOf(BrowserProcessor)
   })
 })


### PR DESCRIPTION
## Goal

This PR changes the browser's `clock.ts` to export a factory function, which allows `performance` to be passed in

This makes unit testing marginally easier as `performance` can be modified without affecting the global `window.performance`