### PR TITLE
Remove browser resource attributes from core

### DIFF
--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -24,14 +24,16 @@ export class SpanAttributes {
   }
 }
 
-export interface ResourceAttributes {
-  brands?: Array<{ name: string, version: string }> // browser.brands
-  platform?: string // browser.platform
-  mobile?: boolean // browser.mobile
-  userAgent: string // browser.user_agent
-  releaseStage: string // deployment.environment
-  sdkName: string // telemetry.sdk.name
-  sdkVersion: string // telemetry.sdk.version
+export class ResourceAttributes extends SpanAttributes {
+  constructor (releaseStage: string, sdkName: string, sdkVersion: string) {
+    const initialValues = new Map([
+      ['releaseStage', releaseStage],
+      ['sdkName', sdkName],
+      ['sdkVersion', sdkVersion]
+    ])
+
+    super(initialValues)
+  }
 }
 
 export type ResourceAttributeSource = () => ResourceAttributes

--- a/packages/core/tests/utilities/resource-attributes-source.ts
+++ b/packages/core/tests/utilities/resource-attributes-source.ts
@@ -1,15 +1,7 @@
-import type { ResourceAttributes } from '../../lib/attributes'
+import { ResourceAttributes } from '../../lib/attributes'
 
 function resourceAttributesSource (): ResourceAttributes {
-  return {
-    brands: [{ name: 'Test Browser', version: '2.0' }],
-    mobile: false,
-    platform: 'test fixture',
-    releaseStage: 'test',
-    sdkName: 'bugsnag.performance.browser',
-    sdkVersion: '1.2.3',
-    userAgent: 'Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3'
-  }
+  return new ResourceAttributes('test', 'bugsnag.performance.core', '1.2.3')
 }
 
 export default resourceAttributesSource

--- a/packages/platforms/browser/lib/BrowserProcessor.ts
+++ b/packages/platforms/browser/lib/BrowserProcessor.ts
@@ -7,7 +7,6 @@ import {
   type ProcessorFactory,
   type ResourceAttributeSource,
   type SpanEnded,
-  attributeToJson,
   spanToJson
 } from '@bugsnag/js-performance-core'
 import browserDelivery, { type Fetch } from './delivery'
@@ -35,14 +34,13 @@ export class BrowserProcessor implements Processor {
   }
 
   add (span: SpanEnded): void {
-    const resourceAttributes = this.resourceAttributeSource()
     const spans = [span]
 
     const payload: DeliveryPayload = {
       resourceSpans: [
         {
           resource: {
-            attributes: Object.entries(resourceAttributes).map(([key, value]) => attributeToJson(key, value))
+            attributes: this.resourceAttributeSource().toJson()
           },
           scopeSpans: [
             {

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -1,18 +1,19 @@
-import type { ResourceAttributes } from '@bugsnag/js-performance-core'
+import { ResourceAttributes } from '@bugsnag/js-performance-core'
 
 function createResourceAttributesSource (navigator: Navigator): () => ResourceAttributes {
   return function resourceAttributesSource () {
-    const attributes: ResourceAttributes = {
-      releaseStage: 'production',
-      sdkName: 'bugsnag.performance.browser',
-      sdkVersion: '__VERSION__',
-      userAgent: navigator.userAgent
-    }
+    const attributes = new ResourceAttributes(
+      'production',
+      'bugsnag.performance.browser',
+      '__VERSION__'
+    )
+
+    attributes.set('userAgent', navigator.userAgent)
 
     // chromium only
     if (navigator.userAgentData) {
-      attributes.platform = navigator.userAgentData.platform
-      attributes.mobile = navigator.userAgentData.mobile
+      attributes.set('platform', navigator.userAgentData.platform)
+      attributes.set('mobile', navigator.userAgentData.mobile)
     }
 
     return attributes

--- a/packages/platforms/browser/navigator-user-agent-data.d.ts
+++ b/packages/platforms/browser/navigator-user-agent-data.d.ts
@@ -3,12 +3,6 @@ declare interface Navigator {
 }
 
 interface NavigatorUserAgentData {
-  readonly brands: BrandVersion[]
   readonly mobile: boolean
   readonly platform: string
-}
-
-interface BrandVersion {
-  readonly brand: string
-  readonly version: string
 }

--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -39,6 +39,8 @@ describe('BrowserProcessor', () => {
 
     const mockDelivery = { send: jest.fn() }
     const mockClock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' }
+    const navigator = { ...window.navigator, userAgent: ':)' }
+
     const processor = new BrowserProcessor('test-api-key', '/traces', mockDelivery, mockClock, resourceAttributesSource(navigator))
     processor.add(span)
 
@@ -52,7 +54,7 @@ describe('BrowserProcessor', () => {
               { key: 'releaseStage', value: { stringValue: 'production' } },
               { key: 'sdkName', value: { stringValue: 'bugsnag.performance.browser' } },
               { key: 'sdkVersion', value: { stringValue: '__VERSION__' } },
-              { key: 'userAgent', value: { stringValue: expect.stringMatching(/\((?<info>.*?)\)(\s|$)|(?<name>.*?)\/(?<version>.*?)(\s|$)/gm) } }
+              { key: 'userAgent', value: { stringValue: ':)' } }
             ]
           },
           scopeSpans: [{

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -5,13 +5,44 @@
 import createResourceAttributesSource from '../lib/resource-attributes-source'
 
 describe('resourceAttributesSource', () => {
-  it('includes the userAgent', () => {
+  it('contains expected values', () => {
+    const navigator = {
+      ...window.navigator,
+      userAgentData: undefined,
+      userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
+    }
+
     const resourceAttributesSource = createResourceAttributesSource(navigator)
-    expect(resourceAttributesSource()).toEqual({
-      userAgent: expect.stringMatching(/\((?<info>.*?)\)(\s|$)|(?<name>.*?)\/(?<version>.*?)(\s|$)/g),
-      releaseStage: 'production',
-      sdkName: 'bugsnag.performance.browser',
-      sdkVersion: '__VERSION__'
-    })
+    const resourceAttributes = resourceAttributesSource()
+
+    expect(resourceAttributes.toJson()).toEqual([
+      { key: 'releaseStage', value: { stringValue: 'production' } },
+      { key: 'sdkName', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'sdkVersion', value: { stringValue: '__VERSION__' } },
+      { key: 'userAgent', value: { stringValue: navigator.userAgent } }
+    ])
+  })
+
+  it('includes browser.platform and browser.mobile if available', () => {
+    const navigator = {
+      ...window.navigator,
+      userAgentData: {
+        platform: 'macOS',
+        mobile: false
+      },
+      userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
+    }
+
+    const resourceAttributesSource = createResourceAttributesSource(navigator)
+    const resourceAttributes = resourceAttributesSource()
+
+    expect(resourceAttributes.toJson()).toEqual([
+      { key: 'releaseStage', value: { stringValue: 'production' } },
+      { key: 'sdkName', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'sdkVersion', value: { stringValue: '__VERSION__' } },
+      { key: 'userAgent', value: { stringValue: navigator.userAgent } },
+      { key: 'platform', value: { stringValue: 'macOS' } },
+      { key: 'mobile', value: { boolValue: false } }
+    ])
   })
 })


### PR DESCRIPTION
## Goal

`ResourceAttributes` is now a class with a default set of values that should be supported on every platform — `releaseStage`, `sdkName` & `sdkVersion`

Platforms can then add whatever other values they require in their `ResourceAttributeSource`, e.g. the browser platform sets `userAgent`