### PR TITLE
Use InMemoryDelivery in favour of Jest mocks

### DIFF
--- a/packages/test-utilities/lib/in-memory-delivery.ts
+++ b/packages/test-utilities/lib/in-memory-delivery.ts
@@ -9,9 +9,18 @@ interface Request {
 class InMemoryDelivery implements Delivery {
   public requests: Request[] = []
 
+  private readonly responseStateStack: ResponseState[] = []
+
   send (endpoint: string, apiKey: string, payload: DeliveryPayload) {
     this.requests.push({ apiKey, endpoint, payload })
-    return Promise.resolve({ state: 'success' as ResponseState })
+
+    const state = this.responseStateStack.pop() || 'success' as ResponseState
+
+    return Promise.resolve({ state })
+  }
+
+  setNextResponseState (state: ResponseState): void {
+    this.responseStateStack.push(state)
   }
 }
 


### PR DESCRIPTION
## Goal

This allows us to add stuff to the Delivery interface without having to update a bunch of tests

There's still one retry queue test using a mock as it keeps track of the number of outstanding requests, which `InMemoryDelivery` can't do