### PR TITLE
Set releaseStage to 'development' on localhost

### DIFF
--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -6,7 +6,7 @@ import createResourceAttributesSource from './resource-attributes-source'
 import spanAttributesSource from './span-attributes-source'
 
 const clock = createClock(performance)
-const resourceAttributesSource = createResourceAttributesSource(navigator)
+const resourceAttributesSource = createResourceAttributesSource(navigator, window.location.host)
 
 const BugsnagPerformance = createClient({
   clock,

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -1,9 +1,11 @@
 import { ResourceAttributes } from '@bugsnag/js-performance-core'
 
-function createResourceAttributesSource (navigator: Navigator): () => ResourceAttributes {
+function createResourceAttributesSource (navigator: Navigator, host: string): () => ResourceAttributes {
+  const releaseStage = /^localhost(:\d+)?$/.test(host) ? 'development' : 'production'
+
   return function resourceAttributesSource () {
     const attributes = new ResourceAttributes(
-      'production',
+      releaseStage,
       'bugsnag.performance.browser',
       '__VERSION__'
     )

--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -9,7 +9,7 @@ import createResourceAttributesSource from '../lib/resource-attributes-source'
 describe('BrowserProcessorFactory', () => {
   it('returns an instance of BrowserProcessor', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
-    const resourceAttributesSource = createResourceAttributesSource(window.navigator)
+    const resourceAttributesSource = createResourceAttributesSource(window.navigator, 'www.bugsnag.com')
     const clock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' }
 
     const factory = new BrowserProcessorFactory(fetch, resourceAttributesSource, clock)
@@ -38,8 +38,14 @@ describe('BrowserProcessor', () => {
     }
 
     const mockDelivery = { send: jest.fn() }
-    const mockClock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' }
-    const processor = new BrowserProcessor('test-api-key', '/traces', mockDelivery, mockClock, createResourceAttributesSource(navigator))
+    const processor = new BrowserProcessor(
+      'test-api-key',
+      '/traces',
+      mockDelivery,
+      { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' },
+      createResourceAttributesSource(navigator, 'www.bugsnag.com')
+    )
+
     processor.add(span)
 
     expect(mockDelivery.send).toHaveBeenCalledWith(

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -12,11 +12,47 @@ describe('resourceAttributesSource', () => {
       userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
     }
 
-    const resourceAttributesSource = createResourceAttributesSource(navigator)
+    const resourceAttributesSource = createResourceAttributesSource(navigator, 'www.bugsnag.com')
     const resourceAttributes = resourceAttributesSource()
 
     expect(resourceAttributes.toJson()).toEqual([
       { key: 'deployment.environment', value: { stringValue: 'production' } },
+      { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
+    ])
+  })
+
+  it('sets releaseStage to development on localhost (with port)', () => {
+    const navigator = {
+      ...window.navigator,
+      userAgentData: undefined,
+      userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
+    }
+
+    const resourceAttributesSource = createResourceAttributesSource(navigator, 'localhost:8000')
+    const resourceAttributes = resourceAttributesSource()
+
+    expect(resourceAttributes.toJson()).toEqual([
+      { key: 'deployment.environment', value: { stringValue: 'development' } },
+      { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
+    ])
+  })
+
+  it('sets releaseStage to development on localhost (without port)', () => {
+    const navigator = {
+      ...window.navigator,
+      userAgentData: undefined,
+      userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
+    }
+
+    const resourceAttributesSource = createResourceAttributesSource(navigator, 'localhost')
+    const resourceAttributes = resourceAttributesSource()
+
+    expect(resourceAttributes.toJson()).toEqual([
+      { key: 'deployment.environment', value: { stringValue: 'development' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
@@ -33,7 +69,7 @@ describe('resourceAttributesSource', () => {
       userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
     }
 
-    const resourceAttributesSource = createResourceAttributesSource(navigator)
+    const resourceAttributesSource = createResourceAttributesSource(navigator, 'www.bugsnag.com')
     const resourceAttributes = resourceAttributesSource()
 
     expect(resourceAttributes.toJson()).toEqual([


### PR DESCRIPTION
## Goal

This PR updates the default value for `releaseStage` in the browser platform so it automatically detects if running in `development`. This uses the same logic as the notifier, so `releaseStage` will be consistent when using both `@bugsnag/browser` and `@bugsnag/js-performance-browser`

I noticed that we're currently ignoring the `releaseStage` configuration option. I think we need a fairly big rework of configuration & resource attributes to be able to do that — resource attributes should probably accept a configuration option and pull release stage from there, but that means the browser platform needs to hook into the configuration validation. I'll make a task to implement something like `@bugsnag/js`'s configuration schemas (https://smartbear.atlassian.net/browse/PLAT-9801)