### PR TITLE
Add modern browsers to ci

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -2,19 +2,16 @@ steps:
 
   - group: "Browser Tests"
     steps:
-      - label:  ":docker: Build browser maze runner image"
+      - label: ":docker: Build browser maze runner image"
         key: "browser-maze-runner"
         timeout_in_minutes: 20
         plugins:
           - docker-compose#v3.9.0:
-              build:
-                - browser-maze-runner
+              build: browser-maze-runner
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-              cache-from:
-                - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
+              cache-from: browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
           - docker-compose#v3.9.0:
-              push:
-                - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
+              push: browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
 
       # BitBar
       - label: ":{{ matrix.browser }}: {{ matrix.version }} tests"


### PR DESCRIPTION
## Goal

This PR adds the modern browsers we support to CI:

- Chrome
- Firefox
- Edge
- Safari

Older browsers require other changes to get working so are not in this PR