### PR TITLE
[PLAT-10036] Add attributes to network spans

### DIFF
--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -30,13 +30,20 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   private trackRequest = (startContext: RequestStartContext): RequestEndCallback | undefined => {
     if (!this.shouldTrackRequest(startContext)) return
 
-    // TODO: set span attributes
     const span = this.spanFactory.startSpan(
       `[HTTP]/${startContext.method.toUpperCase()}`,
       startContext.startTime
     )
+
+    span.setAttribute('bugsnag.span.category', 'network')
+    span.setAttribute('http.url', startContext.url)
+    span.setAttribute('http.method', startContext.method)
+
     return (endContext: RequestEndContext) => {
-      if (endContext.state === 'success') this.spanFactory.endSpan(span, endContext.endTime)
+      if (endContext.state === 'success') {
+        span.setAttribute('http.status_code', endContext.status)
+        this.spanFactory.endSpan(span, endContext.endTime)
+      }
     }
   }
 

--- a/packages/platforms/browser/tests/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/network-request-plugin.test.ts
@@ -62,10 +62,42 @@ describe('network span plugin', () => {
 
     const endRequest = fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', 1)
-
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
+
     endRequest({ status: 200, endTime: 2, state: 'success' })
-    expect(spanFactory.endSpan).toHaveBeenCalledWith(spanFactory.createdSpans[0], 2)
+    expect(spanFactory.endSpan).toHaveBeenCalled()
+    expect(spanFactory.createdSpans.length).toEqual(1)
+
+    const span = spanFactory.createdSpans[0]
+    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.startTime).toEqual(1)
+    expect(span.endTime).toEqual(2)
+    expect(span.attributes.toJson()).toEqual(expect.arrayContaining([
+      {
+        key: 'bugsnag.span.category',
+        value: {
+          stringValue: 'network'
+        }
+      },
+      {
+        key: 'http.url',
+        value: {
+          stringValue: TEST_URL
+        }
+      },
+      {
+        key: 'http.method',
+        value: {
+          stringValue: 'GET'
+        }
+      },
+      {
+        key: 'http.status_code',
+        value: {
+          intValue: '200'
+        }
+      }
+    ]))
   })
 
   it('does not track requests when autoInstrumentNetworkRequests = false', () => {

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -1,21 +1,20 @@
-import { type SpanEnded, type SpanInternal, SpanFactory } from '@bugsnag/js-performance-core'
+import { type SpanInternal, type SpanEnded, SpanFactory } from '@bugsnag/js-performance-core'
 import StableIdGenerator from './stable-id-generator'
 import spanAttributesSource from './span-attributes-source'
+import InMemoryProcessor from './in-memory-processor'
 
 class MockSpanFactory extends SpanFactory {
-  createdSpans: SpanInternal[] = []
+  public createdSpans: SpanEnded[]
 
   constructor () {
-    const delivery = { send: jest.fn() }
-    const processor = { add: (span: SpanEnded) => delivery.send(span) }
     const sampler: any = { probability: 0.1, sample: () => true }
+    const processor = new InMemoryProcessor()
     super(processor, sampler, new StableIdGenerator(), spanAttributesSource)
+    this.createdSpans = processor.spans
   }
 
   startSpan = jest.fn((name: string, startTime: number) => {
-    const span = super.startSpan(name, startTime)
-    this.createdSpans.push(span)
-    return span
+    return super.startSpan(name, startTime)
   })
 
   endSpan = jest.fn((span: SpanInternal, endTime: number) => {


### PR DESCRIPTION
## Goal

Adds the following attributes to network spans:

- `bugsnag.span.category` (with a value of `network`)
- `http.url`
- `http.method`
- `http.status_code`

## Testing

Updated unit tests to assert attributes - e2e tests will be added in a separate PR