### PR TITLE
Consolidate valid configuration into utilities for browser package

### DIFF
--- a/packages/platforms/browser/tests/BrowserProcessor.test.ts
+++ b/packages/platforms/browser/tests/BrowserProcessor.test.ts
@@ -5,14 +5,7 @@
 import { Kind, SpanAttributes, type SpanEnded } from '@bugsnag/js-performance-core'
 import { BrowserProcessor, BrowserProcessorFactory } from '../lib/BrowserProcessor'
 import createResourceAttributesSource from '../lib/resource-attributes-source'
-
-const CONFIGURATION = {
-  apiKey: 'test-api-key',
-  endpoint: '/traces',
-  releaseStage: 'production',
-  logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() },
-  appVersion: ''
-}
+import { createConfiguration } from './utilities'
 
 describe('BrowserProcessorFactory', () => {
   it('returns an instance of BrowserProcessor', () => {
@@ -21,8 +14,7 @@ describe('BrowserProcessorFactory', () => {
     const clock = { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' }
 
     const factory = new BrowserProcessorFactory(fetch, resourceAttributesSource, clock)
-
-    const processor = factory.create(CONFIGURATION)
+    const processor = factory.create(createConfiguration())
 
     expect(processor).toBeInstanceOf(BrowserProcessor)
   })
@@ -42,7 +34,7 @@ describe('BrowserProcessor', () => {
 
     const mockDelivery = { send: jest.fn() }
     const processor = new BrowserProcessor(
-      CONFIGURATION,
+      createConfiguration({ apiKey: 'test-api-key' }),
       mockDelivery,
       { now: jest.now, convert: () => 20_000, toUnixTimestampNanoseconds: () => '50000' },
       createResourceAttributesSource(navigator)

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -3,6 +3,7 @@
  */
 
 import createResourceAttributesSource from '../lib/resource-attributes-source'
+import { createConfiguration } from './utilities'
 
 describe('resourceAttributesSource', () => {
   it('contains expected values', () => {
@@ -13,18 +14,7 @@ describe('resourceAttributesSource', () => {
     }
 
     const resourceAttributesSource = createResourceAttributesSource(navigator)
-    const resourceAttributes = resourceAttributesSource({
-      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      endpoint: '/traces',
-      releaseStage: 'test',
-      logger: {
-        debug: jest.fn(),
-        warn: jest.fn(),
-        info: jest.fn(),
-        error: jest.fn()
-      },
-      appVersion: '1.0.0'
-    })
+    const resourceAttributes = resourceAttributesSource(createConfiguration({ releaseStage: 'test', appVersion: '1.0.0' }))
 
     expect(resourceAttributes.toJson()).toEqual([
       { key: 'deployment.environment', value: { stringValue: 'test' } },
@@ -43,21 +33,10 @@ describe('resourceAttributesSource', () => {
     }
 
     const resourceAttributesSource = createResourceAttributesSource(navigator)
-    const resourceAttributes = resourceAttributesSource({
-      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      endpoint: '/traces',
-      releaseStage: 'test',
-      logger: {
-        debug: jest.fn(),
-        warn: jest.fn(),
-        info: jest.fn(),
-        error: jest.fn()
-      },
-      appVersion: ''
-    })
+    const resourceAttributes = resourceAttributesSource(createConfiguration())
 
     expect(resourceAttributes.toJson()).toEqual([
-      { key: 'deployment.environment', value: { stringValue: 'test' } },
+      { key: 'deployment.environment', value: { stringValue: 'production' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
@@ -75,18 +54,7 @@ describe('resourceAttributesSource', () => {
     }
 
     const resourceAttributesSource = createResourceAttributesSource(navigator)
-    const resourceAttributes = resourceAttributesSource({
-      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      endpoint: '/traces',
-      releaseStage: 'production',
-      logger: {
-        debug: jest.fn(),
-        warn: jest.fn(),
-        info: jest.fn(),
-        error: jest.fn()
-      },
-      appVersion: ''
-    })
+    const resourceAttributes = resourceAttributesSource(createConfiguration())
 
     expect(resourceAttributes.toJson()).toEqual([
       { key: 'deployment.environment', value: { stringValue: 'production' } },

--- a/packages/platforms/browser/tests/utilities/index.ts
+++ b/packages/platforms/browser/tests/utilities/index.ts
@@ -1,0 +1,17 @@
+import { type InternalConfiguration } from '@bugsnag/js-performance-core'
+
+export function createConfiguration (overrides: Partial<InternalConfiguration> = {}): InternalConfiguration {
+  return {
+    apiKey: 'abcdefabcdefabcdefabcdefabcdef12',
+    endpoint: '/traces',
+    releaseStage: 'production',
+    logger: {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn()
+    },
+    appVersion: '',
+    ...overrides
+  }
+}


### PR DESCRIPTION
## Goal

Moves the creation of configuration objects in a couple of tests into a utilities directory in the browser package

Now when we add new configuration properties we only have to change 1 place to get the browser tests running