### PR TITLE
Bail out earlier if release stage is disabled

### DIFF
--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -33,6 +33,12 @@ export class BatchProcessor implements Processor {
   }
 
   add (span: SpanEnded) {
+    if (this.configuration.enabledReleaseStages &&
+      !this.configuration.enabledReleaseStages.includes(this.configuration.releaseStage)
+    ) {
+      return
+    }
+
     this.batch.push(span)
 
     if (this.batch.length >= this.configuration.maximumBatchSize) {
@@ -47,10 +53,6 @@ export class BatchProcessor implements Processor {
 
     const batch = this.batch
     this.batch = []
-
-    if (this.configuration.enabledReleaseStages && !this.configuration.enabledReleaseStages.includes(this.configuration.releaseStage)) {
-      return
-    }
 
     const payload = {
       resourceSpans: [


### PR DESCRIPTION
## Goal

There's no point in adding spans to a batch if they will never be sent, so check the release stage in `BatchProcessor.add` instead of `BatchProcessor.flush`

## Testing

Covered by existing tests