### PR TITLE
Add DeliveryFactory type to help create deliveries

### DIFF
--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -74,11 +74,7 @@ export class BatchProcessor implements Processor {
     }
 
     try {
-      const { state } = await this.delivery.send(
-        this.configuration.endpoint,
-        this.configuration.apiKey,
-        payload
-      )
+      const { state } = await this.delivery.send(payload)
 
       switch (state) {
         case 'success':

--- a/packages/core/lib/delivery.ts
+++ b/packages/core/lib/delivery.ts
@@ -1,15 +1,13 @@
 import { type JsonAttribute } from './attributes'
 import { type Kind } from './span'
 
+export type DeliveryFactory = (apiKey: string, endpoint: string) => Delivery
+
 export type ResponseState = 'success' | 'failure-discard' | 'failure-retryable'
 interface Response { state: ResponseState }
 
 export interface Delivery {
-  send: (
-    endpoint: string,
-    apiKey: string,
-    payload: DeliveryPayload
-  ) => Promise<Response>
+  send: (payload: DeliveryPayload) => Promise<Response>
 }
 
 interface Resource {

--- a/packages/core/lib/retry-queue.ts
+++ b/packages/core/lib/retry-queue.ts
@@ -9,7 +9,7 @@ export class InMemoryQueue implements RetryQueue {
   private payloads: DeliveryPayload[] = []
   private requestQueue: Promise<void> = Promise.resolve()
 
-  constructor (private delivery: Delivery, private endpoint: string, private apiKey: string, private retryQueueMaxSize: number) {}
+  constructor (private delivery: Delivery, private retryQueueMaxSize: number) {}
 
   add (payload: DeliveryPayload) {
     this.payloads.push(payload)
@@ -36,7 +36,7 @@ export class InMemoryQueue implements RetryQueue {
     this.requestQueue = this.requestQueue.then(async () => {
       for (const payload of payloads) {
         try {
-          const { state } = await this.delivery.send(this.endpoint, this.apiKey, payload)
+          const { state } = await this.delivery.send(payload)
 
           switch (state) {
             case 'success':

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -188,7 +188,7 @@ describe('Core', () => {
           const delivery = new InMemoryDelivery()
           const backgroundingListener = new ControllableBackgroundingListener()
 
-          const client = createTestClient({ backgroundingListener, delivery })
+          const client = createTestClient({ backgroundingListener, deliveryFactory: () => delivery })
           client.start(VALID_API_KEY)
 
           client.startSpan('Span 1').end()
@@ -202,7 +202,7 @@ describe('Core', () => {
 
           expect(delivery.requests).toHaveLength(1)
 
-          const payload = delivery.requests[0].payload
+          const payload = delivery.requests[0]
           const spans = payload.resourceSpans[0].scopeSpans[0].spans
 
           expect(spans).toHaveLength(2)
@@ -216,7 +216,7 @@ describe('Core', () => {
           const delivery = new InMemoryDelivery()
           const backgroundingListener = new ControllableBackgroundingListener()
 
-          const client = createTestClient({ backgroundingListener, delivery })
+          const client = createTestClient({ backgroundingListener, deliveryFactory: () => delivery })
           client.start(VALID_API_KEY)
 
           expect(delivery.requests).toHaveLength(0)

--- a/packages/core/tests/retry-queue.test.ts
+++ b/packages/core/tests/retry-queue.test.ts
@@ -11,19 +11,13 @@ import { InMemoryDelivery } from '@bugsnag/js-performance-test-utilities'
 describe('RetryQueue', () => {
   it('calls delivery after flushing', async () => {
     const delivery = new InMemoryDelivery()
-    const retryQueue = new InMemoryQueue(delivery, '/traces', 'valid-api-key', 1000)
+    const retryQueue = new InMemoryQueue(delivery, 1000)
     const payload = generateFullPayload()
 
     retryQueue.add(payload)
     await retryQueue.flush()
 
-    expect(delivery.requests).toStrictEqual([
-      {
-        apiKey: 'valid-api-key',
-        endpoint: '/traces',
-        payload
-      }
-    ])
+    expect(delivery.requests).toStrictEqual([payload])
   })
 
   it('limits the number of spans in the queue', async () => {
@@ -45,22 +39,16 @@ describe('RetryQueue', () => {
     }
 
     const delivery = new InMemoryDelivery()
-    const endpoint = '/traces'
-    const apiKey = 'valid-api-key'
-    const retryQueue = new InMemoryQueue(delivery, endpoint, apiKey, 1000)
+    const retryQueue = new InMemoryQueue(delivery, 1000)
 
     retryQueue.add(initialPayload)
 
-    const expectedPayloads: Array<{
-      apiKey: string
-      endpoint: string
-      payload: DeliveryPayload
-    }> = []
+    const expectedPayloads: DeliveryPayload[] = []
 
     // add 1000 spans
     for (let i = 0; i <= 9; i++) {
       const payload = generateFullPayload()
-      expectedPayloads.push({ apiKey, endpoint, payload })
+      expectedPayloads.push(payload)
 
       retryQueue.add(payload)
     }
@@ -72,12 +60,10 @@ describe('RetryQueue', () => {
   })
 
   it('awaits current delivery before flushing queue', async () => {
-    const endpoint = '/traces'
-    const apiKey = 'valid-api-key'
     let outstandingRequests = 0
 
     const delivery: Delivery = {
-      send: jest.fn((endpoint, apiKey, payload) => {
+      send: jest.fn(payload => {
         ++outstandingRequests
         expect(outstandingRequests).toBe(1)
 
@@ -92,7 +78,7 @@ describe('RetryQueue', () => {
       })
     }
 
-    const retryQueue = new InMemoryQueue(delivery, endpoint, apiKey, 1000)
+    const retryQueue = new InMemoryQueue(delivery, 1000)
 
     const payload1 = generateFullPayload(1)
     const payload2 = generateFullPayload(1)
@@ -109,9 +95,9 @@ describe('RetryQueue', () => {
 
     await Promise.all([flush1, flush2, flush3])
 
-    expect(delivery.send).toHaveBeenNthCalledWith(1, endpoint, apiKey, payload1)
-    expect(delivery.send).toHaveBeenNthCalledWith(2, endpoint, apiKey, payload2)
-    expect(delivery.send).toHaveBeenNthCalledWith(3, endpoint, apiKey, payload3)
+    expect(delivery.send).toHaveBeenNthCalledWith(1, payload1)
+    expect(delivery.send).toHaveBeenNthCalledWith(2, payload2)
+    expect(delivery.send).toHaveBeenNthCalledWith(3, payload3)
   })
 })
 

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -27,7 +27,7 @@ describe('Span', () => {
     ])('uses default clock implementation if startTime is invalid ($type)', ({ startTime }) => {
       const delivery = new InMemoryDelivery()
       const clock = new IncrementingClock('1970-01-01T00:00:00Z')
-      const client = createTestClient({ delivery, clock })
+      const client = createTestClient({ deliveryFactory: () => delivery, clock })
       client.start({ apiKey: VALID_API_KEY })
 
       // @ts-expect-error startTime will be invalid
@@ -46,7 +46,7 @@ describe('Span', () => {
     it('can be ended without an endTime', () => {
       const delivery = new InMemoryDelivery()
       const clock = new IncrementingClock('1970-01-01T00:00:00Z')
-      const client = createTestClient({ delivery, clock })
+      const client = createTestClient({ deliveryFactory: () => delivery, clock })
       client.start({ apiKey: VALID_API_KEY })
 
       const span = client.startSpan('test span')
@@ -68,7 +68,7 @@ describe('Span', () => {
     it('accepts a Date object as endTime', () => {
       const clock = new IncrementingClock('2023-01-02T03:04:05.006Z')
       const delivery = new InMemoryDelivery()
-      const client = createTestClient({ clock, delivery })
+      const client = createTestClient({ deliveryFactory: () => delivery, clock })
       client.start({ apiKey: VALID_API_KEY })
 
       const span = client.startSpan('test span')
@@ -91,7 +91,7 @@ describe('Span', () => {
       const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
       const delivery = new InMemoryDelivery()
 
-      const client = createTestClient({ clock, delivery })
+      const client = createTestClient({ deliveryFactory: () => delivery, clock })
       client.start({ apiKey: VALID_API_KEY })
 
       const span = client.startSpan('test span')

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -2,7 +2,7 @@ import { createClient } from '@bugsnag/js-performance-core'
 import createBrowserBackgroundingListener from './backgrounding-listener'
 import createClock from './clock'
 import { createSchema } from './config'
-import browserDelivery from './delivery'
+import createBrowserDeliveryFactory from './delivery'
 import idGenerator from './id-generator'
 import createResourceAttributesSource from './resource-attributes-source'
 import spanAttributesSource from './span-attributes-source'
@@ -16,7 +16,7 @@ const BugsnagPerformance = createClient({
   clock,
   resourceAttributesSource,
   spanAttributesSource,
-  delivery: browserDelivery(window.fetch, backgroundingListener),
+  deliveryFactory: createBrowserDeliveryFactory(window.fetch, backgroundingListener),
   idGenerator,
   schema: createSchema(window.location.hostname)
 })

--- a/packages/platforms/browser/lib/delivery.ts
+++ b/packages/platforms/browser/lib/delivery.ts
@@ -1,12 +1,13 @@
 import {
   type BackgroundingListener,
   type Delivery,
+  type DeliveryFactory,
   responseStateFromStatusCode
 } from '@bugsnag/js-performance-core'
 
 export type Fetch = typeof fetch
 
-function browserDelivery (fetch: Fetch, backgroundingListener: BackgroundingListener): Delivery {
+function createBrowserDeliveryFactory (fetch: Fetch, backgroundingListener: BackgroundingListener): DeliveryFactory {
   // we set fetch's 'keepalive' flag if the app is backgrounded/terminated so
   // that we can flush the last batch - without 'keepalive' the browser can
   // cancel (or never start sending) this request
@@ -17,28 +18,30 @@ function browserDelivery (fetch: Fetch, backgroundingListener: BackgroundingList
     keepalive = state === 'in-background'
   })
 
-  return {
-    async send (endpoint, apiKey, payload) {
-      const spanCount = payload.resourceSpans.reduce((count, resourceSpan) => count + resourceSpan.scopeSpans.length, 0)
+  return function browserDeliveryFactory (apiKey: string, endpoint: string): Delivery {
+    return {
+      async send (payload) {
+        const spanCount = payload.resourceSpans.reduce((count, resourceSpan) => count + resourceSpan.scopeSpans.length, 0)
 
-      try {
-        const response = await fetch(endpoint, {
-          method: 'POST',
-          keepalive,
-          body: JSON.stringify(payload),
-          headers: {
-            'Bugsnag-Api-Key': apiKey,
-            'Content-Type': 'application/json',
-            'Bugsnag-Span-Sampling': `1.0:${spanCount}`
-          }
-        })
+        try {
+          const response = await fetch(endpoint, {
+            method: 'POST',
+            keepalive,
+            body: JSON.stringify(payload),
+            headers: {
+              'Bugsnag-Api-Key': apiKey,
+              'Content-Type': 'application/json',
+              'Bugsnag-Span-Sampling': `1.0:${spanCount}`
+            }
+          })
 
-        return { state: responseStateFromStatusCode(response.status) }
-      } catch (err) {
-        return { state: 'failure-retryable' }
+          return { state: responseStateFromStatusCode(response.status) }
+        } catch (err) {
+          return { state: 'failure-retryable' }
+        }
       }
     }
   }
 }
 
-export default browserDelivery
+export default createBrowserDeliveryFactory

--- a/packages/platforms/browser/tests/delivery.test.ts
+++ b/packages/platforms/browser/tests/delivery.test.ts
@@ -4,7 +4,7 @@
 
 import { type DeliveryPayload } from '@bugsnag/js-performance-core'
 import { ControllableBackgroundingListener } from '@bugsnag/js-performance-test-utilities'
-import createDelivery from '../lib/delivery'
+import createBrowserDeliveryFactory from '../lib/delivery'
 
 describe('Browser Delivery', () => {
   it('delivers a span', () => {
@@ -28,8 +28,9 @@ describe('Browser Delivery', () => {
       }]
     }
 
-    const delivery = createDelivery(fetch, backgroundingListener)
-    delivery.send('/test', 'test-api-key', deliveryPayload)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const delivery = deliveryFactory('test-api-key', '/test')
+    delivery.send(deliveryPayload)
 
     expect(fetch).toHaveBeenCalledWith('/test', {
       method: 'POST',
@@ -64,11 +65,12 @@ describe('Browser Delivery', () => {
       }]
     }
 
-    const delivery = createDelivery(fetch, backgroundingListener)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const delivery = deliveryFactory('test-api-key', '/test')
 
     backgroundingListener.sendToBackground()
 
-    delivery.send('/test', 'test-api-key', deliveryPayload)
+    delivery.send(deliveryPayload)
 
     expect(fetch).toHaveBeenCalledWith('/test', {
       method: 'POST',
@@ -103,12 +105,13 @@ describe('Browser Delivery', () => {
       }]
     }
 
-    const delivery = createDelivery(fetch, backgroundingListener)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const delivery = deliveryFactory('test-api-key', '/test')
 
     backgroundingListener.sendToBackground()
     backgroundingListener.sendToForeground()
 
-    delivery.send('/test', 'test-api-key', deliveryPayload)
+    delivery.send(deliveryPayload)
 
     expect(fetch).toHaveBeenCalledWith('/test', {
       method: 'POST',

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -16,7 +16,7 @@ import {
 
 const defaultOptions = () => ({
   backgroundingListener: new ControllableBackgroundingListener(),
-  delivery: new InMemoryDelivery(),
+  deliveryFactory: () => new InMemoryDelivery(),
   idGenerator: new StableIdGenerator(),
   clock: new IncrementingClock(),
   resourceAttributesSource,

--- a/packages/test-utilities/lib/in-memory-delivery.ts
+++ b/packages/test-utilities/lib/in-memory-delivery.ts
@@ -1,18 +1,12 @@
 import { type DeliveryPayload, type Delivery, type ResponseState } from '@bugsnag/js-performance-core'
 
-interface Request {
-  apiKey: string
-  endpoint: string
-  payload: DeliveryPayload
-}
-
 class InMemoryDelivery implements Delivery {
-  public requests: Request[] = []
+  public requests: DeliveryPayload[] = []
 
   private readonly responseStateStack: ResponseState[] = []
 
-  send (endpoint: string, apiKey: string, payload: DeliveryPayload) {
-    this.requests.push({ apiKey, endpoint, payload })
+  send (payload: DeliveryPayload) {
+    this.requests.push(payload)
 
     const state = this.responseStateStack.pop() || 'success' as ResponseState
 

--- a/packages/test-utilities/lib/matchers/to-have-sent-span.ts
+++ b/packages/test-utilities/lib/matchers/to-have-sent-span.ts
@@ -9,7 +9,7 @@ const toHaveSentSpan: MatcherFunction<[expectedSpan: unknown]> = function (deliv
   }
 
   // pass if any span matches the expectedSpan; we explicitly don't care about order
-  const pass = delivery.requests.some(request => this.equals(request.payload, expect.objectContaining({
+  const pass = delivery.requests.some(payload => this.equals(payload, expect.objectContaining({
     resourceSpans: expect.arrayContaining([
       expect.objectContaining({
         scopeSpans: expect.arrayContaining([
@@ -27,7 +27,7 @@ const toHaveSentSpan: MatcherFunction<[expectedSpan: unknown]> = function (deliv
   const actual = delivery.requests.length === 0
     ? this.utils.RECEIVED_COLOR('[]')
     : this.utils.RECEIVED_COLOR('[\n    ') +
-      delivery.requests.map(({ payload }) => payload.resourceSpans.flatMap(({ scopeSpans }) => scopeSpans.flatMap(({ spans }) => spans.flatMap(({ attributes, ...rest }) => this.utils.printReceived({ ...rest })).join(',\n    ')))).join(',\n    ') +
+      delivery.requests.map(payload => payload.resourceSpans.flatMap(({ scopeSpans }) => scopeSpans.flatMap(({ spans }) => spans.flatMap(({ attributes, ...rest }) => this.utils.printReceived({ ...rest })).join(',\n    ')))).join(',\n    ') +
       this.utils.RECEIVED_COLOR('\n]')
 
   const message = () =>


### PR DESCRIPTION
## Goal

Core now expects a `DeliveryFactory` from platforms, which takes an `apiKey` and `endpoint` argument and returns a `Delivery`

This means we don't need to pass `apiKey` & `endpoint` to `Delivery.send` with every call, which also means we don't need to store them in classes that just want to send stuff (e.g. `RetryQueue` loses 2 properties)