### PR TITLE
Simplify discards of more than 1 trace

### DIFF
--- a/test/browser/features/retries.feature
+++ b/test/browser/features/retries.feature
@@ -69,9 +69,7 @@ Feature: Retries
         And I wait to receive 3 traces
 
         # Remove failed requests
-        And I discard the oldest trace
-        And I discard the oldest trace
-        And I discard the oldest trace
+        And I discard the oldest 3 traces
 
         Then I click the element "send-final-span"
         And I wait for 5 seconds

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -29,6 +29,14 @@ When('I set the HTTP status code for the next {int} {string} requests to {int}')
   Maze::Server.set_status_code_generator(generator, http_verb)
 end
 
+Then('I discard the oldest {int} {word}') do |number_to_discard, request_type|
+  raise "No #{request_type} to discard" if Maze::Server.list_for(request_type).current.nil?
+
+  number_to_discard.times do
+    Maze::Server.list_for(request_type).next
+  end
+end
+
 module Maze
   module Driver
     class Browser


### PR DESCRIPTION
## Goal

Simplify discards of more than 1 trace by adding a new "`I discard the oldest {int} {word}`" step, e.g. "I discard the oldest 2 traces"