### PR TITLE
Workaround `performance.timeOrigin` being missing

### DIFF
--- a/packages/platforms/browser/lib/clock.ts
+++ b/packages/platforms/browser/lib/clock.ts
@@ -1,17 +1,35 @@
 import { type Clock } from '@bugsnag/js-performance-core'
 
+// a cut-down PerformanceTiming interface, since we don't care about most of
+// its properties
+interface PerformanceTiming {
+  navigationStart: number
+}
+
+// the 'Performance' type says 'timeOrigin' is always available, but that's not
+// true on Safari <15 so we mark it as possibly 'undefined'
+interface PerformanceWithOptionalTimeOrigin {
+  now: () => number
+  timeOrigin?: number
+  timing: PerformanceTiming
+}
+
 const NANOSECONDS_IN_MILLISECONDS = 1_000_000
 
 function millisecondsToNanoseconds (milliseconds: number): number {
   return milliseconds * NANOSECONDS_IN_MILLISECONDS
 }
 
-function createClock (performance: Performance): Clock {
+function createClock (performance: PerformanceWithOptionalTimeOrigin): Clock {
+  const timeOrigin = performance.timeOrigin
+    ? performance.timeOrigin
+    : performance.timing.navigationStart
+
   return {
     now: () => performance.now(),
-    convert: (date) => millisecondsToNanoseconds(date.getTime() - performance.timeOrigin),
+    convert: (date) => millisecondsToNanoseconds(date.getTime() - timeOrigin),
     // convert nanoseconds since timeOrigin to full timestamp
-    toUnixTimestampNanoseconds: (time: number) => time + performance.timeOrigin
+    toUnixTimestampNanoseconds: (time: number) => timeOrigin + time
   }
 }
 

--- a/packages/platforms/browser/tests/clock.test.ts
+++ b/packages/platforms/browser/tests/clock.test.ts
@@ -38,15 +38,33 @@ describe('Browser Clock', () => {
     })
 
     it('returns the difference between provided Date and performance.timeOrigin in nanoseconds', () => {
-      const performance: Performance = {
-        ...window.performance,
-        timeOrigin: new Date('2023-01-02T00:00:00.000Z').getTime()
+      const performance = {
+        now: () => 1234,
+        timeOrigin: new Date('2023-01-02T00:00:00.000Z').getTime(),
+        timing: {
+          // this is different to the above date, so we know which is being used
+          navigationStart: new Date('2022-01-01T00:00:00.000Z').getTime()
+        }
       }
 
       const clock = createClock(performance)
       const time = new Date('2023-01-02T00:00:00.002Z')
 
-      expect(clock.convert(time)).toEqual(2_000_000) // 2ms difference = 2million nanos
+      expect(clock.convert(time)).toEqual(2_000_000) // 2ms difference = 2 million nanos
+    })
+
+    it('works when performance.timeOrigin is not defined', () => {
+      const performance = {
+        now: () => 1234,
+        timing: {
+          navigationStart: new Date('2023-01-01T00:00:00.000Z').getTime()
+        }
+      }
+
+      const clock = createClock(performance)
+      const time = new Date('2023-01-01T00:00:00.015Z')
+
+      expect(clock.convert(time)).toEqual(15_000_000) // 15ms difference = 15 million nanos
     })
   })
 })


### PR DESCRIPTION
## Goal

`performance.timeOrigin` wasn't implemented in Safari until v15, so we need a fallback value for it. The deprecated `performance.timing.navigationStart` should be equivalent