### PR TITLE
Add e2e tests for batch delivery when navigating

### DIFF
--- a/test/browser/features/fixtures/packages/navigation-changes/another-page.html
+++ b/test/browser/features/fixtures/packages/navigation-changes/another-page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
+    </head>
+    <body>
+        <h1>navigation-changes</h1>
+        <h2>another page</h2>
+
+        <p>hello 👋</p>
+    </body>
+</html>

--- a/test/browser/features/fixtures/packages/navigation-changes/index.html
+++ b/test/browser/features/fixtures/packages/navigation-changes/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
+    </head>
+    <body>
+        <h1>navigation-changes</h1>
+
+        <button id="add-span-to-batch">add-span-to-batch</button>
+
+        <a href="./another-page.html" id="go-to-another-page">
+          go to another page
+        </a>
+
+        <script src="./dist/bundle.js"></script>
+    </body>
+</html>

--- a/test/browser/features/fixtures/packages/navigation-changes/package.json
+++ b/test/browser/features/fixtures/packages/navigation-changes/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "navigation-changes",
+    "private": true,
+    "scripts": {
+        "build": "rollup src/index.js --file dist/bundle.js --format iife --plugin @rollup/plugin-node-resolve",
+        "clean": "rm -rf dist"
+    }
+}

--- a/test/browser/features/fixtures/packages/navigation-changes/src/index.js
+++ b/test/browser/features/fixtures/packages/navigation-changes/src/index.js
@@ -1,0 +1,12 @@
+import BugsnagPerformance from '@bugsnag/js-performance-browser'
+
+const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+
+BugsnagPerformance.start({ apiKey, endpoint })
+
+let spanNumber = 0
+
+document.getElementById("add-span-to-batch").addEventListener("click", () => {
+  BugsnagPerformance.startSpan(`Span ${++spanNumber}`).end()
+})

--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -1,9 +1,21 @@
 require 'yaml'
 
 class Browser
-  def initialize(maze_uri, fixtures_uri)
+  def initialize(browser_spec, maze_uri, fixtures_uri)
     @maze_uri = maze_uri
     @fixtures_uri = fixtures_uri
+
+    # e.g. "chrome_61", "edge_latest", "chrome"
+    @name, version = browser_spec.split("_")
+
+    # assume we're running the latest version if there is no version present
+    # this should only happen locally where the browser will auto-update
+    @version =
+      if version.nil? || version == "latest"
+        "latest"
+      else
+        Integer(version)
+      end
   end
 
   def url_for(path)
@@ -17,5 +29,28 @@ class Browser
     end
 
     uri.to_s
+  end
+
+  def supports_fetch_keepalive?
+    case @name
+    when "safari"
+      # support added in Safari 13
+      @version == "latest" || @version >= 13
+
+    when "firefox"
+      # firefox does not support keepalive on any version
+      false
+
+    when "chrome"
+      # support added in Chrome 66
+      @version == "latest" || @version >= 66
+
+    when "edge"
+      # support added in Edge 15
+      @version == "latest" || @version >= 15
+
+    else
+      raise "Unable to determine fetch keepalive support for browser: #{@name}"
+    end
   end
 end

--- a/test/browser/features/navigation-changes.feature
+++ b/test/browser/features/navigation-changes.feature
@@ -1,0 +1,53 @@
+@requires_fetch_keepalive
+Feature: Navigation changes
+    Scenario: Batch is sent when navigating to a new page by clicking an anchor tag
+        Given I navigate to the test URL "/navigation-changes"
+        When I click the element "add-span-to-batch"
+        And I click the element "add-span-to-batch"
+
+        And I wait for 5 seconds
+        Then I wait to receive 0 traces
+
+        When I click the element "go-to-another-page"
+        Then I wait to receive 1 trace
+        Then I wait for 2 spans
+
+        And a span name equals "Span 1"
+        And a span name equals "Span 2"
+
+    Scenario: Batch is sent when navigating to a new page by entering a new URL
+        Given I navigate to the test URL "/navigation-changes"
+        When I click the element "add-span-to-batch"
+        And I click the element "add-span-to-batch"
+        And I click the element "add-span-to-batch"
+
+        And I wait for 5 seconds
+        Then I wait to receive 0 traces
+
+        When I navigate to the test URL "/"
+        Then I wait to receive 1 trace
+        Then I wait for 3 spans
+
+        And a span name equals "Span 1"
+        And a span name equals "Span 2"
+        And a span name equals "Span 3"
+
+    @minimises_window
+    Scenario: Batch is sent when the window is minimised
+        Given I navigate to the test URL "/navigation-changes"
+        When I click the element "add-span-to-batch"
+        And I click the element "add-span-to-batch"
+        And I click the element "add-span-to-batch"
+        And I click the element "add-span-to-batch"
+
+        And I wait for 5 seconds
+        Then I wait to receive 0 traces
+
+        When I minimise the browser window
+        Then I wait to receive 1 trace
+        Then I wait for 4 spans
+
+        And a span name equals "Span 1"
+        And a span name equals "Span 2"
+        And a span name equals "Span 3"
+        And a span name equals "Span 4"

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -37,6 +37,11 @@ Then('I discard the oldest {int} {word}') do |number_to_discard, request_type|
   end
 end
 
+When("I minimise the browser window") do
+  driver = Maze.driver.instance_variable_get(:@driver)
+  driver.manage.window.minimize
+end
+
 module Maze
   module Driver
     class Browser

--- a/test/browser/features/support/maze-config.rb
+++ b/test/browser/features/support/maze-config.rb
@@ -11,6 +11,7 @@ Maze.config.document_server_bind_address = ENV.fetch('HOST', 'localhost')
 Maze.config.document_server_root = File.realpath("#{__dir__}/../fixtures/packages")
 
 $browser = Browser.new(
+  Maze.config.browser,
   URI("http://#{Maze.config.bind_address}:#{Maze.config.port}"),
   URI("http://#{Maze.config.document_server_bind_address}:#{Maze.config.document_server_port}")
 )

--- a/test/browser/features/support/minimises-window.rb
+++ b/test/browser/features/support/minimises-window.rb
@@ -1,0 +1,6 @@
+# if a test minimises the browser, we must maximise it afterwards, otherwise
+# selenium can get confused
+After('@minimises_window') do
+  driver = Maze.driver.instance_variable_get(:@driver)
+  driver.manage.window.maximize
+end

--- a/test/browser/features/support/requires-keepalive.rb
+++ b/test/browser/features/support/requires-keepalive.rb
@@ -1,0 +1,3 @@
+Before("@requires_fetch_keepalive") do
+  skip_this_scenario unless $browser.supports_fetch_keepalive?
+end


### PR DESCRIPTION
## Goal

Adds 3 scenarios that prove a batch is sent when the page's visibility changes:

> Batch is sent when navigating to a new page by clicking an anchor tag
> Batch is sent when navigating to a new page by entering a new URL
> Batch is sent when the window is minimised

There are other scenarios that would result in the same behaviour (e.g. switching tabs, closing the window etc&hellip;), but these are problematic to test with Selenium