### PR TITLE
Fix publish version number never increasing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -20,6 +20,6 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npx lerna publish --canary --yes --registry https://npm.pkg.github.com
+      - run: npx lerna publish --canary --force-publish --preid alpha.$(git rev-parse --short HEAD) --yes --registry https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

Lerna uses `+${SHA}` in the package version but GitHub Packages ignores everything after the `+`, which means the package version is always the same and therefore is only able to be published once

To fix this we can use a custom 'preid' that includes the SHA after a `.`, so every version is actually different: https://github.com/lerna/lerna/issues/2060#issuecomment-658182391

I've also added `--force-publish` to ensure every package is published on each commit: https://github.com/lerna/lerna/issues/2060