### PR TITLE
Standardise parameter order

### DIFF
--- a/packages/platforms/browser/lib/BrowserProcessor.ts
+++ b/packages/platforms/browser/lib/BrowserProcessor.ts
@@ -19,8 +19,8 @@ export class BrowserProcessor implements Processor {
   private resourceAttributeSource: ResourceAttributeSource
 
   constructor (
-    apiKey: string,
     endpoint: string,
+    apiKey: string,
     delivery: Delivery,
     clock: Clock,
     resourceAttributeSource: ResourceAttributeSource
@@ -73,8 +73,8 @@ export class BrowserProcessorFactory implements ProcessorFactory {
     configuration: Required<Configuration>
   ): BrowserProcessor {
     return new BrowserProcessor(
-      configuration.apiKey,
       configuration.endpoint,
+      configuration.apiKey,
       browserDelivery(this.fetch),
       this.clock,
       this.resourceAttributeSource

--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -39,8 +39,8 @@ describe('BrowserProcessor', () => {
 
     const mockDelivery = { send: jest.fn() }
     const processor = new BrowserProcessor(
-      'test-api-key',
       '/traces',
+      'test-api-key',
       mockDelivery,
       { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' },
       createResourceAttributesSource(navigator, 'www.bugsnag.com')


### PR DESCRIPTION
## Goal

Ensure `BrowserProcessor` constructor passes params to `delivery.send()` in the same order