### PR TITLE
Add test utilities for creating spans

### DIFF
--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -1,0 +1,26 @@
+import {
+  type SpanEnded,
+  type SpanInternal,
+  SpanAttributes
+} from '@bugsnag/js-performance-core'
+import { randomBytes } from 'crypto'
+
+export function createSpan (overrides: Partial<SpanInternal> = {}): SpanInternal {
+  return {
+    attributes: new SpanAttributes(new Map()),
+    id: randomBytes(8).toString('hex'),
+    name: 'test span',
+    kind: 1,
+    startTime: 12345,
+    traceId: randomBytes(16).toString('hex'),
+    ...overrides
+  }
+}
+
+export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded {
+  return {
+    ...createSpan(),
+    endTime: 23456,
+    ...overrides
+  }
+}

--- a/packages/test-utilities/lib/index.ts
+++ b/packages/test-utilities/lib/index.ts
@@ -2,6 +2,7 @@ import './matchers'
 
 export { default as ControllableBackgroundingListener } from './controllable-backgrounding-listener'
 export { default as createConfiguration } from './create-configuration'
+export * from './create-span'
 export { default as createTestClient } from './create-test-client'
 export { default as IncrementingClock } from './incrementing-clock'
 export { default as InMemoryDelivery } from './in-memory-delivery'


### PR DESCRIPTION
## Goal

Adds some test utilities for creating a `SpanInternal` or `SpanEnded`. This is used by the batch processor test currently, but will be used by other tests in future