### PR TITLE
Fix resource attributes key names

### DIFF
--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -27,9 +27,9 @@ export class SpanAttributes {
 export class ResourceAttributes extends SpanAttributes {
   constructor (releaseStage: string, sdkName: string, sdkVersion: string) {
     const initialValues = new Map([
-      ['releaseStage', releaseStage],
-      ['sdkName', sdkName],
-      ['sdkVersion', sdkVersion]
+      ['deployment.environment', releaseStage],
+      ['telemetry.sdk.name', sdkName],
+      ['telemetry.sdk.version', sdkVersion]
     ])
 
     super(initialValues)

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -8,12 +8,12 @@ function createResourceAttributesSource (navigator: Navigator): () => ResourceAt
       '__VERSION__'
     )
 
-    attributes.set('userAgent', navigator.userAgent)
+    attributes.set('browser.user_agent', navigator.userAgent)
 
     // chromium only
     if (navigator.userAgentData) {
-      attributes.set('platform', navigator.userAgentData.platform)
-      attributes.set('mobile', navigator.userAgentData.mobile)
+      attributes.set('browser.platform', navigator.userAgentData.platform)
+      attributes.set('browser.mobile', navigator.userAgentData.mobile)
     }
 
     return attributes

--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -39,8 +39,6 @@ describe('BrowserProcessor', () => {
 
     const mockDelivery = { send: jest.fn() }
     const mockClock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' }
-    const navigator = { ...window.navigator, userAgent: ':)' }
-
     const processor = new BrowserProcessor('test-api-key', '/traces', mockDelivery, mockClock, resourceAttributesSource(navigator))
     processor.add(span)
 
@@ -51,10 +49,10 @@ describe('BrowserProcessor', () => {
         resourceSpans: [{
           resource: {
             attributes: [
-              { key: 'releaseStage', value: { stringValue: 'production' } },
-              { key: 'sdkName', value: { stringValue: 'bugsnag.performance.browser' } },
-              { key: 'sdkVersion', value: { stringValue: '__VERSION__' } },
-              { key: 'userAgent', value: { stringValue: ':)' } }
+              { key: 'deployment.environment', value: { stringValue: 'production' } },
+              { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
+              { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+              { key: 'browser.user_agent', value: { stringValue: expect.stringMatching(/\((?<info>.*?)\)(\s|$)|(?<name>.*?)\/(?<version>.*?)(\s|$)/gm) } }
             ]
           },
           scopeSpans: [{

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -16,10 +16,10 @@ describe('resourceAttributesSource', () => {
     const resourceAttributes = resourceAttributesSource()
 
     expect(resourceAttributes.toJson()).toEqual([
-      { key: 'releaseStage', value: { stringValue: 'production' } },
-      { key: 'sdkName', value: { stringValue: 'bugsnag.performance.browser' } },
-      { key: 'sdkVersion', value: { stringValue: '__VERSION__' } },
-      { key: 'userAgent', value: { stringValue: navigator.userAgent } }
+      { key: 'deployment.environment', value: { stringValue: 'production' } },
+      { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
     ])
   })
 
@@ -37,12 +37,12 @@ describe('resourceAttributesSource', () => {
     const resourceAttributes = resourceAttributesSource()
 
     expect(resourceAttributes.toJson()).toEqual([
-      { key: 'releaseStage', value: { stringValue: 'production' } },
-      { key: 'sdkName', value: { stringValue: 'bugsnag.performance.browser' } },
-      { key: 'sdkVersion', value: { stringValue: '__VERSION__' } },
-      { key: 'userAgent', value: { stringValue: navigator.userAgent } },
-      { key: 'platform', value: { stringValue: 'macOS' } },
-      { key: 'mobile', value: { boolValue: false } }
+      { key: 'deployment.environment', value: { stringValue: 'production' } },
+      { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
+      { key: 'browser.platform', value: { stringValue: 'macOS' } },
+      { key: 'browser.mobile', value: { boolValue: false } }
     ])
   })
 })

--- a/test/browser/features/manual-spans.feature
+++ b/test/browser/features/manual-spans.feature
@@ -11,16 +11,16 @@ Feature: Manual creation of spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
 
-    And the trace payload field "resourceSpans.0.resource" string attribute "releaseStage" equals "production"
-    And the trace payload field "resourceSpans.0.resource" string attribute "sdkName" equals "bugsnag.performance.browser"
-    And the trace payload field "resourceSpans.0.resource" string attribute "sdkVersion" equals "0.0.0"
+    And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.browser"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals "0.0.0"
 
   @chromium_only @local_only
   Scenario: userAgentData is included in custom span
     Given I navigate to the test URL "/manual-span"
     When I wait to receive at least 1 trace
-    Then the trace payload field "resourceSpans.0.resource" bool attribute "mobile" is false
-    And the trace payload field "resourceSpans.0.resource" string attribute "platform" is one of:
+    Then the trace payload field "resourceSpans.0.resource" bool attribute "browser.mobile" is false
+    And the trace payload field "resourceSpans.0.resource" string attribute "browser.platform" is one of:
       | Android |
       | Chrome OS |
       | Chromium OS |


### PR DESCRIPTION
## Goal

This PR fixes the resource attribute key names to be Otel compliant:

- `releaseStage` &rarr; `deployment.environment`
- `sdkName` &rarr; `telemetry.sdk.name`
- `sdkVersion` &rarr; `telemetry.sdk.version`
- `userAgent` &rarr; `browser.user_agent`
- `platform` &rarr; `browser.platform`
- `mobile` &rarr; `browser.mobile`