### PR TITLE
Fix crash when running Maze Runner locally

### DIFF
--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -2,9 +2,6 @@ require 'yaml'
 
 class Browser
 
-  # Whether the Browser is running on a mobile device
-  attr_reader :is_device
-
   def initialize(browser_spec, maze_uri, fixtures_uri)
     @maze_uri = maze_uri
     @fixtures_uri = fixtures_uri
@@ -12,16 +9,19 @@ class Browser
     # e.g. "chrome_61", "edge_latest", "chrome"
     @name, version = browser_spec.split("_")
 
-    @is_device = @name.eql?('android') || @name.eql?('iphone')
-
     # assume we're running the latest version if there is no version present
     # this should only happen locally where the browser will auto-update
     @version =
-      if @is_device || version.nil? || version == "latest"
+      if mobile? || version.nil? || version == "latest"
         Float::INFINITY
       else
         Integer(version)
       end
+  end
+
+  # is this a mobile device?
+  def mobile?
+    @name == "android" || @name == "iphone"
   end
 
   def url_for(path)

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -114,10 +114,11 @@ module Maze
       def wait_for_element(id)
         @driver.find_element(id: id)
       end
+
       def click_element(id)
         element = @driver.find_element(id: id)
-        browser_os = Maze.config.capabilities['os']
-        if browser_os.eql?('ios') || browser_os.eql?('android')
+
+        if $browser.mobile?
           element.click
         else
           @driver.action.move_to(element).click.perform

--- a/test/browser/features/support/skip.rb
+++ b/test/browser/features/support/skip.rb
@@ -3,5 +3,5 @@ Before('@skip') do
 end
 
 Before ('@skip_on_device') do
-  skip_this_scenario("Skipping scenario: Not suitable for mobile devices") if $browser.is_device
+  skip_this_scenario("Skipping scenario: Not suitable for mobile devices") if $browser.mobile?
 end


### PR DESCRIPTION
## Goal

`Maze.config.capabilities` is `nil` when running the Maze Runner tests locally, which causes a crash due to some changes from #172