### PR TITLE
Use URLSearchParams to fetch fixture configuration

### DIFF
--- a/test/browser/features/fixtures/packages/batch-max-limit/src/index.js
+++ b/test/browser/features/fixtures/packages/batch-max-limit/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 5 })
 

--- a/test/browser/features/fixtures/packages/batch-timeout/src/index.js
+++ b/test/browser/features/fixtures/packages/batch-timeout/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, batchInactivityTimeoutMs: 2000 })
 

--- a/test/browser/features/fixtures/packages/connection-failure/src/index.js
+++ b/test/browser/features/fixtures/packages/connection-failure/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1 })
 

--- a/test/browser/features/fixtures/packages/empty-batch/src/index.js
+++ b/test/browser/features/fixtures/packages/empty-batch/src/index.js
@@ -1,6 +1,7 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, batchInactivityTimeoutMs: 2000 })

--- a/test/browser/features/fixtures/packages/enabled-release-stages-disabled/src/index.js
+++ b/test/browser/features/fixtures/packages/enabled-release-stages-disabled/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, releaseStage: 'test', enabledReleaseStages: ['production'], maximumBatchSize: 1 })
 

--- a/test/browser/features/fixtures/packages/enabled-release-stages/src/index.js
+++ b/test/browser/features/fixtures/packages/enabled-release-stages/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, enabledReleaseStages: ['test'], releaseStage: 'test', maximumBatchSize: 1 })
 

--- a/test/browser/features/fixtures/packages/manual-span/src/index.js
+++ b/test/browser/features/fixtures/packages/manual-span/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1 })
 

--- a/test/browser/features/fixtures/packages/navigation-changes/src/index.js
+++ b/test/browser/features/fixtures/packages/navigation-changes/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint })
 

--- a/test/browser/features/fixtures/packages/oldest-batch-removed/src/index.js
+++ b/test/browser/features/fixtures/packages/oldest-batch-removed/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, retryQueueMaxSize: 3, maximumBatchSize: 1 })
 

--- a/test/browser/features/fixtures/packages/one-span-per-trace/src/index.js
+++ b/test/browser/features/fixtures/packages/one-span-per-trace/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1 })
 

--- a/test/browser/features/fixtures/packages/pre-start-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/pre-start-spans/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.startSpan("Custom/Pre Start Span 0").end()
 BugsnagPerformance.startSpan("Custom/Pre Start Span 1").end()

--- a/test/browser/features/fixtures/packages/retry-scenario/src/index.js
+++ b/test/browser/features/fixtures/packages/retry-scenario/src/index.js
@@ -1,7 +1,8 @@
 import BugsnagPerformance from '@bugsnag/js-performance-browser'
 
-const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1 })
 

--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -20,7 +20,7 @@ class Browser
 
   def url_for(path)
     uri = URI.join(@fixtures_uri, path)
-    config_query_string = "ENDPOINT=#{@maze_uri}/traces&LOGS=#{@maze_uri}/logs&API_KEY=#{$api_key}"
+    config_query_string = "endpoint=#{@maze_uri}/traces&logs=#{@maze_uri}/logs&api_key=#{$api_key}"
 
     if uri.query
       uri.query += "&#{config_query_string}"


### PR DESCRIPTION
## Goal

Simplifies the fixture configuration (API key & MR endpoint) by using [the `URLSearchParams` class](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)

i.e. instead of:

```js
const apiKey = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
const endpoint = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
```

We can do:

```js
const parameters = new URLSearchParams(window.location.search)
const apiKey = parameters.get('api_key')
const endpoint = parameters.get('endpoint')
```