### PR TITLE
Add `TimeoutSettler`

### DIFF
--- a/packages/js-performance-browser-plugin-settler/lib/timeout-settler.ts
+++ b/packages/js-performance-browser-plugin-settler/lib/timeout-settler.ts
@@ -1,0 +1,27 @@
+import { type Settler } from './settler'
+
+class TimeoutSettler implements Settler {
+  private settled: boolean = false
+  private callbacks: Array<() => void> = []
+
+  constructor (timeoutMilliseconds: number) {
+    setTimeout(() => {
+      this.settled = true
+
+      for (const callback of this.callbacks) {
+        callback()
+      }
+    }, timeoutMilliseconds)
+  }
+
+  subscribe (callback: () => void): void {
+    this.callbacks.push(callback)
+
+    // if we're already settled, call the callback immediately
+    if (this.settled) {
+      callback()
+    }
+  }
+}
+
+export default TimeoutSettler

--- a/packages/js-performance-browser-plugin-settler/tests/timeout-settler.test.ts
+++ b/packages/js-performance-browser-plugin-settler/tests/timeout-settler.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import TimeoutSettler from '../lib/timeout-settler'
+
+describe('TimeoutSettler', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  it('settles when the given timeout has elapsed', async () => {
+    const settleCallback = jest.fn()
+    const settler = new TimeoutSettler(10)
+
+    settler.subscribe(settleCallback)
+
+    // advance by 9ms - 1ms short of when the timeout should fire
+    for (let i = 0; i < 9; ++i) {
+      await jest.advanceTimersByTimeAsync(1)
+      expect(settleCallback).not.toHaveBeenCalled()
+    }
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(settleCallback).toHaveBeenCalled()
+  })
+
+  it('can handle multiple callbacks', async () => {
+    const callbacks = [jest.fn(), jest.fn(), jest.fn(), jest.fn(), jest.fn()]
+
+    const settler = new TimeoutSettler(100)
+
+    for (const callback of callbacks) {
+      settler.subscribe(callback)
+      expect(callback).not.toHaveBeenCalled()
+    }
+
+    await jest.advanceTimersByTimeAsync(100)
+
+    for (const callback of callbacks) {
+      expect(callback).toHaveBeenCalled()
+    }
+  })
+
+  it('calls callbacks immediately if already settled', async () => {
+    const settleCallback1 = jest.fn()
+    const settleCallback2 = jest.fn()
+
+    const settler = new TimeoutSettler(50)
+
+    await jest.advanceTimersByTimeAsync(150)
+
+    settler.subscribe(settleCallback1)
+    settler.subscribe(settleCallback2)
+
+    expect(settleCallback1).toHaveBeenCalled()
+    expect(settleCallback2).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Goal

This Settler implementation settles when the given number of milliseconds has passed

This will be used to implement an overall limit to the wait for page settling, e.g. (pseudocode):

```js
function onSettle (callback) {
  const domMutationSettler = new DomMutationSettler(document.body)
  const timeoutSettler = new TimeoutSettler(60_000)

  let settled = false

  // call the callback when either settler has settled
  const subscription = function () {
    if (!settled) {
      callback()
      settled = true
    }
  }

  domMutationSettler.subscribe(subscription)
  timeoutSettler.subscribe(subscription)
}

// ...

onSettle(function () {
  console.log('either DOM mutations have stopped or 60 seconds has passed')
})
```