### PR TITLE
Add abstraction for managing probabilities

### DIFF
--- a/packages/core/lib/probability-manager.ts
+++ b/packages/core/lib/probability-manager.ts
@@ -1,0 +1,113 @@
+import { type Persistence } from './persistence'
+import type ProbabilityFetcher from './probability-fetcher'
+import type Sampler from './sampler'
+
+// the time between requests to fetch a new probability value from the server
+const PROBABILITY_REFRESH_MILLISECONDS = 24 * 60 * 60 * 1000 // 24 hours
+
+class ProbabilityManager {
+  static async create (
+    persistence: Persistence,
+    sampler: Sampler,
+    configuredProbability: number,
+    probabilityFetcher: ProbabilityFetcher
+  ) {
+    const persistedProbability = await persistence.load('bugsnag-sampling-probability')
+
+    let initialProbabilityTime: number
+    let initialTimoutDuration: number
+
+    if (persistedProbability === undefined) {
+      // If there is no stored probability:
+      // - Set the initial probability value to the value from
+      //   configuration (defaults to 1.0)
+      sampler.probability = configuredProbability
+      initialProbabilityTime = 0
+
+      // - Immediately fetch a new probability value
+      initialTimoutDuration = 0
+    } else if (persistedProbability.time < Date.now() - PROBABILITY_REFRESH_MILLISECONDS) {
+      // If it is >= 24 hours old:
+      // - Set the initial probability value to the stored value
+      sampler.probability = persistedProbability.value
+      initialProbabilityTime = persistedProbability.time
+
+      // - Immediately fetch a new probability value
+      initialTimoutDuration = 0
+    } else {
+      // If it is < 24 hours old:
+      // - Use the stored probability
+      sampler.probability = persistedProbability.value
+      initialProbabilityTime = persistedProbability.time
+
+      // - Fetch a new probability when this value would be 24 hours old
+      initialTimoutDuration = PROBABILITY_REFRESH_MILLISECONDS - (Date.now() - initialProbabilityTime)
+    }
+
+    return new ProbabilityManager(
+      persistence,
+      sampler,
+      probabilityFetcher,
+      initialTimoutDuration,
+      initialProbabilityTime
+    )
+  }
+
+  private readonly persistence: Persistence
+  private readonly sampler: Sampler
+  private readonly probabilityFetcher: ProbabilityFetcher
+
+  private lastProbabilityTime: number
+  private timeout: ReturnType<typeof setTimeout> | undefined = undefined
+
+  private constructor (
+    persistence: Persistence,
+    sampler: Sampler,
+    probabilityFetcher: ProbabilityFetcher,
+    initialTimoutDuration: number,
+    initialProbabilityTime: number
+  ) {
+    this.persistence = persistence
+    this.sampler = sampler
+    this.probabilityFetcher = probabilityFetcher
+    this.lastProbabilityTime = initialProbabilityTime
+
+    this.fetchNewProbabilityIn(initialTimoutDuration)
+  }
+
+  setProbability (newProbability: number): Promise<void> {
+    this.lastProbabilityTime = Date.now()
+    this.sampler.probability = newProbability
+
+    this.fetchNewProbabilityIn(PROBABILITY_REFRESH_MILLISECONDS)
+
+    // return this promise for convience in unit tests as it allows us to wait
+    // for persistence to finish; in real code we won't ever wait for this but
+    // there's no harm in returning it anyway
+    return this.persistence.save('bugsnag-sampling-probability', {
+      value: newProbability,
+      time: this.lastProbabilityTime
+    })
+  }
+
+  private fetchNewProbabilityIn (milliseconds: number): void {
+    clearTimeout(this.timeout)
+
+    const lastProbabilityTimeBeforeTimeout = this.lastProbabilityTime
+
+    this.timeout = setTimeout(
+      async () => {
+        const probability = await this.probabilityFetcher.getNewProbability()
+
+        // only apply the new probability if we haven't received another value
+        // in the meantime, e.g. from a trace request's response
+        if (lastProbabilityTimeBeforeTimeout === this.lastProbabilityTime) {
+          this.setProbability(probability)
+        }
+      },
+      milliseconds
+    )
+  }
+}
+
+export default ProbabilityManager

--- a/packages/core/tests/probability-manager.test.ts
+++ b/packages/core/tests/probability-manager.test.ts
@@ -1,0 +1,218 @@
+import ProbabilityManager from '../lib/probability-manager'
+import ProbabilityFetcher from '../lib/probability-fetcher'
+import Sampler from '../lib/sampler'
+import { InMemoryPersistence } from '../lib/persistence'
+import { InMemoryDelivery } from '@bugsnag/js-performance-test-utilities'
+
+jest.useFakeTimers()
+
+describe('ProbabilityManager', () => {
+  it('uses the configured probability and fetches a new one immediately if there is no persisted value', async () => {
+    const persistence = new InMemoryPersistence()
+    const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(0.5)
+
+    const sampler = new Sampler(0.75)
+    const fetcher = new ProbabilityFetcher(delivery)
+
+    await ProbabilityManager.create(
+      persistence,
+      sampler,
+      1.0,
+      fetcher
+    )
+
+    expect(sampler.probability).toBe(1.0)
+
+    // the configured probability should not be persisted
+    expect(await persistence.load('bugsnag-sampling-probability')).toBeUndefined()
+
+    // a request will only be made after a macro task
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(1)
+
+    // the value fetched from the server should be persisted
+    expect(await persistence.load('bugsnag-sampling-probability')).toStrictEqual({
+      value: 0.5,
+      // the time will be 1ms ago as jest's timer has advanced 1ms after the
+      // persistence happened
+      time: Date.now() - 1
+    })
+
+    // after 1 day, another request should be made
+    await jest.advanceTimersByTimeAsync((24 * 60 * 60 * 1000) - 2)
+    expect(delivery.samplingRequests).toHaveLength(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(2)
+  })
+
+  it('uses the persisted probability and fetches a new one immediately if the persisted value is too old', async () => {
+    const persistence = new InMemoryPersistence()
+    persistence.save('bugsnag-sampling-probability', {
+      value: 0.25,
+      time: 0
+    })
+
+    const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(0.5)
+
+    const sampler = new Sampler(0.5)
+    const fetcher = new ProbabilityFetcher(delivery)
+
+    await ProbabilityManager.create(
+      persistence,
+      sampler,
+      1.0,
+      fetcher
+    )
+
+    expect(sampler.probability).toBe(0.25)
+
+    // a request will only be made after a macro task
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(1)
+
+    // the value fetched from the server should be persisted
+    expect(await persistence.load('bugsnag-sampling-probability')).toStrictEqual({
+      value: 0.5,
+      // the time will be 1ms ago as jest's timer has advanced 1ms after the
+      // persistence happened
+      time: Date.now() - 1
+    })
+
+    // after 1 day, another request should be made
+    await jest.advanceTimersByTimeAsync((24 * 60 * 60 * 1000) - 2)
+    expect(delivery.samplingRequests).toHaveLength(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(2)
+  })
+
+  it('uses the persisted probability and fetches a new one when it expires if the persisted value is recent', async () => {
+    const persistence = new InMemoryPersistence()
+    persistence.save('bugsnag-sampling-probability', {
+      value: 0.25,
+      time: Date.now() - 30_000 // 30 seconds ago
+    })
+
+    const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(0.5)
+
+    const sampler = new Sampler(0.5)
+    const fetcher = new ProbabilityFetcher(delivery)
+
+    await ProbabilityManager.create(
+      persistence,
+      sampler,
+      1.0,
+      fetcher
+    )
+
+    expect(sampler.probability).toBe(0.25)
+
+    // a request should not be made until the probability expires
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    // after 1 day - 30 seconds, another request should be made
+    await jest.advanceTimersByTimeAsync((24 * 60 * 60 * 1000) - 30_000 - 2)
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(1)
+
+    // the value fetched from the server should be persisted
+    expect(await persistence.load('bugsnag-sampling-probability')).toStrictEqual({
+      value: 0.5,
+      time: Date.now()
+    })
+  })
+
+  it('persists new probability values and fetches a new one after they expire', async () => {
+    const persistence = new InMemoryPersistence()
+    const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(0.5)
+
+    const sampler = new Sampler(0.75)
+    const fetcher = new ProbabilityFetcher(delivery)
+
+    const manager = await ProbabilityManager.create(
+      persistence,
+      sampler,
+      1.0,
+      fetcher
+    )
+
+    await manager.setProbability(0.25)
+
+    // the new probability should be persisted
+    expect(await persistence.load('bugsnag-sampling-probability')).toStrictEqual({
+      value: 0.25,
+      time: Date.now()
+    })
+
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    // after 1 day a request for a new probability should be made
+    await jest.advanceTimersByTimeAsync((24 * 60 * 60 * 1000) - 1)
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(1)
+  })
+
+  it('refreshes the expiration timer when a new probability is set', async () => {
+    const persistence = new InMemoryPersistence()
+    const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(0.5)
+
+    const sampler = new Sampler(0.75)
+    const fetcher = new ProbabilityFetcher(delivery)
+
+    const manager = await ProbabilityManager.create(
+      persistence,
+      sampler,
+      1.0,
+      fetcher
+    )
+
+    await manager.setProbability(0.25)
+
+    // the new probability should be persisted
+    expect(await persistence.load('bugsnag-sampling-probability')).toStrictEqual({
+      value: 0.25,
+      time: Date.now()
+    })
+
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    // wait just less than 1 day
+    await jest.advanceTimersByTimeAsync((24 * 60 * 60 * 1000) - 1)
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    await manager.setProbability(0.8)
+
+    expect(await persistence.load('bugsnag-sampling-probability')).toStrictEqual({
+      value: 0.8,
+      time: Date.now()
+    })
+
+    // as we just set a new probability, a request shouldn't be made
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    // wait just less than 1 day again (we've already just waited 1 ms above)
+    await jest.advanceTimersByTimeAsync((24 * 60 * 60 * 1000) - 2)
+    expect(delivery.samplingRequests).toHaveLength(0)
+
+    // now the probability we just set has expired, so we should refresh it from
+    // the server
+    await jest.advanceTimersByTimeAsync(1)
+    expect(delivery.samplingRequests).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Goal

Add a new `ProbabilityManager` that handles persistence and period requests for sampling. Anyone needing to update the sampling probability will use this instead of updating the `Sampler` directly

On `start` it handles the interplay between persistence and the initial request (see comments):

```ts
const probabilityManager = await ProbabilityManager.create(
  options.persistence,
  sampler,
  configuration.samplingProbability,
  probabilityFetcher
)
```

Then when the probability is updated:

```ts
probabilityManager.setProbability(newProbability)
```