### PR TITLE
Add a test for retries on connection failure

### DIFF
--- a/test/browser/features/fixtures/packages/connection-failure/index.html
+++ b/test/browser/features/fixtures/packages/connection-failure/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
+
+        <script>
+          // patch 'fetch' so that it causes a connection failure the first time
+          // it's called, then works as normal for all subsequent calls
+          // this has to be outside of the bundle, otherwise BugsnagPerformance
+          // will grab a reference to fetch at import time (before we patch it)
+          const originalFetch = window.fetch
+          let called = false
+
+          window.fetch = function (resource, options) {
+            // we can't just swap 'window.fetch' back to the original as
+            // BugsnagPerformance has stored a reference to this function
+            if (called) {
+              return originalFetch.call(this, resource, options)
+            }
+
+            called = true
+
+            // make a request to a (hopefully) non-existent URL instead of to
+            // Maze Runner
+            //
+            // port 994 is used because it shouldn't be in use as it's
+            // officially reserved for both TCP & UDP traffic
+            // (https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=994)
+            //
+            // it's also below 1024 so requires privileges to bind to on Linux
+            // and we use HTTPS to make it even less likely to succeed if
+            // something does happen to listen on this port
+            return originalFetch.call(this, 'https://localhost:994', options)
+          }
+        </script>
+    </head>
+    <body>
+        <h1>connection-failure</h1>
+
+        <button id="send-span">send span</button>
+
+        <script src="./dist/bundle.js"></script>
+    </body>
+</html>

--- a/test/browser/features/fixtures/packages/connection-failure/package.json
+++ b/test/browser/features/fixtures/packages/connection-failure/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "connection-failure",
+    "private": true,
+    "scripts": {
+        "build": "rollup src/index.js --file dist/bundle.js --format iife --plugin @rollup/plugin-node-resolve",
+        "clean": "rm -rf dist"
+    }
+}

--- a/test/browser/features/fixtures/packages/connection-failure/src/index.js
+++ b/test/browser/features/fixtures/packages/connection-failure/src/index.js
@@ -1,0 +1,12 @@
+import BugsnagPerformance from '@bugsnag/js-performance-browser'
+
+const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1 })
+
+let spanNumber = 0
+
+document.getElementById("send-span").addEventListener("click", () => {
+  BugsnagPerformance.startSpan(`Custom/Span ${++spanNumber}`).end()
+})

--- a/test/browser/features/retries.feature
+++ b/test/browser/features/retries.feature
@@ -25,6 +25,19 @@ Feature: Retries
             | 429    | Too Many Requests             |
             | 500    | Connection Error              |
 
+    Scenario: Batch is retried with connection failure
+        Given I navigate to the test URL "/connection-failure"
+
+        When I click the element "send-span"
+        And I wait for 5 seconds
+        Then I wait to receive 0 traces
+
+        When I click the element "send-span"
+        And I wait to receive 2 traces
+
+        Then a span name equals "Custom/Span 1"
+        And a span name equals "Custom/Span 2"
+
     Scenario Outline: Batch is not retried with specified status codes
         Given I set the HTTP status code for the next "POST" request to <status>
         And I navigate to the test URL "/retry-scenario"


### PR DESCRIPTION
## Goal

This test simulates a connection failure by rerouting the first `fetch` request to a non-existent resource (`https://localhost:994`)

Any future requests will use the requested resource, so work as normal