### PR TITLE
Lower TypeScript target to ES2015

### DIFF
--- a/packages/platforms/browser/lib/id-generator.ts
+++ b/packages/platforms/browser/lib/id-generator.ts
@@ -1,7 +1,14 @@
 import type { BitLength, IdGenerator } from '@bugsnag/js-performance-core'
 
 function toHex (value: number): string {
-  return value.toString(16).padStart(2, '0')
+  const hex = value.toString(16)
+
+  // pad hex with a leading 0 if it's not already 2 characters
+  if (hex.length === 1) {
+    return '0' + hex
+  }
+
+  return hex
 }
 
 const idGenerator: IdGenerator = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2015",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
## Goal

This PR lowers TypeScript's target from `ESNext` to `ES2015`

This required a code change as `String.padStart` requires `ES2017` and it's a compilation error if you use it when targeting `ES2015`. I've replaced this is with a simple string pad for `toHex` specifically as I don't think we'll need a general-purpose string padding function

The only change to the generated code because of this is that TypeScript will no longer generate [public class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields), as they require Chrome 72+, Firefox 79+ or Safari 14.1+

For example, this TS class definition:

```ts
class SpanAttributes {
  public readonly attributes: Map<string, SpanAttribute>

  constructor (initialValues: Map<string, SpanAttribute>) {
  // etc...
}
```

was being compiled to:

```js
class SpanAttributes {
  attributes

  constructor (initialValues) {
  // etc...
}
```

but now compiles to:

```js
class SpanAttributes {
  constructor (initialValues) {
  // etc...
}
```

Otherwise the generated code is the same