### PR TITLE
Allow the current time when recording time to first byte

### DIFF
--- a/packages/platforms/browser/lib/web-vitals.ts
+++ b/packages/platforms/browser/lib/web-vitals.ts
@@ -113,7 +113,7 @@ export class WebVitals {
     // only use responseStart if it's valid (between 0 and the current time)
     // any other value cannot be valid because it would mean the response
     // started immediately or hasn't happened yet!
-    if (responseStart > 0 && responseStart < this.clock.now()) {
+    if (responseStart > 0 && responseStart <= this.clock.now()) {
       return responseStart
     }
   }


### PR DESCRIPTION
## Goal

Currently we discard time to first byte if its value is equal to the current time, but it's possible (though unlikely) that this is a valid value — most likely on browsers with very limited timestamp accuracy (e.g. Firefox with increased fingerprint protection)