### PR TITLE
Add `makeCurrentContext` to `SpanOptions`

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -47,7 +47,8 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
     options.spanAttributesSource,
     options.clock,
     options.backgroundingListener,
-    options.schema.logger.defaultValue
+    options.schema.logger.defaultValue,
+    spanContextStorage
   )
   const plugins = options.plugins(spanFactory)
 

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -7,7 +7,7 @@ import { SpanEvents } from './events'
 import { type IdGenerator } from './id-generator'
 import { type Processor } from './processor'
 import { type ReadonlySampler } from './sampler'
-import { type SpanContext } from './span-context'
+import { type SpanContext, type SpanContextStorage } from './span-context'
 import { type Time, timeToNumber } from './time'
 import traceIdToSamplingRate from './trace-id-to-sampling-rate'
 
@@ -112,12 +112,13 @@ export interface SpanOptions {
 }
 
 export class SpanFactory {
-  private readonly idGenerator: IdGenerator
-  private readonly spanAttributesSource: SpanAttributesSource
-  private logger: Logger
   private processor: Processor
   private readonly sampler: ReadonlySampler
+  private readonly idGenerator: IdGenerator
+  private readonly spanAttributesSource: SpanAttributesSource
   private readonly clock: Clock
+  private readonly spanContextStorage: SpanContextStorage
+  private logger: Logger
 
   private openSpans: WeakSet<SpanInternal> = new WeakSet<SpanInternal>()
   private isInForeground: boolean = true
@@ -129,14 +130,16 @@ export class SpanFactory {
     spanAttributesSource: SpanAttributesSource,
     clock: Clock,
     backgroundingListener: BackgroundingListener,
-    logger: Logger
+    logger: Logger,
+    spanContextStorage: SpanContextStorage
   ) {
     this.processor = processor
     this.sampler = sampler
     this.idGenerator = idGenerator
-    this.logger = logger
     this.spanAttributesSource = spanAttributesSource
     this.clock = clock
+    this.logger = logger
+    this.spanContextStorage = spanContextStorage
 
     // this will fire immediately if the app is already backgrounded
     backgroundingListener.onStateChange(this.onBackgroundStateChange)

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -109,6 +109,7 @@ export class SpanInternal implements SpanContext {
 
 export interface SpanOptions {
   startTime?: Time
+  makeCurrentContext?: boolean
 }
 
 export class SpanFactory {
@@ -162,6 +163,10 @@ export class SpanFactory {
     // don't track spans that are started while the app is backgrounded
     if (this.isInForeground) {
       this.openSpans.add(span)
+
+      if (options && options.makeCurrentContext === true) {
+        this.spanContextStorage.push(span)
+      }
     }
 
     return span
@@ -183,6 +188,7 @@ export class SpanFactory {
     }
 
     const spanEnded = span.end(endTime, this.sampler.spanProbability)
+    this.spanContextStorage.pop(span)
 
     if (this.sampler.sample(spanEnded)) {
       this.processor.add(spanEnded)

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -164,7 +164,7 @@ export class SpanFactory {
     if (this.isInForeground) {
       this.openSpans.add(span)
 
-      if (options && options.makeCurrentContext === true) {
+      if (!options || options.makeCurrentContext !== false) {
         this.spanContextStorage.push(span)
       }
     }

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -1,5 +1,5 @@
 
-import { Kind } from '@bugsnag/core-performance'
+import { DefaultSpanContextStorage, Kind } from '@bugsnag/core-performance'
 import {
   ControllableBackgroundingListener,
   InMemoryDelivery,
@@ -39,14 +39,16 @@ describe('SpanInternal', () => {
       const sampler = new Sampler(0.5)
       const delivery = { send: jest.fn() }
       const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+      const backgroundingListener = new ControllableBackgroundingListener()
       const spanFactory = new SpanFactory(
         processor,
         sampler,
         new StableIdGenerator(),
         spanAttributesSource,
         new IncrementingClock(),
-        new ControllableBackgroundingListener(),
-        jestLogger
+        backgroundingListener,
+        jestLogger,
+        new DefaultSpanContextStorage(backgroundingListener)
       )
 
       const spanInternal = spanFactory.startSpan('span-name', { startTime: 1234 })
@@ -71,14 +73,16 @@ describe('SpanInternal', () => {
       const sampler = new Sampler(0.5)
       const delivery = { send: jest.fn() }
       const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+      const backgroundingListener = new ControllableBackgroundingListener()
       const spanFactory = new SpanFactory(
         processor,
         sampler,
         new StableIdGenerator(),
         spanAttributesSource,
         new IncrementingClock(),
-        new ControllableBackgroundingListener(),
-        jestLogger
+        backgroundingListener,
+        jestLogger,
+        new DefaultSpanContextStorage(backgroundingListener)
       )
 
       const spanInternal = spanFactory.startSpan('span-name', { startTime: 1234 })

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -149,6 +149,31 @@ describe('Span', () => {
         startTimeUnixNano: '1000000'
       }))
     })
+
+    it('becomes the current SpanContext when SpanOptions.makeCurrentContext === true', () => {
+      const idGenerator = {
+        count: 0,
+        generate (bits: 64 | 128) {
+          if (bits === 64) {
+            this.count++
+            return `span ID ${this.count}`
+          }
+
+          return 'a trace ID'
+        }
+      }
+
+      const client = createTestClient({ idGenerator })
+      client.start({ apiKey: VALID_API_KEY })
+      expect(client.currentSpanContext).toBeUndefined()
+
+      const spanIsContext = client.startSpan('context span', { makeCurrentContext: true })
+      expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
+
+      const spanIsNotContext = client.startSpan('non context span')
+      expect(spanContextEquals(spanIsNotContext, client.currentSpanContext)).toBe(false)
+      expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
+    })
   })
 
   describe('Span.end()', () => {
@@ -434,6 +459,41 @@ describe('Span', () => {
 
       expect(logger.warn).toHaveBeenCalledWith('Attempted to end a Span which has already ended or been discarded.')
       expect(delivery.requests).toHaveLength(1)
+    })
+
+    it('will remove the span from the context stack (if it is the current context)', () => {
+      const idGenerator = {
+        count: 0,
+        generate (bits: 64 | 128) {
+          if (bits === 64) {
+            this.count++
+            return `span ID ${this.count}`
+          }
+
+          return 'a trace ID'
+        }
+      }
+
+      const client = createTestClient({ idGenerator })
+      client.start({ apiKey: VALID_API_KEY })
+      expect(client.currentSpanContext).toBeUndefined()
+
+      const span1 = client.startSpan('span 1', { makeCurrentContext: true })
+      const span2 = client.startSpan('span 2', { makeCurrentContext: true })
+      const span3 = client.startSpan('span 3', { makeCurrentContext: true })
+      expect(spanContextEquals(span3, client.currentSpanContext)).toBe(true)
+
+      // span2 is not at the top of the context stack so span3 should still be the current context
+      span2.end()
+      expect(spanContextEquals(span3, client.currentSpanContext)).toBe(true)
+
+      // span3 is at the top of the stack so should be popped when ended
+      // span2 is already closed so span1 should now be the current context
+      span3.end()
+      expect(spanContextEquals(span1, client.currentSpanContext)).toBe(true)
+
+      span1.end()
+      expect(client.currentSpanContext).toBeUndefined()
     })
   })
 })

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -1,4 +1,4 @@
-import { type SpanInternal, type SpanEnded, type SpanOptions, SpanFactory } from '@bugsnag/core-performance'
+import { type SpanInternal, type SpanEnded, type SpanOptions, SpanFactory, DefaultSpanContextStorage } from '@bugsnag/core-performance'
 import StableIdGenerator from './stable-id-generator'
 import spanAttributesSource from './span-attributes-source'
 import IncrementingClock from './incrementing-clock'
@@ -18,6 +18,7 @@ class MockSpanFactory extends SpanFactory {
   constructor () {
     const sampler: any = { probability: 0.1, sample: () => true }
     const processor = new InMemoryProcessor()
+    const backgroundingListener = new ControllableBackgroundingListener()
 
     super(
       processor,
@@ -25,8 +26,9 @@ class MockSpanFactory extends SpanFactory {
       new StableIdGenerator(),
       spanAttributesSource,
       new IncrementingClock(),
-      new ControllableBackgroundingListener(),
-      jestLogger
+      backgroundingListener,
+      jestLogger,
+      new DefaultSpanContextStorage(backgroundingListener)
     )
 
     this.createdSpans = processor.spans


### PR DESCRIPTION
## Goal

This PR adds a new optional `makeCurrentContext` option to `SpanOptions`

```diff
- startSpan(name: string, options?: { startTime?: Time })
+ startSpan(name: string, options?: { startTime?: Time, makeCurrentContext?: boolean })
```

Unless this is explicitly set to `false`,  starting a span will push it onto the context stack making it the 'current' `SpanContext`

When a span is ended, it will be popped off the context stack (if it is the current `SpanContext`)