### PR TITLE
Share one `ResourceAttributeSource`

### DIFF
--- a/packages/platforms/browser/lib/BrowserProcessor.ts
+++ b/packages/platforms/browser/lib/BrowserProcessor.ts
@@ -10,7 +10,6 @@ import {
   spanToJson
 } from '@bugsnag/js-performance-core'
 import browserDelivery, { type Fetch } from './delivery'
-import createResourceAttributesSource from './resource-attributes-source'
 
 export class BrowserProcessor implements Processor {
   private apiKey: string
@@ -61,12 +60,12 @@ export class BrowserProcessor implements Processor {
 
 export class BrowserProcessorFactory implements ProcessorFactory {
   private fetch: Fetch
-  private navigator: Navigator
+  private resourceAttributeSource: ResourceAttributeSource
   private clock: Clock
 
-  constructor (fetch: Fetch, navigator: Navigator, clock: Clock) {
+  constructor (fetch: Fetch, resourceAttributeSource: ResourceAttributeSource, clock: Clock) {
     this.fetch = fetch
-    this.navigator = navigator
+    this.resourceAttributeSource = resourceAttributeSource
     this.clock = clock
   }
 
@@ -78,7 +77,7 @@ export class BrowserProcessorFactory implements ProcessorFactory {
       configuration.endpoint,
       browserDelivery(this.fetch),
       this.clock,
-      createResourceAttributesSource(this.navigator)
+      this.resourceAttributeSource
     )
   }
 }

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -6,13 +6,14 @@ import createResourceAttributesSource from './resource-attributes-source'
 import spanAttributesSource from './span-attributes-source'
 
 const clock = createClock(performance)
+const resourceAttributesSource = createResourceAttributesSource(navigator)
 
 const BugsnagPerformance = createClient({
   clock,
-  resourceAttributesSource: createResourceAttributesSource(navigator),
+  resourceAttributesSource,
   spanAttributesSource,
   idGenerator,
-  processorFactory: new BrowserProcessorFactory(window.fetch, navigator, clock)
+  processorFactory: new BrowserProcessorFactory(window.fetch, resourceAttributesSource, clock)
 })
 
 export default BugsnagPerformance

--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -4,21 +4,21 @@
 
 import { Kind, SpanAttributes, type SpanEnded } from '@bugsnag/js-performance-core'
 import { BrowserProcessor, BrowserProcessorFactory } from '../lib/BrowserProcessor'
-import resourceAttributesSource from '../lib/resource-attributes-source'
+import createResourceAttributesSource from '../lib/resource-attributes-source'
 
 describe('BrowserProcessorFactory', () => {
   it('returns an instance of BrowserProcessor', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
-    const logger = { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() }
+    const resourceAttributesSource = createResourceAttributesSource(window.navigator)
     const clock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' }
 
-    const factory = new BrowserProcessorFactory(fetch, navigator, clock)
+    const factory = new BrowserProcessorFactory(fetch, resourceAttributesSource, clock)
 
     const processor = factory.create({
       apiKey: 'test-api-key',
       endpoint: '/traces',
       releaseStage: 'test',
-      logger
+      logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() }
     })
 
     expect(processor).toBeInstanceOf(BrowserProcessor)
@@ -39,7 +39,7 @@ describe('BrowserProcessor', () => {
 
     const mockDelivery = { send: jest.fn() }
     const mockClock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' }
-    const processor = new BrowserProcessor('test-api-key', '/traces', mockDelivery, mockClock, resourceAttributesSource(navigator))
+    const processor = new BrowserProcessor('test-api-key', '/traces', mockDelivery, mockClock, createResourceAttributesSource(navigator))
     processor.add(span)
 
     expect(mockDelivery.send).toHaveBeenCalledWith(


### PR DESCRIPTION
## Goal

Previously we made a ResourceAttributeSource for the client and a separate one for the processor

Now we share a single ResourceAttributeSource instance between both