### PR TITLE
[PLAT-10020] Add autoInstrumentNetworkRequests config option

### DIFF
--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -11,6 +11,11 @@ export function createSchema (hostname: string): CoreSchema {
       defaultValue: true,
       message: 'should be true|false',
       validate: (value): value is boolean => value === true || value === false
+    },
+    autoInstrumentNetworkRequests: {
+      defaultValue: true,
+      message: 'should be true|false',
+      validate: (value): value is boolean => value === true || value === false
     }
   }
 }

--- a/test/browser/features/fixtures/packages/batch-max-limit/src/index.js
+++ b/test/browser/features/fixtures/packages/batch-max-limit/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 5, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 5, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 const spanNames = [
   "Custom/Full Batch 1",

--- a/test/browser/features/fixtures/packages/batch-timeout/src/index.js
+++ b/test/browser/features/fixtures/packages/batch-timeout/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, batchInactivityTimeoutMs: 2000, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, batchInactivityTimeoutMs: 2000, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 const span = BugsnagPerformance.startSpan("Custom/Batch Timeout")
 span.end()

--- a/test/browser/features/fixtures/packages/connection-failure/src/index.js
+++ b/test/browser/features/fixtures/packages/connection-failure/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 let spanNumber = 0
 

--- a/test/browser/features/fixtures/packages/empty-batch/src/index.js
+++ b/test/browser/features/fixtures/packages/empty-batch/src/index.js
@@ -4,4 +4,4 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, batchInactivityTimeoutMs: 2000, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, batchInactivityTimeoutMs: 2000, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })

--- a/test/browser/features/fixtures/packages/enabled-release-stages-disabled/src/index.js
+++ b/test/browser/features/fixtures/packages/enabled-release-stages-disabled/src/index.js
@@ -4,6 +4,6 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, releaseStage: 'test', enabledReleaseStages: ['production'], maximumBatchSize: 1, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, releaseStage: 'test', enabledReleaseStages: ['production'], maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 BugsnagPerformance.startSpan('Custom/Should not send').end()

--- a/test/browser/features/fixtures/packages/enabled-release-stages/src/index.js
+++ b/test/browser/features/fixtures/packages/enabled-release-stages/src/index.js
@@ -4,6 +4,6 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, enabledReleaseStages: ['test'], releaseStage: 'test', maximumBatchSize: 1, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, enabledReleaseStages: ['test'], releaseStage: 'test', maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 BugsnagPerformance.startSpan('Custom/Should send').end()

--- a/test/browser/features/fixtures/packages/manual-span/src/index.js
+++ b/test/browser/features/fixtures/packages/manual-span/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 const span = BugsnagPerformance.startSpan("Custom/ManualSpanScenario")
 span.end()

--- a/test/browser/features/fixtures/packages/navigation-changes/src/index.js
+++ b/test/browser/features/fixtures/packages/navigation-changes/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 let spanNumber = 0
 

--- a/test/browser/features/fixtures/packages/oldest-batch-removed/src/index.js
+++ b/test/browser/features/fixtures/packages/oldest-batch-removed/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, retryQueueMaxSize: 3, maximumBatchSize: 1, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, retryQueueMaxSize: 3, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 document.getElementById("send-spans").addEventListener("click", () => {
   BugsnagPerformance.startSpan("Custom/Span to retry 1").end()

--- a/test/browser/features/fixtures/packages/one-span-per-trace/src/index.js
+++ b/test/browser/features/fixtures/packages/one-span-per-trace/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 let spanNumber = 0
 

--- a/test/browser/features/fixtures/packages/pre-start-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/pre-start-spans/src/index.js
@@ -8,6 +8,6 @@ BugsnagPerformance.startSpan("Custom/Pre Start Span 0").end()
 BugsnagPerformance.startSpan("Custom/Pre Start Span 1").end()
 BugsnagPerformance.startSpan("Custom/Pre Start Span 2").end()
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 4, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 4, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 BugsnagPerformance.startSpan("Custom/Post Start").end()

--- a/test/browser/features/fixtures/packages/retry-scenario/src/index.js
+++ b/test/browser/features/fixtures/packages/retry-scenario/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 document.getElementById("send-span").addEventListener("click", () => {
   BugsnagPerformance.startSpan("Custom/Deliver").end()


### PR DESCRIPTION
## Goal

Adds a config option to disable auto instrumentation of network requests and sets this to false in the end to end tests. This config option doesn't do anything yet but will be used by the network span plugin.