### PR TITLE
[PLAT-10021] Add `networkInstrumentationIgnoreUrls` config option

### DIFF
--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -18,7 +18,10 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
 
   configure (configuration: InternalConfiguration<BrowserConfiguration>) {
     if (configuration.autoInstrumentNetworkRequests) {
-      this.ignoredUrls.push(RegExp(configuration.endpoint))
+      this.ignoredUrls = configuration.networkInstrumentationIgnoreUrls.map(
+        (url: string | RegExp): RegExp => typeof url === 'string' ? RegExp(url) : url
+      ).concat(RegExp(configuration.endpoint))
+
       this.xhrTracker.onStart(this.trackRequest)
       this.fetchTracker.onStart(this.trackRequest)
     }

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -12,6 +12,7 @@ export interface BrowserSchema extends CoreSchema {
   autoInstrumentNetworkRequests: ConfigOption<boolean>
   routingProvider: ConfigOption<RoutingProvider>
   urlsToExcludeWhenAwaitingSettle: ConfigOption<Array<string | RegExp>>
+  networkInstrumentationIgnoreUrls: ConfigOption<Array<string | RegExp>>
 }
 
 export interface BrowserConfiguration extends Configuration {
@@ -19,6 +20,7 @@ export interface BrowserConfiguration extends Configuration {
   autoInstrumentNetworkRequests?: boolean
   routingProvider?: RoutingProvider
   urlsToExcludeWhenAwaitingSettle?: Array<string | RegExp>
+  networkInstrumentationIgnoreUrls?: Array<string | RegExp>
 }
 
 export function createSchema (hostname: string): BrowserSchema {
@@ -44,6 +46,11 @@ export function createSchema (hostname: string): BrowserSchema {
       validate: isRoutingProvider
     },
     urlsToExcludeWhenAwaitingSettle: {
+      defaultValue: [],
+      message: 'should be an array of string|RegExp',
+      validate: isStringOrRegExpArray
+    },
+    networkInstrumentationIgnoreUrls: {
       defaultValue: [],
       message: 'should be an array of string|RegExp',
       validate: isStringOrRegExpArray

--- a/packages/test-utilities/lib/create-configuration.ts
+++ b/packages/test-utilities/lib/create-configuration.ts
@@ -3,6 +3,7 @@ import { type Configuration, type InternalConfiguration } from '@bugsnag/js-perf
 function createConfiguration<C extends Configuration> (overrides: Partial<C> = {}): InternalConfiguration<C> {
   return {
     autoInstrumentFullPageLoads: false,
+    autoInstrumentNetworkRequests: false,
     apiKey: 'abcdefabcdefabcdefabcdefabcdef12',
     endpoint: '/traces',
     releaseStage: 'production',
@@ -18,6 +19,7 @@ function createConfiguration<C extends Configuration> (overrides: Partial<C> = {
     },
     appVersion: '',
     samplingProbability: 1.0,
+    networkInstrumentationIgnoreUrls: [],
     ...overrides
   } as unknown as InternalConfiguration<C>
 }


### PR DESCRIPTION
## Goal

Adds a new config option `networkInstrumentationIgnoreUrls` for network spans. This is an array of string or regex values representing URLs to exclude from auto instrumentation.

For string values, the URL is excluded from instrumentation if it contains the supplied string. Default value is `[]`