### PR TITLE
Update Maze Runner to latest

### DIFF
--- a/test/browser/Gemfile
+++ b/test/browser/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.20.1'
+gem 'bugsnag-maze-runner', '~> 7.23'

--- a/test/browser/Gemfile.lock
+++ b/test/browser/Gemfile.lock
@@ -1,9 +1,16 @@
-GIT
-  remote: https://github.com/bugsnag/maze-runner
-  revision: de093a928c85b1d4736fe416ff101385f99908f3
-  tag: v7.20.1
+GEM
+  remote: https://rubygems.org/
   specs:
-    bugsnag-maze-runner (7.20.1)
+    appium_lib (12.0.1)
+      appium_lib_core (~> 5.0)
+      nokogiri (~> 1.8, >= 1.8.1)
+      tomlrb (>= 1.1, < 3.0)
+    appium_lib_core (5.4.0)
+      faye-websocket (~> 0.11.0)
+      selenium-webdriver (~> 4.2, < 4.6)
+    bugsnag (6.25.2)
+      concurrent-ruby (~> 1.0)
+    bugsnag-maze-runner (7.23.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -19,19 +26,6 @@ GIT
       selenium-webdriver (~> 4.0)
       test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    appium_lib (12.0.1)
-      appium_lib_core (~> 5.0)
-      nokogiri (~> 1.8, >= 1.8.1)
-      tomlrb (>= 1.1, < 3.0)
-    appium_lib_core (5.4.0)
-      faye-websocket (~> 0.11.0)
-      selenium-webdriver (~> 4.2, < 4.6)
-    bugsnag (6.25.2)
-      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (4.1.0)
     concurrent-ruby (1.2.2)
@@ -91,7 +85,7 @@ GEM
     os (1.0.1)
     power_assert (2.0.3)
     racc (1.6.2)
-    rack (2.2.6.3)
+    rack (2.2.6.4)
     rake (12.3.3)
     regexp_parser (2.7.0)
     rexml (3.2.5)
@@ -117,7 +111,7 @@ PLATFORMS
   arm64-darwin-21
 
 DEPENDENCIES
-  bugsnag-maze-runner!
+  bugsnag-maze-runner (~> 7.23)
 
 BUNDLED WITH
    2.2.33


### PR DESCRIPTION
## Goal

Update Maze Runner to the latest version & pull from RubyGems instead of directly from GitHub