### PR TITLE
Add 'on settle' function

### DIFF
--- a/packages/platforms/browser/lib/on-settle/index.ts
+++ b/packages/platforms/browser/lib/on-settle/index.ts
@@ -1,0 +1,48 @@
+import DomMutationSettler from './dom-mutation-settler'
+import LoadEventEndSettler, { type PerformanceWithTiming } from './load-event-end-settler'
+import RequestSettler from './request-settler'
+import SettlerAggregate from './settler-aggregate'
+import TimeoutSettler from './timeout-settler'
+import { type RequestTracker } from '../request-tracker/request-tracker'
+
+const TIMEOUT = 60 * 1000
+
+export default function createOnSettle (
+  document: Node,
+  fetchRequestTracker: RequestTracker,
+  xhrRequestTracker: RequestTracker,
+  PerformanceObserverClass: typeof PerformanceObserver,
+  performance: PerformanceWithTiming
+) {
+  const domMutationSettler = new DomMutationSettler(document)
+  const fetchRequestSettler = new RequestSettler(fetchRequestTracker)
+  const xhrRequestSettler = new RequestSettler(xhrRequestTracker)
+  const loadEventEndSettler = new LoadEventEndSettler(PerformanceObserverClass, performance)
+
+  const settler = new SettlerAggregate([
+    domMutationSettler,
+    loadEventEndSettler,
+    fetchRequestSettler,
+    xhrRequestSettler
+  ])
+
+  return function onSettle (callback: () => void): void {
+    const timeout = new TimeoutSettler(TIMEOUT)
+
+    const onSettle = () => {
+      // cancel the timeout and unsubscribe - this is fine to do even if the
+      // timeout is what called this function
+      timeout.cancel()
+      timeout.unsubscribe(onSettle)
+
+      // unsubscribe from the settler so we don't call the callback more than
+      // once
+      settler.unsubscribe(onSettle)
+
+      callback()
+    }
+
+    settler.subscribe(onSettle)
+    timeout.subscribe(onSettle)
+  }
+}

--- a/packages/platforms/browser/lib/on-settle/load-event-end-settler.ts
+++ b/packages/platforms/browser/lib/on-settle/load-event-end-settler.ts
@@ -1,6 +1,6 @@
 import { Settler } from './settler'
 
-interface PerformanceWithTiming {
+export interface PerformanceWithTiming {
   timing: {
     loadEventEnd: number
   }

--- a/packages/platforms/browser/tests/on-settle/index.test.ts
+++ b/packages/platforms/browser/tests/on-settle/index.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import createOnSettle from '../../lib/on-settle'
+import {
+  type RequestStartContext,
+  type RequestEndContext,
+  RequestTracker
+} from '../../lib/request-tracker/request-tracker'
+import { PerformanceObserverManager } from '@bugsnag/js-performance-test-utilities'
+
+const START_CONTEXT: RequestStartContext = {
+  url: 'https://www.bugsnag.com',
+  method: 'GET',
+  startTime: 1234
+}
+
+const END_CONTEXT: RequestEndContext = {
+  endTime: 5678,
+  status: 200
+}
+
+describe('onSettle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  it('settles when all the settlers have settled', async () => {
+    const manager = new PerformanceObserverManager()
+    const performance = { timing: { loadEventEnd: 0 } }
+    const fetchRequestTracker = new RequestTracker()
+    const xhrRequestTracker = new RequestTracker()
+
+    const onSettle = createOnSettle(
+      document,
+      fetchRequestTracker,
+      xhrRequestTracker,
+      manager.createPerformanceObserverFakeClass(),
+      performance
+    )
+
+    const settleCallback = jest.fn()
+
+    onSettle(settleCallback)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    // everything has settled other than the load event end, so once we trigger
+    // that 'settleCallback' should be called
+
+    manager.queueEntry(manager.createPerformanceNavigationTimingFake({ loadEventEnd: 100 }))
+    manager.flushQueue()
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settleCallback).toHaveBeenCalled()
+  })
+
+  it('settles when all the settlers have settled (with DOM mutations)', async () => {
+    document.body.innerHTML = `
+      <p id="a">AAAAAAAAAAA</p>
+      <p id="b">BBBBBBBBBBB</p>
+      <p id="c">CCCCCCCCCCC</p>
+    `
+
+    const manager = new PerformanceObserverManager()
+    const performance = { timing: { loadEventEnd: 0 } }
+    const fetchRequestTracker = new RequestTracker()
+    const xhrRequestTracker = new RequestTracker()
+
+    const onSettle = createOnSettle(
+      document,
+      fetchRequestTracker,
+      xhrRequestTracker,
+      manager.createPerformanceObserverFakeClass(),
+      performance
+    )
+
+    const settleCallback = jest.fn()
+
+    onSettle(settleCallback)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    manager.queueEntry(manager.createPerformanceNavigationTimingFake({ loadEventEnd: 100 }))
+    manager.flushQueue()
+
+    await jest.advanceTimersByTimeAsync(80)
+
+    const d = document.createElement('p')
+    d.textContent = 'DDDDDDDDDDD'
+    document.body.appendChild(d)
+
+    await jest.advanceTimersByTimeAsync(80)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(20)
+    expect(settleCallback).toHaveBeenCalled()
+  })
+
+  it('settles when all the settlers have settled (with fetch requests)', async () => {
+    const manager = new PerformanceObserverManager()
+    const performance = { timing: { loadEventEnd: 0 } }
+    const fetchRequestTracker = new RequestTracker()
+    const xhrRequestTracker = new RequestTracker()
+
+    const onSettle = createOnSettle(
+      document,
+      fetchRequestTracker,
+      xhrRequestTracker,
+      manager.createPerformanceObserverFakeClass(),
+      performance
+    )
+
+    const settleCallback = jest.fn()
+
+    onSettle(settleCallback)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    manager.queueEntry(manager.createPerformanceNavigationTimingFake({ loadEventEnd: 100 }))
+    manager.flushQueue()
+
+    const end = fetchRequestTracker.start(START_CONTEXT)
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    end(END_CONTEXT)
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settleCallback).toHaveBeenCalled()
+  })
+
+  it('settles when all the settlers have settled (with xhr requests)', async () => {
+    const manager = new PerformanceObserverManager()
+    const performance = { timing: { loadEventEnd: 0 } }
+    const fetchRequestTracker = new RequestTracker()
+    const xhrRequestTracker = new RequestTracker()
+
+    const onSettle = createOnSettle(
+      document,
+      fetchRequestTracker,
+      xhrRequestTracker,
+      manager.createPerformanceObserverFakeClass(),
+      performance
+    )
+
+    const settleCallback = jest.fn()
+
+    onSettle(settleCallback)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    manager.queueEntry(manager.createPerformanceNavigationTimingFake({ loadEventEnd: 100 }))
+    manager.flushQueue()
+
+    const end = xhrRequestTracker.start(START_CONTEXT)
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    end(END_CONTEXT)
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settleCallback).toHaveBeenCalled()
+  })
+
+  it('settles after the 60 second timeout if the settlers have not settled', async () => {
+    const manager = new PerformanceObserverManager()
+    const performance = { timing: { loadEventEnd: 0 } }
+
+    const onSettle = createOnSettle(
+      document,
+      new RequestTracker(),
+      new RequestTracker(),
+      manager.createPerformanceObserverFakeClass(),
+      performance
+    )
+
+    const settleCallback = jest.fn()
+
+    onSettle(settleCallback)
+
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(59_900)
+    expect(settleCallback).toHaveBeenCalled()
+  })
+
+  it('does not settle more than once if both the timeout and settlers settle', async () => {
+    const manager = new PerformanceObserverManager()
+    const performance = { timing: { loadEventEnd: 0 } }
+
+    const onSettle = createOnSettle(
+      document,
+      new RequestTracker(),
+      new RequestTracker(),
+      manager.createPerformanceObserverFakeClass(),
+      performance
+    )
+
+    const settleCallback = jest.fn()
+
+    onSettle(settleCallback)
+
+    expect(settleCallback).not.toHaveBeenCalled()
+
+    const finishedEntry = manager.createPerformanceNavigationTimingFake({ loadEventEnd: 100 })
+
+    manager.queueEntry(finishedEntry)
+    manager.flushQueue()
+
+    await jest.advanceTimersByTimeAsync(100)
+    expect(settleCallback).toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(59_900)
+    expect(settleCallback).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(60_000)
+    expect(settleCallback).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Goal

This PR adds the overall `onSettle` function (created with a `createOnSettle` factory function) that combines all of the previous PRs

This isn't the final PR in the stack, but it does finally allow using the full settling functionality:

```ts
import createOnSettle from '...'

const onSettle = createOnSettle(...)

onSettle(() => {
  console.log('the page has settled!')
})
```