### PR TITLE
Compare bundle size

### DIFF
--- a/.github/leave-bundle-size-comment.js
+++ b/.github/leave-bundle-size-comment.js
@@ -1,0 +1,71 @@
+const formatKbs = n => `${(n / 1000).toFixed(2)} kB`
+const showDiff = n => {
+  if (n > 0) return `\`+${n.toLocaleString()} bytes\` ⚠️`
+  if (n < 0) return `\`${n.toLocaleString()} bytes\` 🎉`
+  return '_No change_'
+}
+
+module.exports = async function (github, context, needs) {
+  const npm = {
+    before: {
+      unminified: needs['base-branch'].outputs['unminified-size'],
+      minified: needs['base-branch'].outputs['minified-size'],
+      gzipped: needs['base-branch'].outputs['minified-gzip-size'],
+    },
+
+    after: {
+      unminified: needs['head-branch'].outputs['unminified-size'],
+      minified: needs['head-branch'].outputs['minified-size'],
+      gzipped: needs['head-branch'].outputs['minified-gzip-size'],
+    },
+  }
+
+  const diff = {
+    npm: {
+      unminified: npm.after.unminified - npm.before.unminified,
+      minified: npm.after.minified - npm.before.minified,
+      gzipped: npm.after.gzipped - npm.before.gzipped,
+    },
+  }
+
+  const body = `
+  ### Browser bundle size
+
+  **NPM build**
+
+  |        | Unminified                              | Minfied                               | Minified + gzipped                   |
+  | ------ | --------------------------------------- | ------------------------------------- | ------------------------------------ |
+  | Before | \`${formatKbs(npm.before.unminified)}\` | \`${formatKbs(npm.before.minified)}\` | \`${formatKbs(npm.before.gzipped)}\` |
+  | After  | \`${formatKbs(npm.after.unminified)}\`  | \`${formatKbs(npm.after.minified)}\`  | \`${formatKbs(npm.after.gzipped)}\`  |
+  | ±      | ${showDiff(diff.npm.unminified)}        | ${showDiff(diff.npm.minified)}        | ${showDiff(diff.npm.gzipped)}        |
+
+  <p align="right">
+    Generated against ${context.payload.pull_request.head.sha}
+    on ${new Date().toLocaleString('en-GB', { dateStyle: 'long', timeStyle: 'long' })}
+  </p>
+  `.trim()
+
+  const issue_number = context.issue.number
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+
+  const comments = await github.rest.issues.listComments({ issue_number, owner, repo })
+
+  const existingComment = comments.data.find(function (comment) {
+    return comment.body.startsWith('### Browser bundle size')
+      && comment.user.login === 'github-actions[bot]'
+  })
+
+  if (existingComment) {
+    console.log('Updating existing comment')
+    console.log(existingComment.html_url)
+
+    await github.rest.issues.updateComment({ comment_id: existingComment.id, issue_number, owner, repo, body })
+  } else {
+    console.log('Creating new comment')
+
+    const newComment = await github.rest.issues.createComment({ issue_number, owner, repo, body })
+
+    console.log(newComment.html_url)
+  }
+}

--- a/.github/workflows/compare-pr-stats.yml
+++ b/.github/workflows/compare-pr-stats.yml
@@ -1,0 +1,34 @@
+name: Compare PR stats
+
+on: [pull_request]
+
+concurrency:
+  # only allow one run of this workflow per branch, otherwise the comment could
+  # be overwritten by an earlier commit that runs slower than the latest commit
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  base-branch:
+    uses: ./.github/workflows/record-pr-stats.yml
+    with:
+      ref: ${{ github.event.pull_request.base.sha }}
+
+  head-branch:
+    uses: ./.github/workflows/record-pr-stats.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  compare-bundle-size:
+    runs-on: ubuntu-latest
+    needs: [base-branch, head-branch]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Leave comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const leaveBundleSizeComment = require('./.github/leave-bundle-size-comment.js')
+
+            await leaveBundleSizeComment(github, context, ${{ toJSON(needs) }})

--- a/.github/workflows/record-pr-stats.yml
+++ b/.github/workflows/record-pr-stats.yml
@@ -1,0 +1,50 @@
+name: Record PR stats
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+    outputs:
+      unminified-size:
+        description: "The unminified bundle size"
+        value: ${{ jobs.record-bundle-size.outputs.unminified-size }}
+      minified-size:
+        description: "The minified bundle size"
+        value: ${{ jobs.record-bundle-size.outputs.minified-size }}
+      minified-gzip-size:
+        description: "The minified bundle size after gzipping"
+        value: ${{ jobs.record-bundle-size.outputs.minified-gzip-size }}
+
+jobs:
+  record-bundle-size:
+    runs-on: ubuntu-latest
+
+    outputs:
+      unminified-size: ${{ steps.unminified.outputs.size }}
+      minified-size: ${{ steps.minified.outputs.size }}
+      minified-gzip-size: ${{ steps.minified-gzip.outputs.size }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+      - run: ./.github/create-browser-bundle-from-npm
+
+      - id: unminified
+        run: echo "size=$(wc -c < build/bundle.js)" >> $GITHUB_OUTPUT
+
+      - id: minified
+        run: echo "size=$(wc -c < build/bundle.min.js)" >> $GITHUB_OUTPUT
+
+      - id: minified-gzip
+        run: echo "size=$(gzip < build/bundle.min.js | wc -c)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Goal

Adds a browser bundle size comment to PRs

This uses the build script from https://github.com/bugsnag/bugsnag-js-performance/pull/84 in [a reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) that's called for the base and head of a PR. The outputs from that workflow are then used to update or create a comment on the PR with the bundle stats

The reusable workflow allows us to collect stats from the base and head branches in parallel, so this takes ~40-60 seconds in total

Concurrency controls will prevent more than one build running — any earlier builds are cancelled when a new commit is pushed

## Testing

See comment 👇 (the edit history has stats for the bundle increasing/decreasing in size)