### PR TITLE
Assert Cumulative Layout Shift attribute exists in Maze Runner tests

### DIFF
--- a/test/browser/features/fixtures/packages/page-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/page-load-spans/index.html
@@ -8,8 +8,11 @@
     </head>
     <body>
         <h1>page-load-spans</h1>
-        <span id="clock">0</span>
+
         <button id="stop-clock">Stop</button>
+        <pre id="clock"></pre>
+
+        <p>I'm here to make the layout shift when the clock ticks :)</p>
 
         <script>
           // stop the page from settling until the 'stop-clock' button is
@@ -19,11 +22,13 @@
           let time = 0
 
           const interval = setInterval(() => {
-            node.innerText = time++
+            node.innerText += `${time++}\n`
           }, 50)
 
           document.getElementById("stop-clock").addEventListener("click", () => {
-            clearInterval(interval)
+            // delay stopping the clock for a bit so the performance observers
+            // have a chance to fire
+            setTimeout(() => { clearInterval(interval) }, 1000)
           })
         </script>
     </body>

--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -80,7 +80,7 @@ class Browser
   def chrome_supported_vitals
     case @version
     when (77..)
-      ["ttfb", "fcp", "fid_start", "fid_end", "lcp"] # also ["cls"]
+      ["ttfb", "fcp", "fid_start", "fid_end", "lcp", "cls"]
     when (76..)
       ["ttfb", "fcp", "fid_start", "fid_end"]
     when (64..)
@@ -93,7 +93,7 @@ class Browser
   def edge_supported_vitals
     case @version
     when (79..)
-      ["ttfb", "fcp", "fid_start", "fid_end", "lcp"] # also ["cls"]
+      ["ttfb", "fcp", "fid_start", "fid_end", "lcp", "cls"]
     else 
       ["ttfb"]
     end
@@ -102,9 +102,9 @@ class Browser
   def firefox_supported_vitals
     case @version
     when (89..)
-      ["ttfb", "fcp", "fid_start", "fid_end"] # also ["lcp", "cls"]
+      ["ttfb", "fcp", "fid_start", "fid_end"] # also ["lcp"]
     when (84..)
-      ["ttfb", "fcp"] # also ["cls"]
+      ["ttfb", "fcp", "cls"]
     else
       ["ttfb"]
     end
@@ -113,7 +113,7 @@ class Browser
   def safari_supported_vitals
     case @version
     when (14..) # technically 14.1, but our test fixtures never use 14.0
-      ["ttfb", "fcp"] # also ["cls"]
+      ["ttfb", "fcp"]
     else
       ["ttfb"]
     end


### PR DESCRIPTION
## Goal

Add checking for cumulative layout shift in Maze Runner tests

The page load test fixture now causes layout shifts so a value is always recorded on supported browsers