### PR TITLE
Add 'persistence' as a client option

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -5,6 +5,7 @@ import { type Clock } from './clock'
 import { validateConfig, type Configuration, type CoreSchema } from './config'
 import { type DeliveryFactory } from './delivery'
 import { type IdGenerator } from './id-generator'
+import { type Persistence } from './persistence'
 import { type Plugin } from './plugin'
 import { BufferingProcessor, type Processor } from './processor'
 import { InMemoryQueue } from './retry-queue'
@@ -25,6 +26,7 @@ export interface ClientOptions<S extends CoreSchema, C extends Configuration> {
   spanAttributesSource: SpanAttributesSource
   schema: S
   plugins: (spanFactory: SpanFactory) => Array<Plugin<C>>
+  persistence: Persistence
 }
 
 export function createClient<S extends CoreSchema, C extends Configuration> (options: ClientOptions<S, C>): BugsnagPerformance<C> {

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -6,6 +6,7 @@ import { createSchema } from './config'
 import { createDefaultRoutingProvider } from './default-routing-provider'
 import createBrowserDeliveryFactory from './delivery'
 import idGenerator from './id-generator'
+import makeBrowserPersistence from './persistence'
 import createOnSettle from './on-settle'
 import createFetchRequestTracker from './request-tracker/request-tracker-fetch'
 import createXmlHttpRequestTracker from './request-tracker/request-tracker-xhr'
@@ -49,7 +50,8 @@ const BugsnagPerformance = createClient({
     ),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
     new RouteChangePlugin(spanFactory, window.location)
-  ]
+  ],
+  persistence: makeBrowserPersistence(window)
 })
 
 export default BugsnagPerformance

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -10,6 +10,7 @@ import {
 import {
   createClient,
   schema,
+  InMemoryPersistence,
   type BugsnagPerformance,
   type ClientOptions,
   type Configuration,
@@ -24,7 +25,8 @@ const defaultOptions = () => ({
   resourceAttributesSource,
   spanAttributesSource,
   schema,
-  plugins: () => []
+  plugins: () => [],
+  persistence: new InMemoryPersistence()
 })
 
 function createTestClient <S extends CoreSchema, C extends Configuration> (optionOverrides: Partial<ClientOptions<S, C>> = {}): BugsnagPerformance<C> {


### PR DESCRIPTION
## Goal

First in a stack of PRs to start persisting sampling probabilities

This PR adds `persistence` to `ClientOptions`