### PR TITLE
Fix page load plugin constructor call in test

### DIFF
--- a/packages/platforms/browser/tests/page-load-span-plugin.test.ts
+++ b/packages/platforms/browser/tests/page-load-span-plugin.test.ts
@@ -410,7 +410,16 @@ describe('FullPageLoadPlugin', () => {
           clock,
           deliveryFactory: () => delivery,
           schema: createSchema(window.location.hostname),
-          plugins: (spanFactory) => [new FullPageLoadPlugin(document, window.location, spanFactory, webVitals, onSettle)]
+          plugins: (spanFactory) => [
+            new FullPageLoadPlugin(
+              document,
+              window.location,
+              spanFactory,
+              webVitals,
+              onSettle,
+              new ControllableBackgroundingListener()
+            )
+          ]
         })
 
         testClient.start({ apiKey: VALID_API_KEY })


### PR DESCRIPTION
## Goal

fixes a page load plugin test that was broken by a bad merge (#166)