### PR TITLE
Add Settler#unsubscribe method

### DIFF
--- a/packages/platforms/browser/lib/on-settle/settler.ts
+++ b/packages/platforms/browser/lib/on-settle/settler.ts
@@ -12,6 +12,10 @@ export abstract class Settler {
     }
   }
 
+  unsubscribe (callback: () => void): void {
+    this.callbacks.delete(callback)
+  }
+
   isSettled (): boolean {
     return this.settled
   }

--- a/packages/platforms/browser/tests/on-settle/dom-mutation-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/dom-mutation-settler.test.ts
@@ -56,6 +56,28 @@ describe('DomMutationSettler', () => {
     expect(settler.isSettled()).toBe(true)
   })
 
+  it('can unsubscribe a callback', async () => {
+    const settleCallback1 = jest.fn()
+    const settleCallback2 = jest.fn()
+
+    const settler = new DomMutationSettler(document.body)
+
+    settler.subscribe(settleCallback1)
+    settler.subscribe(settleCallback2)
+
+    expect(settleCallback1).not.toHaveBeenCalled()
+    expect(settleCallback2).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
+
+    settler.unsubscribe(settleCallback2)
+
+    await jest.advanceTimersByTimeAsync(100)
+
+    expect(settleCallback1).toHaveBeenCalledTimes(1)
+    expect(settleCallback2).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
+  })
+
   it('settles immediately if the dom is already settled', async () => {
     const settler = new DomMutationSettler(document.body)
 

--- a/packages/platforms/browser/tests/on-settle/load-event-end-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/load-event-end-settler.test.ts
@@ -61,6 +61,30 @@ describe('LoadEventEndSettler', () => {
     expect(settler.isSettled()).toBe(true)
   })
 
+  it('can unsubscribe a callback', () => {
+    const manager = new PerformanceObserverManager()
+    const performance = { timing: { loadEventEnd: 0 } }
+    const settleCallback1 = jest.fn()
+    const settleCallback2 = jest.fn()
+    const settler = new LoadEventEndSettler(manager.createPerformanceObserverFakeClass(), performance)
+
+    settler.subscribe(settleCallback1)
+    settler.subscribe(settleCallback2)
+
+    expect(settleCallback1).not.toHaveBeenCalled()
+    expect(settleCallback2).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
+
+    settler.unsubscribe(settleCallback2)
+
+    manager.queueEntry(manager.createPerformanceNavigationTimingFake({ loadEventEnd: 100 }))
+    manager.flushQueue()
+
+    expect(settleCallback1).toHaveBeenCalled()
+    expect(settleCallback2).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
+  })
+
   it('settles immediately if already settled', () => {
     const manager = new PerformanceObserverManager()
     const performance = { timing: { loadEventEnd: 0 } }

--- a/packages/platforms/browser/tests/on-settle/request-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/request-settler.test.ts
@@ -153,4 +153,30 @@ describe('RequestSettler', () => {
       expect(settleCallback).toHaveBeenCalled()
     }
   })
+
+  it('can unsubscribe a callback', async () => {
+    const settleCallback1 = jest.fn()
+    const settleCallback2 = jest.fn()
+    const tracker = new RequestTracker()
+    const settler = new RequestSettler(tracker)
+
+    const end = tracker.start(START_CONTEXT)
+
+    settler.subscribe(settleCallback1)
+    settler.subscribe(settleCallback2)
+
+    expect(settleCallback1).not.toHaveBeenCalled()
+    expect(settleCallback2).not.toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(false)
+
+    settler.unsubscribe(settleCallback1)
+
+    end(END_CONTEXT)
+
+    await jest.advanceTimersByTimeAsync(100)
+
+    expect(settleCallback1).not.toHaveBeenCalled()
+    expect(settleCallback2).toHaveBeenCalled()
+    expect(settler.isSettled()).toBe(true)
+  })
 })

--- a/packages/platforms/browser/tests/on-settle/timeout-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/timeout-settler.test.ts
@@ -47,6 +47,25 @@ describe('TimeoutSettler', () => {
     }
   })
 
+  it('can subscribe a callback', async () => {
+    const settleCallback1 = jest.fn()
+    const settleCallback2 = jest.fn()
+
+    const settler = new TimeoutSettler(50)
+    expect(settler.isSettled()).toBe(false)
+
+    settler.subscribe(settleCallback1)
+    settler.subscribe(settleCallback2)
+
+    settler.unsubscribe(settleCallback1)
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settler.isSettled()).toBe(true)
+
+    expect(settleCallback1).not.toHaveBeenCalled()
+    expect(settleCallback2).toHaveBeenCalled()
+  })
+
   it('calls callbacks immediately if already settled', async () => {
     const settleCallback1 = jest.fn()
     const settleCallback2 = jest.fn()


### PR DESCRIPTION
## Goal

This PR adds a `Settler#unsubscribe` method so that subscriptions can be cancelled when no longer needed. This prevents memory leaks where a subscription would be held forever

As part of this I've switched the callback array to be a `Set`, so that deleting a specific callback is easier and doesn't require iterating through an array. This also has the side effect of preventing duplicate callbacks from being registered