### PR TITLE
Add `parentContext` to `SpanOptions` and set parentage for new spans

### DIFF
--- a/packages/core/lib/delivery.ts
+++ b/packages/core/lib/delivery.ts
@@ -37,6 +37,7 @@ export interface DeliverySpan {
   kind: Kind
   spanId: string
   traceId: string
+  parentSpanId?: string
   startTimeUnixNano: string
   endTimeUnixNano: string
   attributes: Array<JsonAttribute | undefined>

--- a/packages/core/lib/validation.ts
+++ b/packages/core/lib/validation.ts
@@ -1,5 +1,6 @@
 import { type Logger } from './config'
 import { type PersistedProbability } from './persistence'
+import { type SpanContext } from './span-context'
 
 export const isBoolean = (value: unknown): value is boolean =>
   value === true || value === false
@@ -31,3 +32,9 @@ export function isPersistedProbabilty (value: unknown): value is PersistedProbab
     isNumber(value.value) &&
     isNumber(value.time)
 }
+
+export const isSpanContext = (value: unknown): value is SpanContext =>
+  isObject(value) &&
+    typeof value.id === 'string' &&
+    typeof value.traceId === 'string' &&
+    typeof value.isValid === 'function'

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -198,15 +198,14 @@ describe('Span', () => {
     })
 
     it('sets traceId and parentSpanId from parentContext if specified', async () => {
-      let count = 0
+      let spanCount = 0
+      let traceCount = 0
       const idGenerator = {
         generate (bits: 64 | 128) {
           if (bits === 64) {
-            count++
-            return `span ID ${count}`
+            return `span ID ${++spanCount}`
           }
-
-          return `trace ID ${count}`
+          return `trace ID ${++traceCount}`
         }
       }
 
@@ -234,15 +233,14 @@ describe('Span', () => {
     })
 
     it('starts a new root span when parentContext is null', async () => {
-      let count = 0
+      let spanCount = 0
+      let traceCount = 0
       const idGenerator = {
         generate (bits: 64 | 128) {
           if (bits === 64) {
-            count++
-            return `span ID ${count}`
+            return `span ID ${++spanCount}`
           }
-
-          return `trace ID ${count}`
+          return `trace ID ${++traceCount}`
         }
       }
 
@@ -262,7 +260,7 @@ describe('Span', () => {
       expect(delivery).toHaveSentSpan(expect.objectContaining({
         name: 'new root span',
         parentSpanId: undefined,
-        traceId: `trace ID ${count}`
+        traceId: `trace ID ${traceCount}`
       }))
     })
 
@@ -279,15 +277,14 @@ describe('Span', () => {
     ]
 
     it.each(parentContextOptions)('defaults to the current context when parentContext is invalid ($type)', async (options) => {
-      let count = 0
+      let spanCount = 0
+      let traceCount = 0
       const idGenerator = {
         generate (bits: 64 | 128) {
           if (bits === 64) {
-            count++
-            return `span ID ${count}`
+            return `span ID ${++spanCount}`
           }
-
-          return `trace ID ${count}`
+          return `trace ID ${++traceCount}`
         }
       }
 

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -205,8 +205,8 @@ describe('Span', () => {
       client.start({ apiKey: VALID_API_KEY })
 
       // push two spans onto the context stack
-      const span1 = client.startSpan('span 1')
-      const span2 = client.startSpan('span 2')
+      const span1 = client.startSpan('should become parent')
+      const span2 = client.startSpan('should not become parent')
       expect(spanContextEquals(span2, client.currentSpanContext)).toBe(true)
 
       // start a new child span with an invalid parent context

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -7,7 +7,8 @@ import {
   StableIdGenerator,
   VALID_API_KEY,
   createTestClient,
-  spanAttributesSource
+  spanAttributesSource,
+  IncrementingIdGenerator
 } from '@bugsnag/js-performance-test-utilities'
 import {
   InMemoryPersistence,
@@ -198,17 +199,7 @@ describe('Span', () => {
     })
 
     it('sets traceId and parentSpanId from parentContext if specified', async () => {
-      let spanCount = 0
-      let traceCount = 0
-      const idGenerator = {
-        generate (bits: 64 | 128) {
-          if (bits === 64) {
-            return `span ID ${++spanCount}`
-          }
-          return `trace ID ${++traceCount}`
-        }
-      }
-
+      const idGenerator = new IncrementingIdGenerator()
       const delivery = new InMemoryDelivery()
       const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
       client.start({ apiKey: VALID_API_KEY })
@@ -233,17 +224,7 @@ describe('Span', () => {
     })
 
     it('starts a new root span when parentContext is null', async () => {
-      let spanCount = 0
-      let traceCount = 0
-      const idGenerator = {
-        generate (bits: 64 | 128) {
-          if (bits === 64) {
-            return `span ID ${++spanCount}`
-          }
-          return `trace ID ${++traceCount}`
-        }
-      }
-
+      const idGenerator = new IncrementingIdGenerator()
       const delivery = new InMemoryDelivery()
       const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
       client.start({ apiKey: VALID_API_KEY })
@@ -260,7 +241,7 @@ describe('Span', () => {
       expect(delivery).toHaveSentSpan(expect.objectContaining({
         name: 'new root span',
         parentSpanId: undefined,
-        traceId: `trace ID ${traceCount}`
+        traceId: `trace ID ${idGenerator.traceCount}`
       }))
     })
 
@@ -277,17 +258,7 @@ describe('Span', () => {
     ]
 
     it.each(parentContextOptions)('defaults to the current context when parentContext is invalid ($type)', async (options) => {
-      let spanCount = 0
-      let traceCount = 0
-      const idGenerator = {
-        generate (bits: 64 | 128) {
-          if (bits === 64) {
-            return `span ID ${++spanCount}`
-          }
-          return `trace ID ${++traceCount}`
-        }
-      }
-
+      const idGenerator = new IncrementingIdGenerator()
       const delivery = new InMemoryDelivery()
       const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
       client.start({ apiKey: VALID_API_KEY })

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -1,5 +1,5 @@
 
-import { DefaultSpanContextStorage, Kind, SpanContext } from '@bugsnag/core-performance'
+import { DefaultSpanContextStorage, Kind } from '@bugsnag/core-performance'
 import {
   ControllableBackgroundingListener,
   InMemoryDelivery,

--- a/packages/test-utilities/lib/incrementing-id-generator.ts
+++ b/packages/test-utilities/lib/incrementing-id-generator.ts
@@ -1,0 +1,14 @@
+import { type IdGenerator, type BitLength } from '@bugsnag/core-performance'
+
+class IncrementingIdGenerator implements IdGenerator {
+  spanCount: number = 0
+  traceCount: number = 0
+  generate (bits: BitLength): string {
+    if (bits === 64) {
+      return `span ID ${++this.spanCount}`
+    }
+    return `trace ID ${++this.traceCount}`
+  }
+}
+
+export default IncrementingIdGenerator

--- a/packages/test-utilities/lib/index.ts
+++ b/packages/test-utilities/lib/index.ts
@@ -11,5 +11,6 @@ export { default as resourceAttributesSource } from './resource-attributes-sourc
 export { default as spanAttributesSource } from './span-attributes-source'
 export { default as StableIdGenerator } from './stable-id-generator'
 export { default as MockSpanFactory } from './mock-span-factory'
+export { default as IncrementingIdGenerator } from './incrementing-id-generator'
 
 export * from './constants'

--- a/test/browser/features/fixtures/packages/nested-spans/index.html
+++ b/test/browser/features/fixtures/packages/nested-spans/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
+        <script src="./dist/bundle.js"></script>
+    </head>
+    <body>
+        <h1>nested-spans</h1>
+    </body>
+</html>

--- a/test/browser/features/fixtures/packages/nested-spans/package.json
+++ b/test/browser/features/fixtures/packages/nested-spans/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "nested-spans",
+    "private": true,
+    "scripts": {
+        "build": "rollup src/index.js --file dist/bundle.js --format iife --plugin @rollup/plugin-node-resolve",
+        "clean": "rm -rf dist"
+    }
+}

--- a/test/browser/features/fixtures/packages/nested-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/nested-spans/src/index.js
@@ -1,0 +1,26 @@
+import BugsnagPerformance from '@bugsnag/browser-performance'
+
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
+
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 5, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
+
+// root span
+const rootSpan = BugsnagPerformance.startSpan("RootSpan")
+
+// both of these are direct children of the root span
+const firstSpan = BugsnagPerformance.startSpan("FirstChildSpan")
+const secondChildOfRootSpan = BugsnagPerformance.startSpan("SecondChildSpan", { parentContext: rootSpan })
+
+// parentContext is null so this should start a new root span
+const newRootSpan = BugsnagPerformance.startSpan("NewRootSpan", { parentContext: null })
+
+// child of the first child span
+const childOfFirstChildSpan = BugsnagPerformance.startSpan("ChildOfFirstChildSpan", { parentContext: firstSpan } )
+
+childOfFirstChildSpan.end()
+newRootSpan.end()
+secondChildOfRootSpan.end()
+firstSpan.end()
+rootSpan.end()

--- a/test/browser/features/nested-spans.feature
+++ b/test/browser/features/nested-spans.feature
@@ -4,16 +4,20 @@ Feature: Nested spans
     Given I navigate to the test URL "/nested-spans"
     And I wait for 5 spans
 
+    # Root span should have no parent
     Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.name" equals "RootSpan"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.parentSpanId" is null
 
+    # Store the root span's id and traceId
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.id" is stored as the value "RootSpanId"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.traceId" is stored as the value "RootSpanTraceId"
 
+    # New root span should also have no parent
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "NewRootSpan"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" is null
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" does not equal the stored value "RootSpanTraceId"
 
+    # All child spans should have parents
     And a span named 'FirstChildSpan' has a parent named 'RootSpan'
     And a span named 'SecondChildSpan' has a parent named 'RootSpan'
     And a span named 'ChildOfFirstChildSpan' has a parent named 'FirstChildSpan'

--- a/test/browser/features/nested-spans.feature
+++ b/test/browser/features/nested-spans.feature
@@ -1,0 +1,20 @@
+Feature: Nested spans
+
+  Scenario: Spans are nested under the correct parent context
+    Given I navigate to the test URL "/nested-spans"
+    And I wait for 5 spans
+
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.name" equals "RootSpan"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.parentSpanId" is null
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.id" is stored as the value "RootSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.4.traceId" is stored as the value "RootSpanTraceId"
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "NewRootSpan"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" is null
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" does not equal the stored value "RootSpanTraceId"
+
+    And a span named 'FirstChildSpan' has a parent named 'RootSpan'
+    And a span named 'SecondChildSpan' has a parent named 'RootSpan'
+    And a span named 'ChildOfFirstChildSpan' has a parent named 'FirstChildSpan'
+


### PR DESCRIPTION
## Goal

This PR adds a new optional `parentContext` option to `SpanOptions`

```ts
interface SpanOptions {
	parentContext?: SpanContext | null
}
```

A new optional `parentSpanId` field has also been added to internal and delivery spans - this is only set if the span has a parent

When a `parentContext` is specified in `SpanOptions`, the created span will become a child of that context. This means that the span's `parentSpanId` will be set to the parent's `id`, and the span's `traceId` will be set to the parent's `traceId`.

If no `parentContext` is specified, by default new spans will become children of `currentSpanContext`. 

if there is no `currentSpanContext`, or `parentContext` is set explicitly to `null`, the created span is a new root span - this means `parentSpanId` is not set and a new `traceId` is generated 


## Testing

Added unit tests for the new `parentContext` option as well as a new mazerunner scenario to test that nested spans are sent with the correct parentage.