### PR TITLE
Add TimeoutSettler#cancel method

### DIFF
--- a/packages/platforms/browser/lib/on-settle/timeout-settler.ts
+++ b/packages/platforms/browser/lib/on-settle/timeout-settler.ts
@@ -1,10 +1,16 @@
 import { Settler } from './settler'
 
 class TimeoutSettler extends Settler {
+  private timeout: ReturnType<typeof setTimeout>
+
   constructor (timeoutMilliseconds: number) {
     super()
 
-    setTimeout(() => { this.settle() }, timeoutMilliseconds)
+    this.timeout = setTimeout(() => { this.settle() }, timeoutMilliseconds)
+  }
+
+  cancel () {
+    clearTimeout(this.timeout)
   }
 }
 

--- a/packages/platforms/browser/tests/on-settle/timeout-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/timeout-settler.test.ts
@@ -63,4 +63,18 @@ describe('TimeoutSettler', () => {
     expect(settleCallback1).toHaveBeenCalled()
     expect(settleCallback2).toHaveBeenCalled()
   })
+
+  it('can be cancelled', async () => {
+    const settleCallback = jest.fn()
+    const settler = new TimeoutSettler(10)
+
+    settler.subscribe(settleCallback)
+
+    settler.cancel()
+
+    await jest.advanceTimersByTimeAsync(10)
+
+    expect(settleCallback).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
+  })
 })


### PR DESCRIPTION
## Goal

This allows cancelling a timeout as it may be obsoleted by another settler settling, e.g.

```ts
const requestSettler = new RequestSettler(fetchRequestTracker)
const timeout = new TimeoutSettler(10_000)

requestSettler.subscribe(() => {
  console.log('no requests :)')

  // cancel the timeout
  timeout.cancel()
})

timeout.subscribe(() => {
  console.log('timed out :(')
})
```