### PR TITLE
Ignore `endpoint` when settling

### DIFF
--- a/packages/platforms/browser/lib/on-settle/index.ts
+++ b/packages/platforms/browser/lib/on-settle/index.ts
@@ -61,7 +61,7 @@ export default function createOnSettle (
   onSettle.configure = function (configuration: InternalConfiguration<BrowserConfiguration>): void {
     const settleIgnoreUrls = configuration.settleIgnoreUrls.map(
       (url: string | RegExp): RegExp => typeof url === 'string' ? RegExp(url) : url
-    )
+    ).concat(RegExp(configuration.endpoint))
 
     fetchRequestSettler.setUrlsToIgnore(settleIgnoreUrls)
     xhrRequestSettler.setUrlsToIgnore(settleIgnoreUrls)


### PR DESCRIPTION
## Goal

The configured endpoint is not currently ignored when settling

This PR adds the configured `endpoint` to the ignored URLs, in the same was as the network request plugin:

https://github.com/bugsnag/bugsnag-js-performance/blob/28554fe6e49609f06efece825216c408480a15f1/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts#L21-L23