### PR TITLE
Use the default output on GH Actions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,5 @@ module.exports = {
   testEnvironment: 'node',
   setupFilesAfterEnv: ['<rootDir>/.jest/matchers.ts'],
   moduleNameMapper,
-  reporters: process.env.CI
-    ? [['github-actions', { silent: false }], 'summary']
-    : ['default']
+  reporters: process.env.CI ? ['github-actions', 'default'] : ['default']
 }


### PR DESCRIPTION
## Goal

The GH Action reporter displays some very weird output when the tests fail, so let's use the default reporter to output stuff instead

The GH Action reporter is still enabled so that it displays annotations on PRs, but no longer outputs to the GH Action log

[With this log, for example](https://github.com/bugsnag/bugsnag-js-performance/actions/runs/4425054353/jobs/7759636409):

<img width="922" alt="image" src="https://user-images.githubusercontent.com/282732/225289265-1183c6ad-185b-4cda-8026-fbdbfe1fabb7.png">

All of the "PASS" sections are empty (note the line numbers) because none of the tests actually passed!