### PR TITLE
Discard page load span if the page is backgrounded

### DIFF
--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -39,7 +39,14 @@ const BugsnagPerformance = createClient({
   schema: createSchema(window.location.hostname),
   plugins: (spanFactory) => [
     onSettle,
-    new FullPageLoadPlugin(document, window.location, spanFactory, webVitals, onSettle),
+    new FullPageLoadPlugin(
+      document,
+      window.location,
+      spanFactory,
+      webVitals,
+      onSettle,
+      backgroundingListener
+    ),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker)
   ]
 })


### PR DESCRIPTION
## Goal

#162 discards open spans when the page is sent to the background. However, for page load spans specifically we want to avoid recording them at all if the page was backgrounded at any point in the page load

We can’t rely on the page load span being open for this as we don’t start the page load span until `BugsnagPerformance#start` is called, but the page could be backgrounded before that is called then returned to the foreground

This PR handles the case where the page is backgrounded at any point before `BugsnagPerformance#start` and stops the page load span from being recorded. If the page is backgrounded after this point, the logic in #162 will catch it and discard the span