### PR TITLE
Add step for validating full page load spans

### DIFF
--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -10,4 +10,4 @@ Feature: Page Load spans
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.url" equals the stored value "bugsnag.browser.page.url"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.route" equals "/page-load-spans/"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.referrer" equals ""
-        
+        And the span named "[FullPageLoad]/page-load-spans/" is a valid full page load span

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -48,6 +48,74 @@ When("I minimise the browser window") do
   driver.manage.window.minimize
 end
 
+# Checks that a span with a given name is a valid page load span:
+#
+#   1. its name starts with "[FullPageLoad]"
+#   2. it has the expected events for a page load ("ttfb" & friends)
+#   3. each event's "timeUnixNano" is between the span's start & end time
+#
+# This step also checks that there is only one full page load span across all
+# received traces as they play by highlander rules (there can only be one)
+#
+# @step_input span_name [String] The name of the span to check
+Then("the span named {string} is a valid full page load span") do |span_name|
+  expected_event_names = []
+  page_load_span_prefix = "[FullPageLoad]"
+
+  Maze.check.true(
+    span_name.start_with?(page_load_span_prefix),
+    "A page load span's name should start with '#{page_load_span_prefix}'"
+  )
+
+  spans = spans_from_request_list(Maze::Server.list_for("traces"))
+
+  # grab all the span names so the error is more useful if no span is found as
+  # this will output all of the span names when it fails
+  span_names = spans.map { |span| span["name"] }
+  Maze.check.includes(span_names, span_name, "No spans were found with the name '#{span_name}'")
+
+  page_load_spans = spans.select { |span| span["name"].start_with?(page_load_span_prefix) }
+  Maze.check.true(
+    page_load_spans.length == 1,
+    <<~MESSAGE
+      Expected only one page load span but found #{page_load_spans.length}:
+        - #{page_load_spans.map { |span| span["name"] }.join("\n  - ") }
+    MESSAGE
+  )
+
+  span = page_load_spans.first
+  Maze.check.equal(span_name, span["name"])
+
+  span_event_names = span["events"].map { |event| event["name"] }.sort
+
+  Maze.check.equal(
+    expected_event_names,
+    span_event_names,
+    "The span's events do not match the expected events"
+  )
+
+  start_time = Integer(span["startTimeUnixNano"])
+  end_time = Integer(span["endTimeUnixNano"])
+
+  span["events"].each do |event|
+    event_time = Integer(event["timeUnixNano"])
+
+    Maze.check.operator(
+      start_time,
+      :<=,
+      event_time,
+      "The '#{event["name"]}' event happened before the span's start time (#{start_time - event_time}ns difference)"
+    )
+
+    Maze.check.operator(
+      end_time,
+      :>=,
+      event_time,
+      "The '#{event["name"]}' event happened after the span's end time (#{event_time - end_time}ns difference)"
+    )
+  end
+end
+
 module Maze
   module Driver
     class Browser


### PR DESCRIPTION
## Goal

Add step for validating full page load spans

This step checks that a span with a given name is a valid page load span:

  1. its name starts with "[FullPageLoad]"
  2. it has the expected events for a page load ("ttfb" & friends)
  3. each event's "timeUnixNano" is between the span's start & end time

It also checks that there is only one full page load span across all received traces as they play by highlander rules (there can only be one)

When we add Cumulative Layout Shift we'll need to add validation for that as well

As there are no events in `next` yet, page load spans are expected to have no events — each PR adding a new event will need to update the `expected_event_names` array