### PR TITLE
[PLAT-9791] Validate start and end times

### DIFF
--- a/test/browser/features/navigation-changes.feature
+++ b/test/browser/features/navigation-changes.feature
@@ -1,5 +1,6 @@
 @requires_fetch_keepalive
 Feature: Navigation changes
+    @skip_span_time_validation
     Scenario: Batch is sent when navigating to a new page by clicking an anchor tag
         Given I navigate to the test URL "/navigation-changes"
         When I click the element "add-span-to-batch"
@@ -15,6 +16,7 @@ Feature: Navigation changes
         And a span name equals "Span 1"
         And a span name equals "Span 2"
 
+    @skip_span_time_validation
     Scenario: Batch is sent when navigating to a new page by entering a new URL
         Given I navigate to the test URL "/navigation-changes"
         When I click the element "add-span-to-batch"

--- a/test/browser/features/support/span-time-validation.rb
+++ b/test/browser/features/support/span-time-validation.rb
@@ -1,0 +1,11 @@
+After('not @skip_span_time_validation') do
+  driver = Maze.driver.instance_variable_get(:@driver)
+  current_time = driver.execute_script("return Date.now() * 1000000")
+  scenario_start_time = driver.execute_script("return (performance.timeOrigin || performance.timing.navigationStart) * 1000000")
+  
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.each do |span|
+    Maze.check.operator(Integer(span["startTimeUnixNano"]), :>=, scenario_start_time)
+    Maze.check.operator(current_time, :>=, Integer(span["endTimeUnixNano"]))
+  end
+end


### PR DESCRIPTION
## Goal

Ensure start and end timestamps are within an expected range for end to end tests, skippable using `@skip_span_time_validation`