### PR TITLE
[PLAT-10258] Add warning when calling Span.end multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## TBD
+
+### Added
+
+- (core) Log a warning when trying to end a Span multiple times [#200](https://github.com/bugsnag/bugsnag-js-performance/pull/200)

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -39,9 +39,9 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
     options.idGenerator,
     options.spanAttributesSource,
     options.clock,
-    options.backgroundingListener
+    options.backgroundingListener,
+    options.schema.logger.defaultValue
   )
-
   const plugins = options.plugins(spanFactory)
 
   return {
@@ -74,7 +74,7 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
         (processor as BatchProcessor<C>).flush()
       })
 
-      spanFactory.updateProcessor(processor)
+      spanFactory.configure(processor, configuration.logger)
 
       for (const plugin of plugins) {
         plugin.configure(configuration)

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -1,6 +1,7 @@
 import { SpanAttributes, type SpanAttribute, type SpanAttributesSource } from './attributes'
 import { type BackgroundingListenerState, type BackgroundingListener } from './backgrounding-listener'
 import { type Clock } from './clock'
+import { type Logger } from './config'
 import { type DeliverySpan } from './delivery'
 import { SpanEvents } from './events'
 import { type IdGenerator } from './id-generator'
@@ -106,6 +107,7 @@ export interface SpanOptions {
 export class SpanFactory {
   private readonly idGenerator: IdGenerator
   private readonly spanAttributesSource: SpanAttributesSource
+  private logger: Logger
   private processor: Processor
   private readonly sampler: Sampler
   private readonly clock: Clock
@@ -119,11 +121,13 @@ export class SpanFactory {
     idGenerator: IdGenerator,
     spanAttributesSource: SpanAttributesSource,
     clock: Clock,
-    backgroundingListener: BackgroundingListener
+    backgroundingListener: BackgroundingListener,
+    logger: Logger
   ) {
     this.processor = processor
     this.sampler = sampler
     this.idGenerator = idGenerator
+    this.logger = logger
     this.spanAttributesSource = spanAttributesSource
     this.clock = clock
 
@@ -153,8 +157,9 @@ export class SpanFactory {
     return span
   }
 
-  updateProcessor (processor: Processor) {
+  configure (processor: Processor, logger: Logger) {
     this.processor = processor
+    this.logger = logger
   }
 
   endSpan (
@@ -162,7 +167,10 @@ export class SpanFactory {
     endTime: number
   ) {
     // if the span doesn't exist here it shouldn't be processed
-    if (!this.openSpans.delete(span)) return
+    if (!this.openSpans.delete(span)) {
+      this.logger.warn('Attempted to end a Span which has already ended or been discarded.')
+      return
+    }
 
     const spanEnded = span.end(endTime, this.sampler.spanProbability)
 

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -5,6 +5,13 @@ import IncrementingClock from './incrementing-clock'
 import InMemoryProcessor from './in-memory-processor'
 import ControllableBackgroundingListener from './controllable-backgrounding-listener'
 
+const jestLogger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn()
+}
+
 class MockSpanFactory extends SpanFactory {
   public createdSpans: SpanEnded[]
 
@@ -18,7 +25,8 @@ class MockSpanFactory extends SpanFactory {
       new StableIdGenerator(),
       spanAttributesSource,
       new IncrementingClock(),
-      new ControllableBackgroundingListener()
+      new ControllableBackgroundingListener(),
+      jestLogger
     )
 
     this.createdSpans = processor.spans


### PR DESCRIPTION
## Goal

To notify users why a no-op has occurred when ending an already ended span

## Changeset

Construct a span factory with the platform schema default logger, swapping it out with a provided logger when a user calls `.start`

## Testing

Add unit test that checks a logger is called when a cancelled (backgrounded) span is ended
Add unit test that checks a logger is called when a span is ended multiple times