### PR TITLE
Return undefined from request start callback to ignore a tracked request

### DIFF
--- a/packages/platforms/browser/lib/on-settle/request-settler.ts
+++ b/packages/platforms/browser/lib/on-settle/request-settler.ts
@@ -7,8 +7,6 @@ import {
   type RequestTracker
 } from '../request-tracker/request-tracker'
 
-const ignoreRequest: RequestEndCallback = () => {}
-
 class RequestSettler extends Settler {
   private timeout: ReturnType<typeof setTimeout> | undefined = undefined
   private urlsToIgnore: RegExp[] = []
@@ -30,11 +28,9 @@ class RequestSettler extends Settler {
     this.urlsToIgnore = urlsToIgnore
   }
 
-  private onRequestStart (startContext: RequestStartContext): RequestEndCallback {
+  private onRequestStart (startContext: RequestStartContext): RequestEndCallback | undefined {
     // if this is an excluded URL, ignore this request
-    if (this.shouldIgnoreUrl(startContext.url)) {
-      return ignoreRequest
-    }
+    if (this.shouldIgnoreUrl(startContext.url)) return
 
     clearTimeout(this.timeout)
     this.settled = false


### PR DESCRIPTION
## Goal

Updates the request settler's `onRequestStart` callback to return `undefined` for ignored requests (instead of a noop callback) to be consistent with the network spans plugin