### PR TITLE
Add the concept of a 'BackgroundingListener'

### DIFF
--- a/packages/core/lib/backgrounding-listener.ts
+++ b/packages/core/lib/backgrounding-listener.ts
@@ -1,0 +1,18 @@
+export type BackgroundingListenerState = 'in-foreground' | 'in-background'
+export type BackgroundingListenerCallback = (state: BackgroundingListenerState) => void
+
+/**
+ * A BackgroundingListener allows core to register a callback to be called when
+ * the app is "backgrounded" (or terminated) and when it is brought back to the
+ * foreground (but not when relaunched)
+ *
+ * This allows each platform to define _what_ backgrounding/foregrounding is,
+ * while core implements the logic _when_ the state changes
+ */
+export interface BackgroundingListener {
+  /**
+   * NOTE: the callback should be triggered immediately if the app is already in
+   *       the background!
+   */
+  onStateChange: (callback: BackgroundingListenerCallback) => void
+}

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -1,4 +1,5 @@
 import { SpanAttributes, type ResourceAttributeSource, type SpanAttributesSource } from './attributes'
+import { type BackgroundingListener } from './backgrounding-listener'
 import { BatchProcessor } from './batch-processor'
 import { type Clock } from './clock'
 import { validateConfig, type Configuration, type CoreSchema } from './config'
@@ -31,6 +32,7 @@ export interface ClientOptions {
   clock: Clock
   idGenerator: IdGenerator
   delivery: Delivery
+  backgroundingListener: BackgroundingListener
   resourceAttributesSource: ResourceAttributeSource
   spanAttributesSource: SpanAttributesSource
   schema: CoreSchema
@@ -49,6 +51,14 @@ export function createClient (options: ClientOptions): BugsnagPerformance {
       // ensure all spans started before .start() are added to the batch
       bufferingProcessor.spans.forEach(span => {
         processor.add(span)
+      })
+
+      // register with the backgrounding listener - we do this in 'start' as
+      // there's nothing to do if we're backgrounded before start is called
+      // e.g. we can't trigger delivery until we have the apiKey and endpoint
+      // from configuration
+      options.backgroundingListener.onStateChange(state => {
+        // to be implemented
       })
     },
     startSpan: (name, startTime) => {

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './attributes'
+export * from './backgrounding-listener'
 export * from './clock'
 export * from './core'
 export * from './delivery'

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -1,4 +1,5 @@
 import { createNoopClient } from '../lib/core'
+import { type BackgroundingListener } from '../lib/backgrounding-listener'
 import { createTestClient, VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
 
 describe('Core', () => {
@@ -161,6 +162,21 @@ describe('Core', () => {
 
           // @ts-expect-error invalid configuration provided
           expect(() => { client.start(config) }).toThrow('No Bugsnag API Key set')
+        })
+
+        it('registers with the backgrounding listener', () => {
+          const backgroundingListener: BackgroundingListener = {
+            onStateChange: jest.fn()
+          }
+
+          const client = createTestClient({ backgroundingListener })
+
+          expect(backgroundingListener.onStateChange).not.toHaveBeenCalled()
+
+          client.start(VALID_API_KEY)
+
+          expect(backgroundingListener.onStateChange).toHaveBeenCalled()
+          expect(console.warn).not.toHaveBeenCalled()
         })
       })
     })

--- a/packages/platforms/browser/lib/backgrounding-listener.ts
+++ b/packages/platforms/browser/lib/backgrounding-listener.ts
@@ -1,0 +1,36 @@
+import {
+  type BackgroundingListener,
+  type BackgroundingListenerCallback
+} from '@bugsnag/js-performance-core'
+
+interface DocumentForVisibilityState {
+  addEventListener: (event: string, callback: () => void) => void
+  visibilityState: string
+}
+
+export default function createBrowserBackgroundingListener (document: DocumentForVisibilityState) {
+  const callbacks: BackgroundingListenerCallback[] = []
+
+  const backgroundingListener: BackgroundingListener = {
+    onStateChange (backgroundingListenerCallback: BackgroundingListenerCallback): void {
+      callbacks.push(backgroundingListenerCallback)
+
+      // trigger the callback immediately if the document is already 'hidden'
+      if (document.visibilityState === 'hidden') {
+        backgroundingListenerCallback('in-background')
+      }
+    }
+  }
+
+  document.addEventListener('visibilitychange', function () {
+    const state = document.visibilityState === 'hidden'
+      ? 'in-background'
+      : 'in-foreground'
+
+    for (const callback of callbacks) {
+      callback(state)
+    }
+  })
+
+  return backgroundingListener
+}

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@bugsnag/js-performance-core'
+import createBrowserBackgroundingListener from './backgrounding-listener'
 import createClock from './clock'
 import { createSchema } from './config'
 import browserDelivery from './delivery'
@@ -10,6 +11,7 @@ const clock = createClock(performance)
 const resourceAttributesSource = createResourceAttributesSource(navigator)
 
 const BugsnagPerformance = createClient({
+  backgroundingListener: createBrowserBackgroundingListener(document),
   clock,
   resourceAttributesSource,
   spanAttributesSource,

--- a/packages/platforms/browser/tests/backgrounding-listener.test.ts
+++ b/packages/platforms/browser/tests/backgrounding-listener.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import createBrowserBackgroundingListener from '../lib/backgrounding-listener'
+
+// there are a few issues with using the real 'document' (e.g. visibilityState
+// is readonly) so we stub it
+class DocumentStub {
+  readonly #eventListeners = new Map<string, () => void>()
+  #visibilityState: 'visible' | 'hidden' = 'visible'
+
+  get visibilityState () {
+    return this.#visibilityState
+  }
+
+  set visibilityState (state: 'visible' | 'hidden') {
+    this.#visibilityState = state
+
+    const callback = this.#eventListeners.get('visibilitychange')
+
+    if (callback) {
+      callback()
+    }
+  }
+
+  addEventListener (event: string, callback: () => void) {
+    this.#eventListeners.set(event, callback)
+  }
+}
+
+describe('Browser BackgroundingListener', () => {
+  it('calls the registered callback with "in-foreground" when visibilityState changes to "visible"', () => {
+    const documentStub = new DocumentStub()
+    const onStateChangeCallback = jest.fn()
+
+    const listener = createBrowserBackgroundingListener(documentStub)
+    listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    documentStub.visibilityState = 'visible'
+
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-foreground')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls the registered callback with "in-background" when visibilityState changes to "hidden"', () => {
+    const documentStub = new DocumentStub()
+    const onStateChangeCallback = jest.fn()
+
+    const listener = createBrowserBackgroundingListener(documentStub)
+    listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    documentStub.visibilityState = 'hidden'
+
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls the registered callback immediately when visibilityState is "hidden" on registration', () => {
+    const documentStub = new DocumentStub()
+    const onStateChangeCallback = jest.fn()
+
+    const listener = createBrowserBackgroundingListener(documentStub)
+
+    documentStub.visibilityState = 'hidden'
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/test-utilities/lib/controllable-backgrounding-listener.ts
+++ b/packages/test-utilities/lib/controllable-backgrounding-listener.ts
@@ -1,0 +1,26 @@
+import {
+  type BackgroundingListener,
+  type BackgroundingListenerCallback
+} from '@bugsnag/js-performance-core'
+
+class ControllableBackgroundingListener implements BackgroundingListener {
+  private callbacks: BackgroundingListenerCallback[] = []
+
+  onStateChange (callback: BackgroundingListenerCallback) {
+    this.callbacks.push(callback)
+  }
+
+  sendToBackground () {
+    for (const backgroundingListenerCallback of this.callbacks) {
+      backgroundingListenerCallback('in-background')
+    }
+  }
+
+  sendToForeground () {
+    for (const backgroundingListenerCallback of this.callbacks) {
+      backgroundingListenerCallback('in-foreground')
+    }
+  }
+}
+
+export default ControllableBackgroundingListener

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -1,4 +1,5 @@
 import {
+  ControllableBackgroundingListener,
   IncrementingClock,
   InMemoryDelivery,
   resourceAttributesSource,
@@ -14,6 +15,7 @@ import {
 } from '@bugsnag/js-performance-core'
 
 const defaultOptions = () => ({
+  backgroundingListener: new ControllableBackgroundingListener(),
   delivery: new InMemoryDelivery(),
   idGenerator: new StableIdGenerator(),
   clock: new IncrementingClock(),

--- a/packages/test-utilities/lib/index.ts
+++ b/packages/test-utilities/lib/index.ts
@@ -1,5 +1,6 @@
 import './matchers'
 
+export { default as ControllableBackgroundingListener } from './controllable-backgrounding-listener'
 export { default as createConfiguration } from './create-configuration'
 export { default as createTestClient } from './create-test-client'
 export { default as IncrementingClock } from './incrementing-clock'


### PR DESCRIPTION
## Goal

This listens for when the app is backgrounded in a platform-specific way, allowing core to interact with it and do whatever it wants when the app is backgrounded (or terminated — the name isn't perfect!) or foregrounded

As this requires a change to `ClientOptions` it's pretty chunky, so I've pulled it into a separate PR where it's not fully used yet (core registers an empty callback). For the full context, see also https://github.com/bugsnag/bugsnag-js-performance/pull/75