### PR TITLE
Make `SpanContextStorage` a client option and add `currentSpanContext` to client

### DIFF
--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -16,7 +16,8 @@ describe('Core', () => {
 
       expect(client).toStrictEqual({
         start: expect.any(Function),
-        startSpan: expect.any(Function)
+        startSpan: expect.any(Function),
+        currentSpanContext: undefined
       })
     })
 
@@ -178,12 +179,12 @@ describe('Core', () => {
 
           const client = createTestClient({ backgroundingListener })
 
-          expect(backgroundingListener.onStateChange).toHaveBeenCalledTimes(1)
+          expect(backgroundingListener.onStateChange).toHaveBeenCalledTimes(2)
 
           client.start(VALID_API_KEY)
           await jest.runOnlyPendingTimersAsync()
 
-          expect(backgroundingListener.onStateChange).toHaveBeenCalledTimes(2)
+          expect(backgroundingListener.onStateChange).toHaveBeenCalledTimes(3)
           expect(console.warn).not.toHaveBeenCalled()
         })
 

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -1,5 +1,6 @@
 import { createNoopClient } from '../lib/core'
 import { type BackgroundingListener } from '../lib/backgrounding-listener'
+import { DefaultSpanContextStorage } from '../lib/span-context'
 import {
   ControllableBackgroundingListener,
   createTestClient,
@@ -232,6 +233,17 @@ describe('Core', () => {
           backgroundingListener.sendToBackground()
 
           expect(delivery.requests).toHaveLength(0)
+        })
+      })
+
+      describe('currentSpanContext', () => {
+        it('returns the current span context', () => {
+          const spanContextStorage = new DefaultSpanContextStorage(new ControllableBackgroundingListener())
+          const client = createTestClient({ spanContextStorage })
+
+          const spanContext = { id: '0123456789abcdef', traceId: '0123456789abcdeffedcba9876543210', isValid: () => true }
+          spanContextStorage.push(spanContext)
+          expect(client.currentSpanContext).toBe(spanContext)
         })
       })
     })


### PR DESCRIPTION
## Goal

Adds a new `spanContextStorage` client option for platforms to provide their own implementation. There are currently no platforms-specific implementations, so this is optional - if no implementation is provided then `DefaultSpanContextStorage` is used.

Also adds `currentSpanContext` as a new readonly property to the client to allow users to retrieve the current context and use it manually if they need to (for example starting multiple spans under the same parent context)