### PR TITLE
Prevent network spans from becoming the current span context

### DIFF
--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -32,7 +32,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
 
     const span = this.spanFactory.startSpan(
       `[HTTP]/${startContext.method.toUpperCase()}`,
-      { startTime: startContext.startTime }
+      { startTime: startContext.startTime, makeCurrentContext: false }
     )
 
     span.setAttribute('bugsnag.span.category', 'network')


### PR DESCRIPTION
## Goal

This PR prevents auto-instrumented network spans from becoming the current span context, since network spans should not have any children