### PR TITLE
[PLAT-10224] Add `SpanContext` interface

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -10,7 +10,6 @@ import { BufferingProcessor, type Processor } from './processor'
 import { InMemoryQueue } from './retry-queue'
 import Sampler from './sampler'
 import { SpanFactory, type Span, type SpanOptions } from './span'
-import { type Time } from './time'
 
 export interface BugsnagPerformance<C extends Configuration> {
   start: (config: C | string) => void

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -77,6 +77,13 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
       const span = spanFactory.startSpan(name, safeStartTime)
 
       return {
+        get id () {
+          return span.id
+        },
+        get traceId () {
+          return span.traceId
+        },
+        isValid: span.isValid,
         end: (endTime) => {
           const safeEndTime = timeToNumber(options.clock, endTime)
           spanFactory.endSpan(span, safeEndTime)
@@ -91,6 +98,6 @@ export function createNoopClient<C extends Configuration> (): BugsnagPerformance
 
   return {
     start: noop,
-    startSpan: () => ({ end: noop })
+    startSpan: () => ({ id: '', traceId: '', end: noop, isValid: () => false })
   }
 }

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -81,7 +81,7 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
     },
     startSpan: (name, spanOptions?: SpanOptions) => {
       const span = spanFactory.startSpan(name, spanOptions)
-      return spanFactory.spanFromSpanInternal(span)
+      return spanFactory.toPublicApi(span)
     }
   }
 }

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -64,11 +64,11 @@ export function spanToJson (span: SpanEnded, clock: Clock): DeliverySpan {
   }
 }
 
-export function spanContextEquals (s1?: SpanContext, s2?: SpanContext) {
-  if (s1 === s2) return true
+export function spanContextEquals (span1?: SpanContext, span2?: SpanContext) {
+  if (span1 === span2) return true
 
-  if (s1 !== undefined && s2 !== undefined) {
-    return s1.id === s2.id && s1.traceId === s2.traceId
+  if (span1 !== undefined && span2 !== undefined) {
+    return span1.id === span2.id && span1.traceId === span2.traceId
   }
 
   return false

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -9,7 +9,13 @@ import type Sampler from './sampler'
 import { type Time } from './time'
 import traceIdToSamplingRate from './trace-id-to-sampling-rate'
 
-export interface Span {
+export interface SpanContext {
+  readonly id: string // 64 bit random string
+  readonly traceId: string // 128 bit random string
+
+  // returns true if this is still considered a valid context
+  readonly isValid: () => boolean
+}
   end: (endTime?: Time) => void
 }
 

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -136,7 +136,6 @@ export class SpanFactory {
 
   private openSpans: WeakSet<SpanInternal> = new WeakSet<SpanInternal>()
   private isInForeground: boolean = true
-  private clock: Clock
 
   constructor (
     processor: Processor,

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -118,7 +118,7 @@ export class SpanInternal implements SpanContext {
     }
   }
 
-  isValid = () => {
+  isValid () {
     return this.endTime === undefined
   }
 }
@@ -203,7 +203,7 @@ export class SpanFactory {
       get traceId () {
         return span.traceId
       },
-      isValid: span.isValid,
+      isValid: () => span.isValid(),
       end: (endTime) => {
         const safeEndTime = timeToNumber(this.clock, endTime)
         this.endSpan(span, safeEndTime)

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -64,6 +64,16 @@ export function spanToJson (span: SpanEnded, clock: Clock): DeliverySpan {
   }
 }
 
+export function spanContextEquals (s1?: SpanContext, s2?: SpanContext) {
+  if (s1 === s2) return true
+
+  if (s1 !== undefined && s2 !== undefined) {
+    return s1.id === s2.id && s1.traceId === s2.traceId
+  }
+
+  return false
+}
+
 export class SpanInternal implements SpanContext {
   readonly id: string
   readonly traceId: string

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -195,7 +195,7 @@ export class SpanFactory {
     }
   }
 
-  spanFromSpanInternal (span: SpanInternal): Span {
+  toPublicApi (span: SpanInternal): Span {
     return {
       get id () {
         return span.id

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -378,42 +378,42 @@ describe('SpanContext', () => {
   describe('spanContextEquals()', () => {
     it.each([
       {
-        s1: undefined,
-        s2: undefined,
+        span1: undefined,
+        span2: undefined,
         expected: true
       },
       {
-        s1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
-        s2: undefined,
+        span1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span2: undefined,
         expected: false
       },
       {
-        s1: undefined,
-        s2: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span1: undefined,
+        span2: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
         expected: false
       },
       {
-        s1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
-        s2: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span2: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
         expected: true
       },
       {
-        s1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
-        s2: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => false },
+        span1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span2: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => false },
         expected: true
       },
       {
-        s1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
-        s2: { id: '0123456789abcdef', traceId: 'a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3', isValid: () => true },
+        span1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span2: { id: '0123456789abcdef', traceId: 'a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3', isValid: () => true },
         expected: false
       },
       {
-        s1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
-        s2: { id: '9876543210fedcba', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span1: { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
+        span2: { id: '9876543210fedcba', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true },
         expected: false
       }
-    ])('returns $expected given inputs $s1 and $s2', ({ s1, s2, expected }) => {
-      expect(spanContextEquals(s1, s2)).toEqual(expected)
+    ])('returns $expected given inputs $span1 and $span2', ({ span1, span2, expected }) => {
+      expect(spanContextEquals(span1, span2)).toEqual(expected)
     })
   })
 })

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -84,7 +84,12 @@ describe('Span', () => {
     it('returns a Span', () => {
       const client = createTestClient()
       const span = client.startSpan('test span')
-      expect(span).toStrictEqual({ end: expect.any(Function) })
+      expect(span).toStrictEqual({
+        id: expect.any(String),
+        traceId: expect.any(String),
+        end: expect.any(Function),
+        isValid: expect.any(Function)
+      })
     })
 
     it.each([
@@ -337,6 +342,21 @@ describe('Span', () => {
       expect(delivery).toHaveSentSpan(expect.objectContaining({
         name: 'entirely-in-foreground'
       }))
+    })
+  })
+
+  describe('Span.isValid()', () => {
+    it('returns false if the span has been ended', () => {
+      const delivery = new InMemoryDelivery()
+      const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+      const client = createTestClient({ deliveryFactory: () => delivery, clock })
+      client.start({ apiKey: VALID_API_KEY })
+
+      const span = client.startSpan('test span')
+      expect(span.isValid()).toEqual(true)
+
+      span.end()
+      expect(span.isValid()).toEqual(false)
     })
   })
 })

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -31,7 +31,8 @@ describe('SpanInternal', () => {
         sampler,
         new StableIdGenerator(),
         spanAttributesSource,
-        new ControllableBackgroundingListener()
+        new ControllableBackgroundingListener(),
+        clock
       )
 
       const spanInternal = spanFactory.startSpan('span-name', 1234)
@@ -61,7 +62,8 @@ describe('SpanInternal', () => {
         sampler,
         new StableIdGenerator(),
         spanAttributesSource,
-        new ControllableBackgroundingListener()
+        new ControllableBackgroundingListener(),
+        clock
       )
 
       const spanInternal = spanFactory.startSpan('span-name', 1234)

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -1,14 +1,12 @@
-import { timeToNumber, type Clock, type InternalConfiguration, type Plugin, type SpanFactory, type Time } from '@bugsnag/core-performance'
+import { type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
 import { type BrowserConfiguration } from '../config'
 
 export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
   private readonly spanFactory: SpanFactory
-  private readonly clock: Clock
   private readonly location: Location
 
-  constructor (spanFactory: SpanFactory, clock: Clock, location: Location) {
+  constructor (spanFactory: SpanFactory, location: Location) {
     this.spanFactory = spanFactory
-    this.clock = clock
     this.location = location
   }
 
@@ -18,8 +16,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
     let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
 
     configuration.routingProvider.listenForRouteChanges((route, trigger, options = {}) => {
-      const startTime = timeToNumber(this.clock, options.startTime)
-      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, startTime)
+      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, options.startTime)
       span.setAttribute('bugsnag.span.category', 'route_change')
       span.setAttribute('bugsnag.browser.page.route', route)
       span.setAttribute('bugsnag.browser.page.previous_route', previousRoute)
@@ -27,12 +24,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
 
       previousRoute = route
 
-      return {
-        end: (endTime?: Time) => {
-          const realEndTime = timeToNumber(this.clock, endTime)
-          this.spanFactory.endSpan(span, realEndTime)
-        }
-      }
+      return this.spanFactory.spanFromSpanInternal(span)
     })
   }
 }

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -25,7 +25,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
 
       previousRoute = route
 
-      return this.spanFactory.spanFromSpanInternal(span)
+      return this.spanFactory.toPublicApi(span)
     })
   }
 }

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -48,7 +48,7 @@ const BugsnagPerformance = createClient({
       backgroundingListener
     ),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
-    new RouteChangePlugin(spanFactory, clock, window.location)
+    new RouteChangePlugin(spanFactory, window.location)
   ]
 })
 

--- a/packages/platforms/browser/tests/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/route-change-plugin.test.ts
@@ -31,7 +31,7 @@ describe('RouteChangePlugin', () => {
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
-      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, clock, window.location)]
+      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
     })
 
     testClient.start({ apiKey: VALID_API_KEY })
@@ -63,7 +63,7 @@ describe('RouteChangePlugin', () => {
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
-      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, clock, window.location)]
+      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
     })
 
     history.pushState({}, '', '/first-route')
@@ -120,7 +120,7 @@ describe('RouteChangePlugin', () => {
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
-      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, clock, window.location)]
+      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
     })
 
     testClient.start({ apiKey: VALID_API_KEY })
@@ -142,7 +142,7 @@ describe('RouteChangePlugin', () => {
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
-      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, clock, window.location)]
+      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
     })
 
     testClient.start({ apiKey: VALID_API_KEY, autoInstrumentRouteChanges: false })

--- a/packages/platforms/browser/tests/routing-provider.test.ts
+++ b/packages/platforms/browser/tests/routing-provider.test.ts
@@ -23,7 +23,7 @@ describe('DefaultRoutingProvider', () => {
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, routingProvier),
-      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, clock, window.location)]
+      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
     })
 
     testClient.start({ apiKey: VALID_API_KEY })
@@ -45,7 +45,7 @@ describe('DefaultRoutingProvider', () => {
         clock,
         deliveryFactory: () => delivery,
         schema: createSchema(window.location.hostname, routingProvier),
-        plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, clock, window.location)]
+        plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
       })
 
       testClient.start({ apiKey: VALID_API_KEY })

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -3,6 +3,7 @@ import StableIdGenerator from './stable-id-generator'
 import spanAttributesSource from './span-attributes-source'
 import InMemoryProcessor from './in-memory-processor'
 import ControllableBackgroundingListener from './controllable-backgrounding-listener'
+import IncrementingClock from './incrementing-clock'
 
 class MockSpanFactory extends SpanFactory {
   public createdSpans: SpanEnded[]
@@ -10,7 +11,8 @@ class MockSpanFactory extends SpanFactory {
   constructor () {
     const sampler: any = { probability: 0.1, sample: () => true }
     const processor = new InMemoryProcessor()
-    super(processor, sampler, new StableIdGenerator(), spanAttributesSource, new ControllableBackgroundingListener())
+    const clock = new IncrementingClock()
+    super(processor, sampler, new StableIdGenerator(), spanAttributesSource, new ControllableBackgroundingListener(), clock)
     this.createdSpans = processor.spans
   }
 

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -4,7 +4,6 @@ import spanAttributesSource from './span-attributes-source'
 import IncrementingClock from './incrementing-clock'
 import InMemoryProcessor from './in-memory-processor'
 import ControllableBackgroundingListener from './controllable-backgrounding-listener'
-import IncrementingClock from './incrementing-clock'
 
 class MockSpanFactory extends SpanFactory {
   public createdSpans: SpanEnded[]


### PR DESCRIPTION
## Goal

Introduces a `SpanContext` interface that exposes a span's `id` and `traceId` as readonly properties, as well as an `isValid()` method which returns a boolean indicating whether the span is still valid (open)

## Design

Both `Span` and `SpanInternal` now implement the `SpanContext` interface.

A convenience function `spanContextEquals` has also been added to compare two `SpanContext` instances - this isn't used yet but will be used in future to ensure the correct context is popped from the context stack

The creation of the public `Span` instances (as well as the start/end time sanitization) has been moved into the span factory, since we already do this in a couple of places
