### PR TITLE
[PLAT-10061] Handle open and send being called repeatedly in XHR tracker

### DIFF
--- a/packages/platforms/browser/lib/request-tracker/request-tracker-xhr.ts
+++ b/packages/platforms/browser/lib/request-tracker/request-tracker-xhr.ts
@@ -5,31 +5,57 @@ interface WindowWithXmlHttpRequest {
   XMLHttpRequest: typeof XMLHttpRequest
 }
 
+interface RequestData {
+  method: string
+  url: string
+}
+
+type ReadyStateChangeHandler = (this: XMLHttpRequest, ev: Event) => any
+
 function createXmlHttpRequestTracker (window: WindowWithXmlHttpRequest, clock: Clock): RequestTracker {
   const requestTracker = new RequestTracker()
+  const trackedRequests = new WeakMap<XMLHttpRequest, RequestData>()
+  const requestHandlers = new WeakMap<XMLHttpRequest, ReadyStateChangeHandler>()
+
   const originalOpen = window.XMLHttpRequest.prototype.open
   window.XMLHttpRequest.prototype.open = function open (method, url, ...rest: any[]): void {
-    // start tracking the request on send
-    const originalSend = this.send
-    let onRequestEnd: RequestEndCallback
-    this.send = function send (body?: Document | XMLHttpRequestBodyInit | null) {
-      onRequestEnd = requestTracker.start({ method, url: String(url), startTime: clock.now() })
-      originalSend.call(this, body)
-    }
-
-    this.addEventListener('readystatechange', () => {
-      if (this.readyState === window.XMLHttpRequest.DONE && onRequestEnd) {
-        // If the status is 0 the request did not complete so report this as an error
-        const endContext: RequestEndContext = this.status > 0
-          ? { endTime: clock.now(), status: this.status, state: 'success' }
-          : { endTime: clock.now(), state: 'error' }
-
-        onRequestEnd(endContext)
-      }
-    })
+    trackedRequests.set(this, { method, url: String(url) })
 
     // @ts-expect-error rest
     originalOpen.call(this, method, url, ...rest)
+  }
+
+  const originalSend = window.XMLHttpRequest.prototype.send
+  window.XMLHttpRequest.prototype.send = function send (body?: Document | XMLHttpRequestBodyInit | null) {
+    const requestData = trackedRequests.get(this)
+    if (requestData) {
+      // if there is an existing event listener this request instance is being reused,
+      // so we need to remove the listener from the previous send
+      const existingHandler = requestHandlers.get(this)
+      if (existingHandler) this.removeEventListener('readystatechange', existingHandler)
+
+      const onRequestEnd: RequestEndCallback = requestTracker.start({
+        method: requestData.method,
+        url: requestData.url,
+        startTime: clock.now()
+      })
+
+      const onReadyStateChange: ReadyStateChangeHandler = (evt) => {
+        if (this.readyState === window.XMLHttpRequest.DONE && onRequestEnd) {
+          // If the status is 0 the request did not complete so report this as an error
+          const endContext: RequestEndContext = this.status > 0
+            ? { endTime: clock.now(), status: this.status, state: 'success' }
+            : { endTime: clock.now(), state: 'error' }
+
+          onRequestEnd(endContext)
+        }
+      }
+
+      this.addEventListener('readystatechange', onReadyStateChange)
+      requestHandlers.set(this, onReadyStateChange)
+    }
+
+    originalSend.call(this, body)
   }
 
   return requestTracker


### PR DESCRIPTION
## Goal

Updates the XHR tracker to handle the same `XmlHttpRequest` being re-used. 

Prior to this change each call to `open` or `send` would effectively result in stacked monkey-patches, meaning start and end callbacks from previous requests would be invoked again and again.

## Design

The request tracker now keeps a map of tracked request instances and their respective method and url, which is re-set each time `open` is called.

`send` is now overridden just once, on the prototype, and retrieves the method and url to send from this map.
 
A second weakmap of requests and their respective `onReadyStateChange` handlers is used to remove any previous handlers each time `send` is called.

## Testing

Added unit tests for the following cases:
-  `open` -> `open` -> `send`
- `open` -> `send` -> `open` 