### PR TITLE
Add Settler#isSettled method

### DIFF
--- a/packages/platforms/browser/lib/on-settle/settler.ts
+++ b/packages/platforms/browser/lib/on-settle/settler.ts
@@ -7,9 +7,13 @@ export abstract class Settler {
     this.callbacks.push(callback)
 
     // if we're already settled, call the callback immediately
-    if (this.settled) {
+    if (this.isSettled()) {
       callback()
     }
+  }
+
+  isSettled (): boolean {
+    return this.settled
   }
 
   protected settle (): void {

--- a/packages/platforms/browser/tests/on-settle/dom-mutation-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/dom-mutation-settler.test.ts
@@ -24,10 +24,12 @@ describe('DomMutationSettler', () => {
     settler.subscribe(settleCallback)
 
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     await jest.advanceTimersByTimeAsync(100)
 
     expect(settleCallback).toHaveBeenCalledTimes(1)
+    expect(settler.isSettled()).toBe(true)
   })
 
   it('can handle multiple callbacks', async () => {
@@ -44,18 +46,22 @@ describe('DomMutationSettler', () => {
     expect(settleCallback1).not.toHaveBeenCalled()
     expect(settleCallback2).not.toHaveBeenCalled()
     expect(settleCallback3).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     await jest.advanceTimersByTimeAsync(100)
 
     expect(settleCallback1).toHaveBeenCalledTimes(1)
     expect(settleCallback2).toHaveBeenCalledTimes(1)
     expect(settleCallback3).toHaveBeenCalledTimes(1)
+    expect(settler.isSettled()).toBe(true)
   })
 
   it('settles immediately if the dom is already settled', async () => {
     const settler = new DomMutationSettler(document.body)
 
     await jest.advanceTimersByTimeAsync(100)
+
+    expect(settler.isSettled()).toBe(true)
 
     const settleCallback = jest.fn()
     settler.subscribe(settleCallback)
@@ -69,9 +75,11 @@ describe('DomMutationSettler', () => {
 
     settler.subscribe(settleCallback)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     await jest.advanceTimersByTimeAsync(80)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     // fix a typo
     // @ts-expect-error 'c' definitely exists
@@ -79,6 +87,7 @@ describe('DomMutationSettler', () => {
 
     await jest.advanceTimersByTimeAsync(80)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     // mutate something again
     // @ts-expect-error 'a' definitely exists
@@ -86,8 +95,10 @@ describe('DomMutationSettler', () => {
 
     await jest.advanceTimersByTimeAsync(80)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     await jest.advanceTimersByTimeAsync(20)
     expect(settleCallback).toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
   })
 })

--- a/packages/platforms/browser/tests/on-settle/request-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/request-settler.test.ts
@@ -30,6 +30,8 @@ describe('RequestSettler', () => {
     const tracker = new RequestTracker()
     const settler = new RequestSettler(tracker)
 
+    expect(settler.isSettled()).toBe(true)
+
     settler.subscribe(settleCallback)
     expect(settleCallback).toHaveBeenCalled()
   })
@@ -41,6 +43,8 @@ describe('RequestSettler', () => {
     tracker.start(START_CONTEXT)
 
     const settler = new RequestSettler(tracker)
+
+    expect(settler.isSettled()).toBe(false)
 
     settler.subscribe(settleCallback)
     expect(settleCallback).not.toHaveBeenCalled()
@@ -55,17 +59,21 @@ describe('RequestSettler', () => {
 
     settler.subscribe(settleCallback)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     end(END_CONTEXT)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     // after 99ms (1ms short of the timeout) we should not settle
     await jest.advanceTimersByTimeAsync(99)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     // it should settle after another 1ms
     await jest.advanceTimersByTimeAsync(1)
     expect(settleCallback).toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
   })
 
   it.failing('settles 100ms after a request created before construction finishes', async () => {
@@ -78,12 +86,15 @@ describe('RequestSettler', () => {
 
     settler.subscribe(settleCallback)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     end(END_CONTEXT)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     await jest.advanceTimersByTimeAsync(100)
     expect(settleCallback).toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
   })
 
   it('does not settle after a request finishes if there is another outstanding request', async () => {
@@ -101,12 +112,15 @@ describe('RequestSettler', () => {
 
     await jest.advanceTimersByTimeAsync(100)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     endRequest2(END_CONTEXT)
     expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
 
     await jest.advanceTimersByTimeAsync(100)
     expect(settleCallback).toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
   })
 
   it('can handle multiple callbacks', async () => {
@@ -116,12 +130,15 @@ describe('RequestSettler', () => {
 
     const end = tracker.start(START_CONTEXT)
 
+    expect(settler.isSettled()).toBe(false)
+
     for (const settleCallback of settleCallbacks) {
       settler.subscribe(settleCallback)
       expect(settleCallback).not.toHaveBeenCalled()
     }
 
     end(END_CONTEXT)
+    expect(settler.isSettled()).toBe(false)
 
     for (const settleCallback of settleCallbacks) {
       settler.subscribe(settleCallback)
@@ -129,6 +146,7 @@ describe('RequestSettler', () => {
     }
 
     await jest.advanceTimersByTimeAsync(100)
+    expect(settler.isSettled()).toBe(true)
 
     for (const settleCallback of settleCallbacks) {
       settler.subscribe(settleCallback)

--- a/packages/platforms/browser/tests/on-settle/timeout-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/timeout-settler.test.ts
@@ -21,14 +21,18 @@ describe('TimeoutSettler', () => {
       expect(settleCallback).not.toHaveBeenCalled()
     }
 
+    expect(settler.isSettled()).toBe(false)
+
     await jest.advanceTimersByTimeAsync(1)
     expect(settleCallback).toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
   })
 
   it('can handle multiple callbacks', async () => {
     const callbacks = [jest.fn(), jest.fn(), jest.fn(), jest.fn(), jest.fn()]
 
     const settler = new TimeoutSettler(100)
+    expect(settler.isSettled()).toBe(false)
 
     for (const callback of callbacks) {
       settler.subscribe(callback)
@@ -36,6 +40,7 @@ describe('TimeoutSettler', () => {
     }
 
     await jest.advanceTimersByTimeAsync(100)
+    expect(settler.isSettled()).toBe(true)
 
     for (const callback of callbacks) {
       expect(callback).toHaveBeenCalled()
@@ -47,8 +52,10 @@ describe('TimeoutSettler', () => {
     const settleCallback2 = jest.fn()
 
     const settler = new TimeoutSettler(50)
+    expect(settler.isSettled()).toBe(false)
 
     await jest.advanceTimersByTimeAsync(150)
+    expect(settler.isSettled()).toBe(true)
 
     settler.subscribe(settleCallback1)
     settler.subscribe(settleCallback2)


### PR DESCRIPTION
## Goal

Add a new `Settler#isSettled` method for querying if a Settler is settled

This is useful for checking if multiple settlers have settled from within a `subscribe` callback, e.g.:

```ts
const settler1 = new ExampleSettler()
const settler2 = new ExampleSettler()

function onSettle () {
  if (settler1.isSettled() && settler2.isSettled()) {
    console.log('both settled!')
  }
}

settler1.subscribe(onSettle)
settler2.subscribe(onSettle)
```