### PR TITLE
Persist sampling changes

### DIFF
--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -5,7 +5,7 @@ import { type Delivery, type DeliverySpan } from './delivery'
 import { type Processor } from './processor'
 import type ProbabilityManager from './probability-manager'
 import { type RetryQueue } from './retry-queue'
-import type Sampler from './sampler'
+import { type ReadonlySampler } from './sampler'
 import { spanToJson, type SpanEnded } from './span'
 
 type MinimalProbabilityManager = Pick<ProbabilityManager, 'setProbability'>
@@ -16,7 +16,7 @@ export class BatchProcessor<C extends Configuration> implements Processor {
   private readonly resourceAttributeSource: ResourceAttributeSource<C>
   private readonly clock: Clock
   private readonly retryQueue: RetryQueue
-  private readonly sampler: Sampler
+  private readonly sampler: ReadonlySampler
   private readonly probabilityManager: MinimalProbabilityManager
 
   private batch: SpanEnded[] = []
@@ -28,7 +28,7 @@ export class BatchProcessor<C extends Configuration> implements Processor {
     resourceAttributeSource: ResourceAttributeSource<C>,
     clock: Clock,
     retryQueue: RetryQueue,
-    sampler: Sampler,
+    sampler: ReadonlySampler,
     probabilityManager: MinimalProbabilityManager
   ) {
     this.delivery = delivery

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -65,7 +65,8 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
           options.resourceAttributesSource,
           options.clock,
           new InMemoryQueue(delivery, configuration.retryQueueMaxSize),
-          sampler
+          sampler,
+          manager
         )
 
         // ensure all spans started before .start() are added to the batch

--- a/packages/core/lib/probability-manager.ts
+++ b/packages/core/lib/probability-manager.ts
@@ -1,6 +1,6 @@
 import { type Persistence } from './persistence'
 import type ProbabilityFetcher from './probability-fetcher'
-import type Sampler from './sampler'
+import { type ReadWriteSampler } from './sampler'
 
 // the time between requests to fetch a new probability value from the server
 const PROBABILITY_REFRESH_MILLISECONDS = 24 * 60 * 60 * 1000 // 24 hours
@@ -8,7 +8,7 @@ const PROBABILITY_REFRESH_MILLISECONDS = 24 * 60 * 60 * 1000 // 24 hours
 class ProbabilityManager {
   static async create (
     persistence: Persistence,
-    sampler: Sampler,
+    sampler: ReadWriteSampler,
     configuredProbability: number,
     probabilityFetcher: ProbabilityFetcher
   ) {
@@ -54,7 +54,7 @@ class ProbabilityManager {
   }
 
   private readonly persistence: Persistence
-  private readonly sampler: Sampler
+  private readonly sampler: ReadWriteSampler
   private readonly probabilityFetcher: ProbabilityFetcher
 
   private lastProbabilityTime: number
@@ -62,7 +62,7 @@ class ProbabilityManager {
 
   private constructor (
     persistence: Persistence,
-    sampler: Sampler,
+    sampler: ReadWriteSampler,
     probabilityFetcher: ProbabilityFetcher,
     initialTimoutDuration: number,
     initialProbabilityTime: number

--- a/packages/core/lib/sampler.ts
+++ b/packages/core/lib/sampler.ts
@@ -7,6 +7,16 @@ function scaleProbabilityToMatchSamplingRate (probability: number): SpanProbabil
   return Math.floor(probability * 0xffffffff) as SpanProbability
 }
 
+interface ReadonlySampler {
+  readonly probability: number
+  readonly spanProbability: SpanProbability
+  readonly sample: (span: SpanEnded) => boolean
+}
+
+interface ReadWriteSampler extends ReadonlySampler {
+  probability: number
+}
+
 class Sampler {
   private _probability: number
 
@@ -56,3 +66,4 @@ class Sampler {
 }
 
 export default Sampler
+export { type ReadonlySampler, type ReadWriteSampler }

--- a/packages/core/lib/sampler.ts
+++ b/packages/core/lib/sampler.ts
@@ -1,9 +1,4 @@
-import { type Delivery } from './delivery'
 import { type SpanEnded, type SpanProbability } from './span'
-
-const PROBABILITY_REFRESH_INTERVAL = 24 * 60 * 60_000 // 24 hours in ms
-
-const PROBABILITY_REFRESH_RETRY_INTERVAL = 30_000 // 30 seconds
 
 // sampling rates are stored as a number between 0 and 2^32 - 1 (i.e. they are
 // u32s) so we need to scale the probability value to match this range as they
@@ -14,8 +9,6 @@ function scaleProbabilityToMatchSamplingRate (probability: number): SpanProbabil
 
 class Sampler {
   private _probability: number
-  private delivery?: Delivery
-  private interval?: ReturnType<typeof setInterval>
 
   /**
    * The current probability scaled to match sampling rate
@@ -42,9 +35,6 @@ class Sampler {
   set probability (probability: number) {
     this._probability = probability
     this.scaledProbability = scaleProbabilityToMatchSamplingRate(probability)
-
-    // reset the timer whenever we receive a new probability value
-    this.resetTimer()
   }
 
   /**
@@ -60,49 +50,8 @@ class Sampler {
     return this.scaledProbability
   }
 
-  initialise (configuredProbability: number, delivery: Delivery) {
-    this._probability = configuredProbability
-    this.scaledProbability = scaleProbabilityToMatchSamplingRate(configuredProbability)
-    this.delivery = delivery
-
-    // make an initial request for the probability value
-    // when this completes a timer will be setup to make periodic requests
-    this.fetchSamplingProbability()
-  }
-
   sample (span: SpanEnded): boolean {
     return span.samplingRate <= span.samplingProbability
-  }
-
-  private fetchSamplingProbability = async () => {
-    if (!this.delivery) return
-
-    try {
-      const payload = { resourceSpans: [] }
-      const response = await this.delivery.send(payload)
-
-      // if the response doesn't contain a valid probability
-      // or the request failed, retry in 30 seconds
-      if (response.samplingProbability !== undefined) {
-        this.probability = response.samplingProbability
-      } else {
-        this.resetTimer(true)
-      }
-    } catch (err) {
-      // request failed - retry
-      this.resetTimer(true)
-    }
-  }
-
-  private resetTimer (isRetry: boolean = false) {
-    if (this.interval) {
-      clearInterval(this.interval)
-    }
-
-    this.interval = setInterval(
-      this.fetchSamplingProbability,
-      isRetry ? PROBABILITY_REFRESH_RETRY_INTERVAL : PROBABILITY_REFRESH_INTERVAL
-    )
   }
 }
 

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -6,7 +6,7 @@ import { type DeliverySpan } from './delivery'
 import { SpanEvents } from './events'
 import { type IdGenerator } from './id-generator'
 import { type Processor } from './processor'
-import type Sampler from './sampler'
+import { type ReadonlySampler } from './sampler'
 import { type SpanContext } from './span-context'
 import { type Time, timeToNumber } from './time'
 import traceIdToSamplingRate from './trace-id-to-sampling-rate'
@@ -116,7 +116,7 @@ export class SpanFactory {
   private readonly spanAttributesSource: SpanAttributesSource
   private logger: Logger
   private processor: Processor
-  private readonly sampler: Sampler
+  private readonly sampler: ReadonlySampler
   private readonly clock: Clock
 
   private openSpans: WeakSet<SpanInternal> = new WeakSet<SpanInternal>()
@@ -124,7 +124,7 @@ export class SpanFactory {
 
   constructor (
     processor: Processor,
-    sampler: Sampler,
+    sampler: ReadonlySampler,
     idGenerator: IdGenerator,
     spanAttributesSource: SpanAttributesSource,
     clock: Clock,

--- a/packages/core/tests/batch-processor.test.ts
+++ b/packages/core/tests/batch-processor.test.ts
@@ -1,4 +1,7 @@
 import { BatchProcessor } from '../lib/batch-processor'
+import { InMemoryPersistence } from '../lib/persistence'
+import ProbabilityFetcher from '../lib/probability-fetcher'
+import ProbabilityManager from '../lib/probability-manager'
 import Sampler from '../lib/sampler'
 import {
   IncrementingClock,
@@ -19,7 +22,8 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       { add: jest.fn(), flush: jest.fn() },
-      new Sampler(1.0)
+      new Sampler(1.0),
+      { setProbability () { return Promise.resolve() } }
     )
 
     // add 99 spans
@@ -42,7 +46,8 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       { add: jest.fn(), flush: jest.fn() },
-      new Sampler(1.0)
+      new Sampler(1.0),
+      { setProbability () { return Promise.resolve() } }
     )
 
     batchProcessor.add(createEndedSpan())
@@ -62,7 +67,8 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       { add: jest.fn(), flush: jest.fn() },
-      new Sampler(1.0)
+      new Sampler(1.0),
+      { setProbability () { return Promise.resolve() } }
     )
 
     batchProcessor.add(createEndedSpan())
@@ -87,7 +93,8 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       { add: jest.fn(), flush: jest.fn() },
-      new Sampler(1.0)
+      new Sampler(1.0),
+      { setProbability () { return Promise.resolve() } }
     )
 
     batchProcessor.add(createEndedSpan())
@@ -108,7 +115,8 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       retryQueue,
-      new Sampler(1.0)
+      new Sampler(1.0),
+      { setProbability () { return Promise.resolve() } }
     )
 
     delivery.setNextResponseState('failure-retryable')
@@ -134,7 +142,8 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       retryQueue,
-      new Sampler(1.0)
+      new Sampler(1.0),
+      { setProbability () { return Promise.resolve() } }
     )
 
     delivery.setNextResponseState('failure-discard')
@@ -160,7 +169,8 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       retryQueue,
-      new Sampler(1.0)
+      new Sampler(1.0),
+      { setProbability () { return Promise.resolve() } }
     )
 
     batchProcessor.add(createEndedSpan())
@@ -183,7 +193,13 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       { add: jest.fn(), flush: jest.fn() },
-      sampler
+      sampler,
+      await ProbabilityManager.create(
+        new InMemoryPersistence(),
+        sampler,
+        1.0,
+        new ProbabilityFetcher(delivery)
+      )
     )
 
     batchProcessor.add(createEndedSpan())
@@ -207,7 +223,13 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       { add: jest.fn(), flush: jest.fn() },
-      sampler
+      sampler,
+      await ProbabilityManager.create(
+        new InMemoryPersistence(),
+        sampler,
+        0.5,
+        new ProbabilityFetcher(delivery)
+      )
     )
 
     const span1 = createEndedSpan({
@@ -247,7 +269,13 @@ describe('BatchProcessor', () => {
       resourceAttributesSource,
       new IncrementingClock('1970-01-01T00:00:00Z'),
       { add: jest.fn(), flush: jest.fn() },
-      sampler
+      sampler,
+      await ProbabilityManager.create(
+        new InMemoryPersistence(),
+        sampler,
+        0.5,
+        new ProbabilityFetcher(delivery)
+      )
     )
 
     const span1 = createEndedSpan({

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -171,7 +171,7 @@ describe('Core', () => {
           expect(() => { client.start(config) }).toThrow('No Bugsnag API Key set')
         })
 
-        it('registers with the backgrounding listener', () => {
+        it('registers with the backgrounding listener', async () => {
           const backgroundingListener: BackgroundingListener = {
             onStateChange: jest.fn()
           }
@@ -181,17 +181,20 @@ describe('Core', () => {
           expect(backgroundingListener.onStateChange).toHaveBeenCalledTimes(1)
 
           client.start(VALID_API_KEY)
+          await jest.runOnlyPendingTimersAsync()
 
           expect(backgroundingListener.onStateChange).toHaveBeenCalledTimes(2)
           expect(console.warn).not.toHaveBeenCalled()
         })
 
-        it('flushes the processor when the app is backgrounded', () => {
+        it('flushes the processor when the app is backgrounded', async () => {
           const delivery = new InMemoryDelivery()
           const backgroundingListener = new ControllableBackgroundingListener()
 
           const client = createTestClient({ backgroundingListener, deliveryFactory: () => delivery })
           client.start(VALID_API_KEY)
+
+          await jest.runOnlyPendingTimersAsync()
 
           client.startSpan('Span 1').end()
           client.startSpan('Span 2').end()

--- a/packages/core/tests/sampler.test.ts
+++ b/packages/core/tests/sampler.test.ts
@@ -1,6 +1,5 @@
 import Sampler from '../lib/sampler'
-import { InMemoryDelivery, createEndedSpan } from '@bugsnag/js-performance-test-utilities'
-import { type ResponseState } from '../lib'
+import { createEndedSpan } from '@bugsnag/js-performance-test-utilities'
 
 jest.useFakeTimers()
 
@@ -16,22 +15,6 @@ describe('Sampler', () => {
     sampler.probability = 0.25
 
     expect(sampler.probability).toBe(0.25)
-  })
-
-  describe('initialise', () => {
-    it('uses the provided probability when initialised', () => {
-      const sampler = new Sampler(1.0)
-      const delivery = new InMemoryDelivery()
-      sampler.initialise(0.5, delivery)
-      expect(sampler.probability).toBe(0.5)
-    })
-
-    it('makes an initial probability request when initialised', () => {
-      const sampler = new Sampler(1.0)
-      const delivery = new InMemoryDelivery()
-      sampler.initialise(0.5, delivery)
-      expect(delivery.samplingRequests.length).toEqual(1)
-    })
   })
 
   describe('sample', () => {
@@ -156,119 +139,6 @@ describe('Sampler', () => {
       })
 
       expect(sampler.sample(span)).toBe(expected)
-    })
-  })
-
-  describe('periodic sampling request', () => {
-    it('requests a new sampling probability after 24 hours', async () => {
-      const sampler = new Sampler(1.0)
-      const delivery = new InMemoryDelivery()
-      delivery.setNextSamplingProbability(0.5)
-      sampler.initialise(1.0, delivery)
-
-      // initial request
-      expect(delivery.samplingRequests.length).toEqual(1)
-
-      // allow the async request to complete
-      await jest.advanceTimersByTimeAsync(0)
-      expect(sampler.probability).toEqual(0.5)
-
-      // just under 24 hours - no peridoic request yet
-      await jest.advanceTimersByTimeAsync((24 * 60 * 60_000) - 1)
-      expect(delivery.samplingRequests.length).toEqual(1)
-
-      delivery.setNextSamplingProbability(0.25)
-
-      // just over 24 hours - peridoic request sent
-      await jest.advanceTimersByTimeAsync(2)
-      expect(delivery.samplingRequests.length).toEqual(2)
-
-      expect(sampler.probability).toEqual(0.25)
-    })
-
-    it('uses a requested probability when sampling the next batch', async () => {
-      const sampler = new Sampler(1.0)
-      const delivery = new InMemoryDelivery()
-      delivery.setNextSamplingProbability(0.25)
-
-      sampler.initialise(1.0, delivery)
-      expect(delivery.samplingRequests.length).toEqual(1)
-
-      // initial request
-      await jest.advanceTimersByTimeAsync(0)
-      expect(sampler.probability).toEqual(0.25)
-
-      const span = createEndedSpan({
-        samplingRate: Math.floor(0.5 * 0xffffffff),
-        samplingProbability: sampler.spanProbability
-      })
-
-      expect(sampler.sample(span)).toEqual(false)
-    })
-
-    it('resets the timer when a probability value is set', async () => {
-      const sampler = new Sampler(1.0)
-      const delivery = new InMemoryDelivery()
-      delivery.setNextSamplingProbability(0.5)
-      sampler.initialise(1.0, delivery)
-
-      // initial request
-      expect(delivery.samplingRequests.length).toEqual(1)
-      await jest.advanceTimersByTimeAsync(0)
-      expect(sampler.probability).toEqual(0.5)
-
-      // probability updated directly after 23 hours (should reset timer)
-      await jest.advanceTimersByTimeAsync(82800000)
-      sampler.probability = 0.75
-
-      // 25 hours (2 hours since reset) - still no request
-      await jest.advanceTimersByTimeAsync(7200000)
-      expect(delivery.samplingRequests.length).toEqual(1)
-
-      delivery.setNextSamplingProbability(0.25)
-
-      // +22 hours (24 hours since reset) - peridoic request sent
-      await jest.advanceTimersByTimeAsync(79200000)
-      expect(delivery.samplingRequests.length).toEqual(2)
-
-      expect(sampler.probability).toEqual(0.25)
-    })
-
-    it('retries the request after 30 seconds when samplingProbability is not defined', async () => {
-      const sampler = new Sampler(1.0)
-      const state: ResponseState = 'failure-retryable'
-      const delivery = {
-        send: jest.fn(() => {
-          return Promise.resolve({ state })
-        })
-      }
-
-      sampler.initialise(1.0, delivery)
-      expect(delivery.send).toHaveBeenCalledTimes(1)
-
-      await jest.advanceTimersByTimeAsync(29999)
-      expect(delivery.send).toHaveBeenCalledTimes(1)
-
-      await jest.advanceTimersByTimeAsync(30000)
-      expect(delivery.send).toHaveBeenCalledTimes(2)
-    })
-
-    it('retries the request after 30 seconds when the request errors', async () => {
-      const sampler = new Sampler(1.0)
-      const delivery = {
-        send: jest.fn(() => {
-          return Promise.reject(new Error('request failed'))
-        })
-      }
-
-      sampler.initialise(1.0, delivery)
-      expect(delivery.send).toHaveBeenCalledTimes(1)
-
-      await jest.advanceTimersByTimeAsync(29999)
-      expect(delivery.send).toHaveBeenCalledTimes(1)
-
-      await jest.advanceTimersByTimeAsync(30000)
-      expect(delivery.send).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/platforms/browser/tests/page-load-span-plugin.test.ts
+++ b/packages/platforms/browser/tests/page-load-span-plugin.test.ts
@@ -28,7 +28,7 @@ import MockRoutingProvider from './utilities/mock-routing-provider'
 jest.useFakeTimers()
 
 describe('FullPageLoadPlugin', () => {
-  it('Automatically creates and delivers a pageLoadSpan', () => {
+  it('Automatically creates and delivers a pageLoadSpan', async () => {
     const manager = new PerformanceObserverManager()
 
     const performance = new PerformanceFake()
@@ -77,7 +77,7 @@ describe('FullPageLoadPlugin', () => {
 
     testClient.start({ apiKey: VALID_API_KEY })
 
-    jest.runOnlyPendingTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     expect(delivery).toHaveSentSpan(expect.objectContaining({ name: '[FullPageLoad]/initial-route' }))
 
@@ -95,7 +95,7 @@ describe('FullPageLoadPlugin', () => {
     expect(span).toHaveEvent('lcp', '64000000')
   })
 
-  it('Does not create a pageLoadSpan with autoInstrumentFullPageLoads set to false', () => {
+  it('Does not create a pageLoadSpan with autoInstrumentFullPageLoads set to false', async () => {
     const clock = new IncrementingClock()
     const delivery = new InMemoryDelivery()
     const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(1234) }
@@ -119,7 +119,7 @@ describe('FullPageLoadPlugin', () => {
 
     testClient.start({ apiKey: VALID_API_KEY, autoInstrumentFullPageLoads: false })
 
-    jest.runOnlyPendingTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     expect(delivery.requests).toHaveLength(0)
   })
@@ -304,7 +304,7 @@ describe('FullPageLoadPlugin', () => {
 
   describe('WebVitals', () => {
     describe('lcp', () => {
-      it('uses the latest lcp entry (multiple entries)', () => {
+      it('uses the latest lcp entry (multiple entries)', async () => {
         const manager = new PerformanceObserverManager()
         const performance = new PerformanceFake()
 
@@ -337,7 +337,7 @@ describe('FullPageLoadPlugin', () => {
 
         testClient.start({ apiKey: VALID_API_KEY })
 
-        jest.runOnlyPendingTimers()
+        await jest.runOnlyPendingTimersAsync()
 
         expect(delivery).toHaveSentSpan(expect.objectContaining({
           name: '[FullPageLoad]/initial-route',
@@ -350,7 +350,7 @@ describe('FullPageLoadPlugin', () => {
         }))
       })
 
-      it('uses the latest lcp entry (multiple batches)', () => {
+      it('uses the latest lcp entry (multiple batches)', async () => {
         const manager = new PerformanceObserverManager()
         const performance = new PerformanceFake()
 
@@ -389,7 +389,7 @@ describe('FullPageLoadPlugin', () => {
 
         testClient.start({ apiKey: VALID_API_KEY })
 
-        jest.runOnlyPendingTimers()
+        await jest.runOnlyPendingTimersAsync()
 
         expect(delivery).toHaveSentSpan(expect.objectContaining({
           name: '[FullPageLoad]/initial-route',
@@ -402,7 +402,7 @@ describe('FullPageLoadPlugin', () => {
         }))
       })
 
-      it('handles there being no lcp entry', () => {
+      it('handles there being no lcp entry', async () => {
         const manager = new PerformanceObserverManager()
         const performance = new PerformanceFake()
 
@@ -431,7 +431,7 @@ describe('FullPageLoadPlugin', () => {
 
         testClient.start(VALID_API_KEY)
 
-        jest.runOnlyPendingTimers()
+        await jest.runOnlyPendingTimersAsync()
 
         expect(delivery).toHaveSentSpan(expect.objectContaining({
           name: '[FullPageLoad]/initial-route',
@@ -444,7 +444,7 @@ describe('FullPageLoadPlugin', () => {
       })
     })
 
-    it('handles PerformanceObserver not being available', () => {
+    it('handles PerformanceObserver not being available', async () => {
       const performance = new PerformanceFake()
 
       const clock = new IncrementingClock('1970-01-01T00:00:00Z')
@@ -469,7 +469,7 @@ describe('FullPageLoadPlugin', () => {
 
       testClient.start({ apiKey: VALID_API_KEY })
 
-      jest.runOnlyPendingTimers()
+      await jest.runOnlyPendingTimersAsync()
 
       expect(delivery).toHaveSentSpan(expect.objectContaining({
         name: '[FullPageLoad]/initial-route',

--- a/packages/platforms/browser/tests/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/route-change-plugin.test.ts
@@ -21,7 +21,7 @@ describe('RouteChangePlugin', () => {
     { type: 'URL', url: new URL('https://bugsnag.com/second-route') },
     { type: 'string (absolute URL)', url: 'https://bugsnag.com/second-route' },
     { type: 'string (relative URL)', url: '/second-route' }
-  ])('creates a route change span on pushState with $type', ({ url }) => {
+  ])('creates a route change span on pushState with $type', async ({ url }) => {
     const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
     const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
@@ -38,7 +38,7 @@ describe('RouteChangePlugin', () => {
 
     history.pushState({}, '', url)
 
-    jest.runOnlyPendingTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     expect(delivery).toHaveSentSpan(expect.objectContaining({
       name: '[RouteChange]/second-route',
@@ -53,7 +53,7 @@ describe('RouteChangePlugin', () => {
     expect(span).toHaveAttribute('bugsnag.browser.page.route_change.trigger', 'pushState')
   })
 
-  it('creates a route change span on popstate', () => {
+  it('creates a route change span on popstate', async () => {
     const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
     const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
@@ -71,6 +71,7 @@ describe('RouteChangePlugin', () => {
     testClient.start({ apiKey: VALID_API_KEY })
 
     history.back()
+    await jest.runOnlyPendingTimersAsync()
     jest.runAllTimers()
 
     const firstSpan = expect.objectContaining({
@@ -110,7 +111,7 @@ describe('RouteChangePlugin', () => {
     { type: 'empty string', url: '' },
     { type: 'undefined', url: undefined },
     { type: 'null', url: null }
-  ])('does not create a route change span on pushState with $type', ({ url }) => {
+  ])('does not create a route change span on pushState with $type', async ({ url }) => {
     const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
     const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
@@ -127,13 +128,13 @@ describe('RouteChangePlugin', () => {
 
     history.pushState({}, '', url)
 
-    jest.runOnlyPendingTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     // No delivery
     expect(delivery.requests).toHaveLength(0)
   })
 
-  it('does not create route change spans with autoInstrumentFullPageLoads set to false', () => {
+  it('does not create route change spans with autoInstrumentFullPageLoads set to false', async () => {
     const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
     const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
     const clock = new IncrementingClock()
@@ -149,7 +150,7 @@ describe('RouteChangePlugin', () => {
 
     history.pushState('', '', new URL('https://bugsnag.com/second-route'))
 
-    jest.runAllTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     expect(delivery).not.toHaveSentSpan(expect.objectContaining({
       name: '[RouteChange]/second-route'

--- a/packages/platforms/browser/tests/routing-provider.test.ts
+++ b/packages/platforms/browser/tests/routing-provider.test.ts
@@ -14,7 +14,7 @@ jest.useFakeTimers()
 const DefaultRoutingProvider = createDefaultRoutingProvider(jest.fn((c) => { c(32) }), window.location)
 
 describe('DefaultRoutingProvider', () => {
-  it('Uses a provided route resolver function', () => {
+  it('Uses a provided route resolver function', async () => {
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
     const routeResolverFn = jest.fn((url: URL | string) => '/resolved-route')
@@ -30,14 +30,14 @@ describe('DefaultRoutingProvider', () => {
 
     history.pushState({}, '', '/new-route')
 
-    jest.runOnlyPendingTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     expect(routeResolverFn).toHaveBeenCalled()
     expect(delivery).toHaveSentSpan(expect.objectContaining({ name: '[RouteChange]/resolved-route' }))
   })
 
   describe('defaultRouteResolver', () => {
-    it('Returns a route when provided a complete URL', () => {
+    it('Returns a route when provided a complete URL', async () => {
       const clock = new IncrementingClock('1970-01-01T00:00:00Z')
       const delivery = new InMemoryDelivery()
       const routingProvier = new DefaultRoutingProvider()
@@ -53,7 +53,7 @@ describe('DefaultRoutingProvider', () => {
       const url = new URL('https://bugsnag.com/platforms/javascript?test=true#unit-test')
       history.pushState({}, '', url)
 
-      jest.runOnlyPendingTimers()
+      await jest.runOnlyPendingTimersAsync()
 
       expect(delivery).toHaveSentSpan(expect.objectContaining({ name: '[RouteChange]/platforms/javascript' }))
     })

--- a/test/browser/features/support/isolate-scenarios.rb
+++ b/test/browser/features/support/isolate-scenarios.rb
@@ -11,4 +11,7 @@ Maze.hooks.after do
     Maze.driver.navigate.to path
     # If a further error occurs it will get thrown as normal
   end
+
+  driver = Maze.driver.instance_variable_get(:@driver)
+  hostname = driver.execute_script("window.localStorage.clear()")
 end


### PR DESCRIPTION
## Goal

This PR integrates the `ProbabilityManager` (#205) with `BugsnagPerformance#start` and the `BatchProcessor`

Most of the changes here are swapping `jest.runOnlyPendingTimers()` to `await jest.runOnlyPendingTimersAsync()` as there's now a promise in `start` — `PerformanceManager.create` is async as it needs to read from persisted storage

I've also added two new interfaces for `Sampler` — `ReadonlySampler` and `ReadWriteSampler`. Using `ReadonlySampler` means you can't update the probability value, since that should always go through the `ProbabilityManager`. This obviously isn't foolproof but hopefully should help prevent bugs due to not persisting probabilities in future

The e2e tests also clear local storage after running so that tests can't interfere with each other if they set different sampling probability values