### PR TITLE
add `SpanOptions` and replace `startTime` when starting spans

### DIFF
--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -263,7 +263,7 @@ describe('Core', () => {
           releaseStage: 'staging'
         })
 
-        const span = client.startSpan('name', new Date())
+        const span = client.startSpan('name', { startTime: new Date() })
         span.end()
       }).not.toThrow()
     })

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -31,10 +31,11 @@ describe('SpanInternal', () => {
         sampler,
         new StableIdGenerator(),
         spanAttributesSource,
+        new IncrementingClock(),
         new ControllableBackgroundingListener()
       )
 
-      const spanInternal = spanFactory.startSpan('span-name', 1234)
+      const spanInternal = spanFactory.startSpan('span-name', { startTime: 1234 })
       spanInternal.setAttribute('bugsnag.test.attribute', parameter)
 
       spanFactory.endSpan(spanInternal, 5678)
@@ -61,10 +62,11 @@ describe('SpanInternal', () => {
         sampler,
         new StableIdGenerator(),
         spanAttributesSource,
+        new IncrementingClock(),
         new ControllableBackgroundingListener()
       )
 
-      const spanInternal = spanFactory.startSpan('span-name', 1234)
+      const spanInternal = spanFactory.startSpan('span-name', { startTime: 1234 })
       spanInternal.addEvent('bugsnag.test.event', 1234)
 
       spanFactory.endSpan(spanInternal, 5678)
@@ -87,21 +89,33 @@ describe('Span', () => {
       expect(span).toStrictEqual({ end: expect.any(Function) })
     })
 
-    it.each([
+    const invalidStartTimes: any[] = [
       { type: 'string', startTime: 'i am not a startTime' },
       { type: 'bigint', startTime: BigInt(9007199254740991) },
-      { type: 'boolean', startTime: true },
+      { type: 'true', startTime: true },
+      { type: 'false', startTime: false },
       { type: 'function', startTime: () => {} },
       { type: 'object', startTime: { property: 'test' } },
-      { type: 'object', startTime: [] },
-      { type: 'symbol', startTime: Symbol('test') }
-    ])('uses default clock implementation if startTime is invalid ($type)', ({ startTime }) => {
+      { type: 'empty array', startTime: [] },
+      { type: 'array', startTime: [1, 2, 3] },
+      { type: 'symbol', startTime: Symbol('test') },
+      { type: 'null', startTime: null },
+      { type: 'undefined', startTime: undefined }
+    ]
+
+    invalidStartTimes.push(...invalidStartTimes.map(
+      ({ type, startTime }) => ({
+        type: `{ startTime: ${type} }`,
+        startTime: { startTime }
+      }))
+    )
+
+    it.each(invalidStartTimes)('uses default clock implementation if startTime is invalid ($type)', ({ startTime }) => {
       const delivery = new InMemoryDelivery()
       const clock = new IncrementingClock('1970-01-01T00:00:00Z')
       const client = createTestClient({ deliveryFactory: () => delivery, clock })
       client.start({ apiKey: VALID_API_KEY })
 
-      // @ts-expect-error startTime will be invalid
       const span = client.startSpan('test span', startTime)
       span.end()
 

--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -55,7 +55,7 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
       const route = configuration.routingProvider.resolveRoute(url)
 
       const startTime = 0
-      const span = this.spanFactory.startSpan(`[FullPageLoad]${route}`, startTime)
+      const span = this.spanFactory.startSpan(`[FullPageLoad]${route}`, { startTime })
 
       // Browser attributes
       span.setAttribute('bugsnag.span.category', 'full_page_load')

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -32,7 +32,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
 
     const span = this.spanFactory.startSpan(
       `[HTTP]/${startContext.method.toUpperCase()}`,
-      startContext.startTime
+      { startTime: startContext.startTime }
     )
 
     span.setAttribute('bugsnag.span.category', 'network')

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -17,9 +17,9 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
 
     let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
 
-    configuration.routingProvider.listenForRouteChanges((route, trigger, options = {}) => {
-      const startTime = timeToNumber(this.clock, options.startTime)
-      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, startTime)
+    configuration.routingProvider.listenForRouteChanges((route, trigger, options) => {
+      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, options)
+
       span.setAttribute('bugsnag.span.category', 'route_change')
       span.setAttribute('bugsnag.browser.page.route', route)
       span.setAttribute('bugsnag.browser.page.previous_route', previousRoute)

--- a/packages/platforms/browser/lib/index.ts
+++ b/packages/platforms/browser/lib/index.ts
@@ -1,3 +1,4 @@
 export { DefaultRoutingProvider, default, onSettle } from './browser'
 export { type BrowserConfiguration } from './config'
 export { type RouteResolver, type RoutingProvider } from './routing-provider'
+export { type SpanOptions, type Time } from '@bugsnag/core-performance'

--- a/packages/platforms/browser/lib/routing-provider.ts
+++ b/packages/platforms/browser/lib/routing-provider.ts
@@ -1,10 +1,6 @@
-import { isObject, type Span, type Time } from '@bugsnag/core-performance'
+import { isObject, type Span, type SpanOptions } from '@bugsnag/core-performance'
 
-interface StartRouteChangeOptions {
-  startTime?: Time
-}
-
-export type StartRouteChangeCallback = (route: string, trigger: string, options?: StartRouteChangeOptions) => Span
+export type StartRouteChangeCallback = (route: string, trigger: string, options?: SpanOptions) => Span
 
 export interface RoutingProvider {
   resolveRoute: (url: URL) => string

--- a/packages/platforms/browser/tests/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/network-request-plugin.test.ts
@@ -46,10 +46,10 @@ describe('network span plugin', () => {
     }))
 
     fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', 1)
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1 })
 
     xhrTracker.start({ method: 'POST', url: TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', 2)
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2 })
   })
 
   it('ends a span on request end', () => {
@@ -61,7 +61,7 @@ describe('network span plugin', () => {
     }))
 
     const endRequest = fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', 1)
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1 })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
@@ -141,7 +141,7 @@ describe('network span plugin', () => {
 
     // does not match the URLs to exclude
     fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', 1)
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1 })
   })
 
   it('discards the span if the status is 0', () => {
@@ -153,7 +153,7 @@ describe('network span plugin', () => {
     }))
 
     const endRequest = xhrTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', 1)
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1 })
 
     endRequest({ endTime: 2, state: 'error' })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -168,7 +168,7 @@ describe('network span plugin', () => {
     }))
 
     const endRequest = fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', 1)
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1 })
 
     endRequest({ state: 'error', error: new Error('woopsy'), endTime: 2 })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -1,6 +1,7 @@
-import { type SpanInternal, type SpanEnded, SpanFactory } from '@bugsnag/core-performance'
+import { type SpanInternal, type SpanEnded, type SpanOptions, SpanFactory } from '@bugsnag/core-performance'
 import StableIdGenerator from './stable-id-generator'
 import spanAttributesSource from './span-attributes-source'
+import IncrementingClock from './incrementing-clock'
 import InMemoryProcessor from './in-memory-processor'
 import ControllableBackgroundingListener from './controllable-backgrounding-listener'
 
@@ -10,12 +11,21 @@ class MockSpanFactory extends SpanFactory {
   constructor () {
     const sampler: any = { probability: 0.1, sample: () => true }
     const processor = new InMemoryProcessor()
-    super(processor, sampler, new StableIdGenerator(), spanAttributesSource, new ControllableBackgroundingListener())
+
+    super(
+      processor,
+      sampler,
+      new StableIdGenerator(),
+      spanAttributesSource,
+      new IncrementingClock(),
+      new ControllableBackgroundingListener()
+    )
+
     this.createdSpans = processor.spans
   }
 
-  startSpan = jest.fn((name: string, startTime: number) => {
-    return super.startSpan(name, startTime)
+  startSpan = jest.fn((name: string, options?: SpanOptions) => {
+    return super.startSpan(name, options)
   })
 
   endSpan = jest.fn((span: SpanInternal, endTime: number) => {


### PR DESCRIPTION
## Goal

Change the API of `startSpan` to take a `SpanOptions` object instead of `startTime`:

```diff
-startSpan(name: string, startTime?: Time)
+startSpan(name: string, options?: { startTime?: Time })
```

This allows us to add additional options without having to make breaking changes (or add more parameters)

The `SpanOptions` and `Time` types are also now exported from the browser library for the convenience of TypeScripters