### PR TITLE
[PLAT-9751] Restart inactivity timer when adding new Span

### DIFF
--- a/packages/core/tests/batch-processor.test.ts
+++ b/packages/core/tests/batch-processor.test.ts
@@ -53,23 +53,7 @@ describe('BatchProcessor', () => {
   it('restarts the timer when calling .add()', () => {
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery: Delivery = { send: jest.fn() }
-    const logger: Logger = {
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      debug: jest.fn()
-    }
-    const config: InternalConfiguration = {
-      apiKey: VALID_API_KEY,
-      releaseStage: 'test',
-      enabledReleaseStages: ['test'],
-      appVersion: '1.0.0',
-      batchInactivityTimeoutMs: 30 * 1000,
-      maximumBatchSize: 100,
-      endpoint: '/traces',
-      logger
-    }
-    const batchProcessor = new BatchProcessor(delivery, config, resourceAttributesSource, clock)
+    const batchProcessor = new BatchProcessor(delivery, VALID_CONFIGURATION, resourceAttributesSource, clock)
     batchProcessor.add(generateSpan())
     jest.advanceTimersByTime(20_000)
     expect(delivery.send).not.toHaveBeenCalled()


### PR DESCRIPTION
## Goal

To bring batching processor in line with engineering design and start the inactivity timer from the moment a new Span is added to the queue

## Testing

Unit test that the timer is reset in between adding new spans