### PR TITLE
Publish packages to GitHub's NPM registry

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,25 @@
+name: Publish packages
+
+on:
+  push:
+    branches: ['next']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://npm.pkg.github.com/
+
+      - run: npm ci
+      - run: npm run build
+      - run: npx lerna publish --canary --yes --registry https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

This allows us to use the performance SDK internally, without exposing it as a public package

The publish is done in a GitHub Action on push to `next`, using the `--canary` flag to bump versions based on the commit hash (this also avoids making a tag for every version)

See https://github.com/orgs/bugsnag/packages?repo_name=bugsnag-js-performance for a publish from this branch (I commented out the `branches: ['next']` line)

The packages can be installed by specifying the registry when installing, e.g.:

```sh
npm install \
  @bugsnag/js-performance-browser@0.0.1-alpha.0 \
  --save \
  --registry https://npm.pkg.github.com
```

This requires a personal access token as the packages are private: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token