### PR TITLE
[PLAT-9793] Check SDK version from package json

### DIFF
--- a/test/browser/features/manual-spans.feature
+++ b/test/browser/features/manual-spans.feature
@@ -11,7 +11,7 @@ Feature: Manual creation of spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.browser"
-    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals the stored value "app_version"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals the stored value "telemetry.sdk.version"
     And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals the stored value "environment"
 
   @chromium_only @local_only

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -10,7 +10,7 @@ When("I navigate to the test URL {string}") do |test_path|
 
   # store app version from package.json
   package = JSON.parse(File.read("./features/fixtures/node_modules/@bugsnag/js-performance-browser/package.json"))
-  Maze::Store.values["app_version"] = package["version"]
+  Maze::Store.values["telemetry.sdk.version"] = package["version"]
 end
 
 When("I set the HTTP status code for the next {int} {string} requests to {int}") do |count, http_verb, status_code|


### PR DESCRIPTION
## Goal

Validate the "telemetry.sdk.version" resource attribute matches the version from package.json in the browser performance client