### PR TITLE
Pass `spanFactory` to plugin constructors

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -25,7 +25,7 @@ export interface ClientOptions {
   resourceAttributesSource: ResourceAttributeSource
   spanAttributesSource: SpanAttributesSource
   schema: CoreSchema
-  plugins: Plugin[]
+  plugins: (spanFactory: SpanFactory) => Plugin[]
 }
 
 export function createClient (options: ClientOptions): BugsnagPerformance {
@@ -34,10 +34,7 @@ export function createClient (options: ClientOptions): BugsnagPerformance {
 
   const sampler = new Sampler(1.0)
   const spanFactory = new SpanFactory(processor, sampler, options.idGenerator, options.spanAttributesSource)
-
-  for (const plugin of options.plugins) {
-    plugin.load(spanFactory)
-  }
+  const plugins = options.plugins(spanFactory)
 
   return {
     start: (config: Configuration | string) => {
@@ -71,7 +68,7 @@ export function createClient (options: ClientOptions): BugsnagPerformance {
 
       spanFactory.updateProcessor(processor)
 
-      for (const plugin of options.plugins) {
+      for (const plugin of plugins) {
         plugin.configure(configuration)
       }
     },

--- a/packages/core/lib/plugin.ts
+++ b/packages/core/lib/plugin.ts
@@ -1,7 +1,5 @@
 import { type InternalConfiguration } from './config'
-import { type SpanFactory } from './span'
 
 export interface Plugin {
-  load: (spanFactory: SpanFactory) => void
   configure: (configuration: InternalConfiguration) => void
 }

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -230,10 +230,11 @@ describe('Core', () => {
       })
     })
 
-    it('loads and configures a given plugin', () => {
-      const plugin = { load: jest.fn(), configure: jest.fn() }
-      const client = createTestClient({ plugins: [plugin] })
-      expect(plugin.load).toHaveBeenCalled()
+    it('creates and configures a given plugin', () => {
+      const plugin = { configure: jest.fn() }
+      const createPlugins = jest.fn(() => [plugin])
+      const client = createTestClient({ plugins: createPlugins })
+      expect(createPlugins).toHaveBeenCalled()
       expect(plugin.configure).not.toHaveBeenCalled()
       client.start(VALID_API_KEY)
       expect(plugin.configure).toHaveBeenCalled()

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -19,7 +19,7 @@ const BugsnagPerformance = createClient({
   deliveryFactory: createBrowserDeliveryFactory(window.fetch, backgroundingListener),
   idGenerator,
   schema: createSchema(window.location.hostname),
-  plugins: []
+  plugins: () => []
 })
 
 export default BugsnagPerformance

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -22,7 +22,7 @@ const defaultOptions = () => ({
   resourceAttributesSource,
   spanAttributesSource,
   schema,
-  plugins: []
+  plugins: () => []
 })
 
 function createTestClient (optionOverrides: Partial<ClientOptions> = {}): BugsnagPerformance {


### PR DESCRIPTION
## Goal

Updates the client's plugin interface to allow plugins to be constructed with a `SpanFactory`

`load` has been removed, and the `plugins` client config option is now a function that takes a `SpanFactory` and returns an array of plugins 

```
const BugsnagPerformance = createClient({
  plugins: (spanFactory) => [new Plugin(spanFactory)]
})
```