### PR TITLE
Add public access to publish config

### DIFF
--- a/packages/platforms/js/package.json
+++ b/packages/platforms/js/package.json
@@ -10,6 +10,9 @@
     "reporting",
     "client-side"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "BugSnag",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",


### PR DESCRIPTION
Required to publish js meta package