### PR TITLE
Move time utilities to core

### DIFF
--- a/packages/core/lib/clock.ts
+++ b/packages/core/lib/clock.ts
@@ -1,3 +1,9 @@
+const NANOSECONDS_IN_MILLISECONDS = 1_000_000
+
+export function millisecondsToNanoseconds (milliseconds: number): number {
+  return milliseconds * NANOSECONDS_IN_MILLISECONDS
+}
+
 export interface Clock {
   // returns a platform-specific value representing the current time
   // this could be an absolute timestamp, a time relative to a "time origin"

--- a/packages/platforms/browser/lib/clock.ts
+++ b/packages/platforms/browser/lib/clock.ts
@@ -1,4 +1,4 @@
-import { type Clock } from '@bugsnag/js-performance-core'
+import { type Clock, millisecondsToNanoseconds } from '@bugsnag/js-performance-core'
 
 // a cut-down PerformanceTiming interface, since we don't care about most of
 // its properties
@@ -12,12 +12,6 @@ interface PerformanceWithOptionalTimeOrigin {
   now: () => number
   timeOrigin?: number
   timing: PerformanceTiming
-}
-
-const NANOSECONDS_IN_MILLISECONDS = 1_000_000
-
-function millisecondsToNanoseconds (milliseconds: number): number {
-  return milliseconds * NANOSECONDS_IN_MILLISECONDS
 }
 
 function createClock (performance: PerformanceWithOptionalTimeOrigin): Clock {


### PR DESCRIPTION
## Goal

Tiny tidy up: `NANOSECONDS_IN_MILLISECONDS` and `millisecondsToNanoseconds` have been moved to core as they are not browser specific