### PR TITLE
Make Settler an abstract class

### DIFF
--- a/packages/platforms/browser/lib/on-settle/dom-mutation-settler.ts
+++ b/packages/platforms/browser/lib/on-settle/dom-mutation-settler.ts
@@ -1,11 +1,11 @@
-import { type Settler } from './settler'
+import { Settler } from './settler'
 
-class DomMutationSettler implements Settler {
+class DomMutationSettler extends Settler {
   private timeout: ReturnType<typeof setTimeout> | undefined = undefined
-  private settled: boolean = false
-  private callbacks: Array<() => void> = []
 
   constructor (target: Node) {
+    super()
+
     const observer = new MutationObserver(() => { this.restart() })
 
     observer.observe(target, {
@@ -19,26 +19,11 @@ class DomMutationSettler implements Settler {
     this.restart()
   }
 
-  subscribe (callback: () => void): void {
-    this.callbacks.push(callback)
-
-    // if the dom is already settled, call the callback immediately
-    if (this.settled) {
-      callback()
-    }
-  }
-
   private restart (): void {
     clearTimeout(this.timeout)
     this.settled = false
 
-    this.timeout = setTimeout(() => {
-      this.settled = true
-
-      for (const callback of this.callbacks) {
-        callback()
-      }
-    }, 100)
+    this.timeout = setTimeout(() => { this.settle() }, 100)
   }
 }
 

--- a/packages/platforms/browser/lib/on-settle/load-event-end-settler.ts
+++ b/packages/platforms/browser/lib/on-settle/load-event-end-settler.ts
@@ -1,4 +1,4 @@
-import { type Settler } from './settler'
+import { Settler } from './settler'
 
 interface PerformanceWithTiming {
   timing: {
@@ -11,11 +11,10 @@ function isPerformanceNavigationTiming (entry: PerformanceEntry): entry is Perfo
   return entry.entryType === 'navigation'
 }
 
-class LoadEventEndSettler implements Settler {
-  private settled: boolean = false
-  private callbacks: Array<() => void> = []
-
+class LoadEventEndSettler extends Settler {
   constructor (PerformanceObserverClass: typeof PerformanceObserver, performance: PerformanceWithTiming) {
+    super()
+
     const supportedEntryTypes = PerformanceObserverClass.supportedEntryTypes
 
     // if the browser doesn't support 'supportedEntryTypes' or doesn't support
@@ -26,15 +25,6 @@ class LoadEventEndSettler implements Settler {
       this.settleUsingPerformanceObserver(PerformanceObserverClass)
     } else {
       this.settleUsingPerformanceTiming(performance)
-    }
-  }
-
-  subscribe (callback: () => void): void {
-    this.callbacks.push(callback)
-
-    // if we're already settled, call the callback immediately
-    if (this.settled) {
-      callback()
     }
   }
 
@@ -75,14 +65,6 @@ class LoadEventEndSettler implements Settler {
     }
 
     settleOnValidLoadEventEnd()
-  }
-
-  private settle (): void {
-    this.settled = true
-
-    for (const callback of this.callbacks) {
-      callback()
-    }
   }
 }
 

--- a/packages/platforms/browser/lib/on-settle/settler.ts
+++ b/packages/platforms/browser/lib/on-settle/settler.ts
@@ -1,3 +1,22 @@
-export interface Settler {
-  subscribe: (callback: () => void) => void
+export abstract class Settler {
+  protected settled: boolean = false
+
+  private readonly callbacks: Array<() => void> = []
+
+  subscribe (callback: () => void): void {
+    this.callbacks.push(callback)
+
+    // if we're already settled, call the callback immediately
+    if (this.settled) {
+      callback()
+    }
+  }
+
+  protected settle (): void {
+    this.settled = true
+
+    for (const callback of this.callbacks) {
+      callback()
+    }
+  }
 }

--- a/packages/platforms/browser/lib/on-settle/timeout-settler.ts
+++ b/packages/platforms/browser/lib/on-settle/timeout-settler.ts
@@ -1,26 +1,10 @@
-import { type Settler } from './settler'
+import { Settler } from './settler'
 
-class TimeoutSettler implements Settler {
-  private settled: boolean = false
-  private callbacks: Array<() => void> = []
-
+class TimeoutSettler extends Settler {
   constructor (timeoutMilliseconds: number) {
-    setTimeout(() => {
-      this.settled = true
+    super()
 
-      for (const callback of this.callbacks) {
-        callback()
-      }
-    }, timeoutMilliseconds)
-  }
-
-  subscribe (callback: () => void): void {
-    this.callbacks.push(callback)
-
-    // if we're already settled, call the callback immediately
-    if (this.settled) {
-      callback()
-    }
+    setTimeout(() => { this.settle() }, timeoutMilliseconds)
   }
 }
 


### PR DESCRIPTION
## Goal

Every Settler has ended up with exact copy/pastes of the same code, which clearly implies it should be shared by all Settlers

The Settler interface is now an abstract class and it handles all of the callback logic internally — concrete classes just need to call 'settle' at the appropriate time

## Testing

All existing tests pass