### PR TITLE
Add ProbabilityFetcher abstraction for getting probabilities from the pipeline

### DIFF
--- a/packages/core/lib/probability-fetcher.ts
+++ b/packages/core/lib/probability-fetcher.ts
@@ -1,0 +1,39 @@
+import { type Delivery } from './delivery'
+
+// the time to wait before retrying a failed request
+const RETRY_MILLISECONDS = 30 * 1000
+
+// the request body sent when fetching a new probability value; this is the
+// minimal body the server expects to receive
+const PROBABILITY_REQUEST = { resourceSpans: [] }
+
+class ProbabilityFetcher {
+  private readonly delivery: Delivery
+
+  constructor (delivery: Delivery) {
+    this.delivery = delivery
+  }
+
+  async getNewProbability (): Promise<number> {
+    // keep making requests until we get a new probability value from the server
+    while (true) {
+      const response = await this.delivery.send(PROBABILITY_REQUEST)
+
+      // in theory this should always be present, but it's possible the request
+      // fails or there's a bug on the server side causing it not to be returned
+      if (response.samplingProbability !== undefined) {
+        return response.samplingProbability
+      }
+
+      await this.timeBetweenRetries()
+    }
+  }
+
+  private timeBetweenRetries (): Promise<void> {
+    return new Promise(resolve => {
+      setTimeout(resolve, RETRY_MILLISECONDS)
+    })
+  }
+}
+
+export default ProbabilityFetcher

--- a/packages/core/tests/probability-fetcher.test.ts
+++ b/packages/core/tests/probability-fetcher.test.ts
@@ -1,0 +1,54 @@
+import ProbabilityFetcher from '../lib/probability-fetcher'
+import { InMemoryDelivery } from '@bugsnag/js-performance-test-utilities'
+
+jest.useFakeTimers()
+
+describe('ProbabilityFetcher', () => {
+  it('returns probability when delivery returns a value immediately', async () => {
+    const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(0.25)
+
+    const fetcher = new ProbabilityFetcher(delivery)
+    const probability = await fetcher.getNewProbability()
+
+    expect(probability).toBe(0.25)
+  })
+
+  it('returns probability when delivery returns 0.0', async () => {
+    const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(0.0)
+
+    const fetcher = new ProbabilityFetcher(delivery)
+    const probability = await fetcher.getNewProbability()
+
+    expect(probability).toBe(0.0)
+  })
+
+  it('retries if delivery fails until a new probability is retrieved', async () => {
+    const delivery = new InMemoryDelivery()
+    const fetcher = new ProbabilityFetcher(delivery)
+
+    const fetcherPromise = fetcher.getNewProbability()
+
+    // 1 request is made immediately, but no sampling probability is returned
+    expect(delivery.samplingRequests).toHaveLength(1)
+
+    // after 30 seconds another request should be made
+    await jest.advanceTimersByTimeAsync(30_000)
+    expect(delivery.samplingRequests).toHaveLength(2)
+
+    // etc..
+    await jest.advanceTimersByTimeAsync(30_000)
+    expect(delivery.samplingRequests).toHaveLength(3)
+
+    // etc..
+    await jest.advanceTimersByTimeAsync(30_000)
+    expect(delivery.samplingRequests).toHaveLength(4)
+
+    // when a probability is returned, the promise should resolve to its value
+    delivery.setNextSamplingProbability(0.75)
+    await jest.advanceTimersByTimeAsync(30_000)
+
+    expect(await fetcherPromise).toBe(0.75)
+  })
+})


### PR DESCRIPTION
## Goal

Usage:

```ts
const probabilityFetcher = new ProbabilityFetcher(delivery)
const probability: number = await probabilityFetcher.getNewProbability()

// do stuff with 'probability'
```

This will normally make 1 request but if the request fails or the server doesn't return a sampling probability it will retry until a probability is available

This abstraction will help to remove some of the complexity from the `Sampler` class as it got very tricky to deal with when adding persistence on top of the period requests