### PR TITLE
Add `device.id` as a resource attribute

### DIFF
--- a/.github/create-browser-bundle-from-npm
+++ b/.github/create-browser-bundle-from-npm
@@ -10,15 +10,17 @@ import BugsnagPerformance from '@bugsnag/browser-performance'
 BugsnagPerformance.start('abcdefabcdefabcdefabcdefabcdef12')
 JAVASCRIPT
 
-npm install @rollup/plugin-node-resolve @rollup/plugin-terser
+npm install @rollup/plugin-node-resolve @rollup/plugin-commonjs @rollup/plugin-terser
 
 npx rollup build/index.js \
   --file build/bundle.js \
   --format iife \
-  --plugin @rollup/plugin-node-resolve
+  --plugin @rollup/plugin-commonjs \
+  --plugin '@rollup/plugin-node-resolve={ browser: true }'
 
 npx rollup build/index.js \
   --file build/bundle.min.js \
   --format iife \
-  --plugin @rollup/plugin-node-resolve \
+  --plugin @rollup/plugin-commonjs \
+  --plugin '@rollup/plugin-node-resolve={ browser: true }' \
   --plugin @rollup/plugin-terser

--- a/package-lock.json
+++ b/package-lock.json
@@ -653,6 +653,11 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@bugsnag/cuid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.2.tgz",
+      "integrity": "sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ=="
+    },
     "node_modules/@bugsnag/js-performance": {
       "resolved": "packages/platforms/js",
       "link": true
@@ -11941,7 +11946,8 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^0.0.2"
+        "@bugsnag/core-performance": "^0.0.2",
+        "@bugsnag/cuid": "^3.0.2"
       }
     },
     "packages/platforms/js": {

--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -43,7 +43,8 @@ export class ResourceAttributes extends SpanAttributes {
   }
 }
 
-export type ResourceAttributeSource<C extends Configuration> = (configuration: InternalConfiguration<C>) => ResourceAttributes
+export type ResourceAttributeSource<C extends Configuration>
+  = (configuration: InternalConfiguration<C>) => Promise<ResourceAttributes>
 
 export interface JsonAttribute {
   key: string

--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -79,11 +79,13 @@ export class BatchProcessor<C extends Configuration> implements Processor {
       return
     }
 
+    const resourceAttributes = await this.resourceAttributeSource(this.configuration)
+
     const payload = {
       resourceSpans: [
         {
           resource: {
-            attributes: this.resourceAttributeSource(this.configuration).toJson()
+            attributes: resourceAttributes.toJson()
           },
           scopeSpans: [{ spans: batch }]
         }

--- a/packages/core/lib/persistence.ts
+++ b/packages/core/lib/persistence.ts
@@ -5,6 +5,8 @@ export interface PersistedProbability {
 
 export interface PersistencePayloadMap {
   'bugsnag-sampling-probability': PersistedProbability
+  // used for device ID
+  'bugsnag-anonymous-id': string
 }
 
 export type PersistenceKey = keyof PersistencePayloadMap
@@ -19,7 +21,7 @@ export class InMemoryPersistence implements Persistence {
   private readonly persistedItems = new Map<PersistenceKey, PersistencePayload>()
 
   async load<K extends PersistenceKey> (key: K): Promise<PersistencePayloadMap[K] | undefined> {
-    return this.persistedItems.get(key)
+    return this.persistedItems.get(key) as PersistencePayloadMap[K] | undefined
   }
 
   async save<K extends PersistenceKey> (key: K, value: PersistencePayloadMap[K]): Promise<void> {

--- a/packages/core/tests/batch-processor.test.ts
+++ b/packages/core/tests/batch-processor.test.ts
@@ -14,7 +14,7 @@ import {
 jest.useFakeTimers()
 
 describe('BatchProcessor', () => {
-  it('delivers after reaching the specified span limit', () => {
+  it('delivers after reaching the specified span limit', async () => {
     const delivery = new InMemoryDelivery()
     const batchProcessor = new BatchProcessor(
       delivery,
@@ -35,10 +35,12 @@ describe('BatchProcessor', () => {
 
     batchProcessor.add(createEndedSpan())
 
+    await jest.advanceTimersByTimeAsync(0)
+
     expect(delivery.requests).toHaveLength(1)
   })
 
-  it('delivers after the specified time limit', () => {
+  it('delivers after the specified time limit', async () => {
     const delivery = new InMemoryDelivery()
     const batchProcessor = new BatchProcessor(
       delivery,
@@ -54,12 +56,12 @@ describe('BatchProcessor', () => {
 
     expect(delivery.requests).toHaveLength(0)
 
-    jest.advanceTimersByTime(30_000)
+    await jest.advanceTimersByTimeAsync(30_000)
 
     expect(delivery.requests).toHaveLength(1)
   })
 
-  it('restarts the timer when calling .add()', () => {
+  it('restarts the timer when calling .add()', async () => {
     const delivery = new InMemoryDelivery()
     const batchProcessor = new BatchProcessor(
       delivery,
@@ -73,19 +75,19 @@ describe('BatchProcessor', () => {
 
     batchProcessor.add(createEndedSpan())
 
-    jest.advanceTimersByTime(20_000)
+    await jest.advanceTimersByTimeAsync(20_000)
     expect(delivery.requests).toHaveLength(0)
 
     batchProcessor.add(createEndedSpan())
 
-    jest.advanceTimersByTime(20_000)
+    await jest.advanceTimersByTimeAsync(20_000)
     expect(delivery.requests).toHaveLength(0)
 
-    jest.advanceTimersByTime(10_000)
+    await jest.advanceTimersByTimeAsync(10_000)
     expect(delivery.requests).toHaveLength(1)
   })
 
-  it('prevents delivery if releaseStage not in enabledReleaseStages', () => {
+  it('prevents delivery if releaseStage not in enabledReleaseStages', async () => {
     const delivery = new InMemoryDelivery()
     const batchProcessor = new BatchProcessor(
       delivery,
@@ -99,7 +101,7 @@ describe('BatchProcessor', () => {
 
     batchProcessor.add(createEndedSpan())
 
-    jest.runOnlyPendingTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     expect(delivery.requests).toHaveLength(0)
   })

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -205,6 +205,8 @@ describe('Core', () => {
           // deliver both spans we just ended
           backgroundingListener.sendToBackground()
 
+          await jest.advanceTimersByTimeAsync(0)
+
           expect(delivery.requests).toHaveLength(1)
 
           const payload = delivery.requests[0]

--- a/packages/core/tests/persistence.test.ts
+++ b/packages/core/tests/persistence.test.ts
@@ -1,24 +1,29 @@
-import { InMemoryPersistence } from '../lib/persistence'
+import {
+  type PersistenceKey,
+  type PersistencePayload,
+  InMemoryPersistence
+} from '../lib/persistence'
 
 describe('InMemoryPersistence', () => {
-  it('can save an item', async () => {
+  const payloads: Array<{ key: PersistenceKey, value: PersistencePayload }> = [
+    { key: 'bugsnag-sampling-probability', value: { value: 0.5, time: 12345678 } },
+    { key: 'bugsnag-anonymous-id', value: 'an anonymous id' }
+  ]
+
+  it.each(payloads)('can save $key', async ({ key, value }) => {
     const persistence = new InMemoryPersistence()
-    const probability = {
-      value: 0.5,
-      time: 12345678
-    }
 
-    await persistence.save('bugsnag-sampling-probability', probability)
+    await persistence.save(key, value)
 
-    const actual = await persistence.load('bugsnag-sampling-probability')
+    const actual = await persistence.load(key)
 
-    expect(actual).toStrictEqual(probability)
+    expect(actual).toStrictEqual(value)
   })
 
-  it('returns undefined when no item is saved', async () => {
+  it.each(payloads)('returns undefined when no $key is saved', async ({ key }) => {
     const persistence = new InMemoryPersistence()
 
-    const actual = await persistence.load('bugsnag-sampling-probability')
+    const actual = await persistence.load(key)
 
     expect(actual).toBeUndefined()
   })

--- a/packages/platforms/browser/cuid.d.ts
+++ b/packages/platforms/browser/cuid.d.ts
@@ -1,0 +1,5 @@
+declare module '@bugsnag/cuid' {
+  declare function cuid (): string
+
+  export default cuid
+}

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -16,8 +16,9 @@ import { WebVitals } from './web-vitals'
 
 const backgroundingListener = createBrowserBackgroundingListener(document)
 const clock = createClock(performance, backgroundingListener)
+const persistence = makeBrowserPersistence(window)
 const spanAttributesSource = createSpanAttributesSource(document.title, window.location.href)
-const resourceAttributesSource = createResourceAttributesSource(navigator)
+const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
 const fetchRequestTracker = createFetchRequestTracker(window, clock)
 const xhrRequestTracker = createXmlHttpRequestTracker(window, clock)
 const webVitals = new WebVitals(performance, clock, window.PerformanceObserver)
@@ -51,7 +52,7 @@ const BugsnagPerformance = createClient({
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
     new RouteChangePlugin(spanFactory, window.location)
   ],
-  persistence: makeBrowserPersistence(window)
+  persistence
 })
 
 export default BugsnagPerformance

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -12,6 +12,7 @@ export interface BrowserSchema extends CoreSchema {
   autoInstrumentFullPageLoads: ConfigOption<boolean>
   autoInstrumentNetworkRequests: ConfigOption<boolean>
   autoInstrumentRouteChanges: ConfigOption<boolean>
+  generateAnonymousId: ConfigOption<boolean>
   routingProvider: ConfigOption<RoutingProvider>
   settleIgnoreUrls: ConfigOption<Array<string | RegExp>>
   networkInstrumentationIgnoreUrls: ConfigOption<Array<string | RegExp>>
@@ -21,6 +22,7 @@ export interface BrowserConfiguration extends Configuration {
   autoInstrumentFullPageLoads?: boolean
   autoInstrumentNetworkRequests?: boolean
   autoInstrumentRouteChanges?: boolean
+  generateAnonymousId?: boolean
   routingProvider?: RoutingProvider
   settleIgnoreUrls?: Array<string | RegExp>
   networkInstrumentationIgnoreUrls?: Array<string | RegExp>
@@ -44,6 +46,11 @@ export function createSchema (hostname: string, defaultRoutingProvider: RoutingP
       validate: isBoolean
     },
     autoInstrumentRouteChanges: {
+      defaultValue: true,
+      message: 'should be true|false',
+      validate: isBoolean
+    },
+    generateAnonymousId: {
       defaultValue: true,
       message: 'should be true|false',
       validate: isBoolean

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -1,3 +1,4 @@
+import cuid from '@bugsnag/cuid'
 import { ResourceAttributes, type Persistence, type ResourceAttributeSource } from '@bugsnag/core-performance'
 import { type BrowserConfiguration } from './config'
 
@@ -24,9 +25,15 @@ function createResourceAttributesSource (
     }
 
     getDeviceId.then(maybeDeviceId => {
-      if (maybeDeviceId) {
-        attributes.set('device.id', maybeDeviceId)
+      // use the persisted value or generate a new ID
+      const deviceId = maybeDeviceId || cuid()
+
+      // if there was no persisted value, save the newly generated ID
+      if (!maybeDeviceId) {
+        persistence.save('bugsnag-anonymous-id', deviceId)
       }
+
+      attributes.set('device.id', deviceId)
     })
 
     return attributes

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -1,7 +1,12 @@
-import { ResourceAttributes, type ResourceAttributeSource } from '@bugsnag/core-performance'
+import { ResourceAttributes, type Persistence, type ResourceAttributeSource } from '@bugsnag/core-performance'
 import { type BrowserConfiguration } from './config'
 
-function createResourceAttributesSource (navigator: Navigator): ResourceAttributeSource<BrowserConfiguration> {
+function createResourceAttributesSource (
+  navigator: Navigator,
+  persistence: Persistence
+): ResourceAttributeSource<BrowserConfiguration> {
+  const getDeviceId = persistence.load('bugsnag-anonymous-id')
+
   return function resourceAttributesSource (config) {
     const attributes = new ResourceAttributes(
       config.releaseStage,
@@ -17,6 +22,12 @@ function createResourceAttributesSource (navigator: Navigator): ResourceAttribut
       attributes.set('browser.platform', navigator.userAgentData.platform)
       attributes.set('browser.mobile', navigator.userAgentData.mobile)
     }
+
+    getDeviceId.then(maybeDeviceId => {
+      if (maybeDeviceId) {
+        attributes.set('device.id', maybeDeviceId)
+      }
+    })
 
     return attributes
   }

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -52,13 +52,16 @@ function createResourceAttributesSource (
         attributes.set('device.id', deviceId)
       } else {
         // otherwise add it when the promise resolves
-        getDeviceId.then(deviceId => {
-          attributes.set('device.id', deviceId)
-        })
+        return getDeviceId
+          .then(deviceId => {
+            attributes.set('device.id', deviceId)
+
+            return attributes
+          })
       }
     }
 
-    return attributes
+    return Promise.resolve(attributes)
   }
 }
 

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -6,6 +6,9 @@ function createResourceAttributesSource (
   navigator: Navigator,
   persistence: Persistence
 ): ResourceAttributeSource<BrowserConfiguration> {
+  let getDeviceId: Promise<string> | undefined
+  let deviceId: string | undefined
+
   return function resourceAttributesSource (config) {
     const attributes = new ResourceAttributes(
       config.releaseStage,
@@ -23,17 +26,36 @@ function createResourceAttributesSource (
     }
 
     if (config.generateAnonymousId) {
-      persistence.load('bugsnag-anonymous-id').then(maybeDeviceId => {
-        // use the persisted value or generate a new ID
-        const deviceId = maybeDeviceId || cuid()
+      // ensure we only load/generate the anonymous ID once no matter how many
+      // times we're called, otherwise we could generate different IDs on
+      // different calls as cuids are partly time based
+      if (!getDeviceId) {
+        getDeviceId = persistence.load('bugsnag-anonymous-id')
+          .then(maybeAnonymousId => {
+            // use the persisted value or generate a new ID
+            const anonymousId = maybeAnonymousId || cuid()
 
-        // if there was no persisted value, save the newly generated ID
-        if (!maybeDeviceId) {
-          persistence.save('bugsnag-anonymous-id', deviceId)
-        }
+            // if there was no persisted value, save the newly generated ID
+            if (!maybeAnonymousId) {
+              persistence.save('bugsnag-anonymous-id', anonymousId)
+            }
 
+            // store the device ID so we can set it synchronously in future
+            deviceId = anonymousId
+
+            return deviceId
+          })
+      }
+
+      if (deviceId) {
+        // set device ID synchronously if it's already available
         attributes.set('device.id', deviceId)
-      })
+      } else {
+        // otherwise add it when the promise resolves
+        getDeviceId.then(deviceId => {
+          attributes.set('device.id', deviceId)
+        })
+      }
     }
 
     return attributes

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -19,7 +19,8 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^0.0.2"
+    "@bugsnag/core-performance": "^0.0.2",
+    "@bugsnag/cuid": "^3.0.2"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/platforms/browser/rollup.config.mjs
+++ b/packages/platforms/browser/rollup.config.mjs
@@ -1,4 +1,6 @@
 import fs from 'fs'
 import createRollupConfig from '../../../.rollup/index.mjs'
 
-export default createRollupConfig()
+export default createRollupConfig({
+  external: ['@bugsnag/cuid'],
+})

--- a/packages/platforms/browser/tests/persistence.test.ts
+++ b/packages/platforms/browser/tests/persistence.test.ts
@@ -44,6 +44,15 @@ describe('BrowserPersistence', () => {
     expect(actual).toStrictEqual(probability)
   })
 
+  it('can save anonymous ID', async () => {
+    const persistence = makeBrowserPersistence(window)
+
+    await persistence.save('bugsnag-anonymous-id', 'c1234567890abcdefghijklmnop')
+
+    const actual = await persistence.load('bugsnag-anonymous-id')
+    expect(actual).toBe('c1234567890abcdefghijklmnop')
+  })
+
   it('saves to localStorage', async () => {
     const persistence = makeBrowserPersistence(window)
     const probability = {
@@ -173,6 +182,15 @@ describe('BrowserPersistence', () => {
 
     // this load won't return anything as the stored probability is not valid
     const actual = await persistence.load('bugsnag-sampling-probability')
+    expect(actual).toBeUndefined()
+  })
+
+  it('ignores invalid anonymous ID values on load', async () => {
+    const persistence = makeBrowserPersistence(window)
+
+    await persistence.save('bugsnag-anonymous-id', 'an anonymous id :)')
+
+    const actual = await persistence.load('bugsnag-anonymous-id')
     expect(actual).toBeUndefined()
   })
 })

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -17,15 +17,17 @@ describe('resourceAttributesSource', () => {
     }
 
     await persistence.save('bugsnag-anonymous-id', 'c1234567890abcdefghijklmnop')
+    expect(await persistence.load('bugsnag-anonymous-id')).toBe('c1234567890abcdefghijklmnop')
 
     const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
     const resourceAttributes = resourceAttributesSource(
       createConfiguration<BrowserConfiguration>({ releaseStage: 'test', appVersion: '1.0.0' })
     )
 
-    // wait for the anyonmous ID to be available (we don't actually need to load
-    // it, just wait for the next iteration of the event loop)
-    await persistence.load('bugsnag-anonymous-id')
+    await new Promise<void>(resolve => { resolve() })
+
+    // ensure the anyonmous ID hasn't changed
+    expect(await persistence.load('bugsnag-anonymous-id')).toBe('c1234567890abcdefghijklmnop')
 
     expect(resourceAttributes.toJson()).toEqual([
       { key: 'deployment.environment', value: { stringValue: 'test' } },
@@ -103,6 +105,47 @@ describe('resourceAttributesSource', () => {
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
       { key: 'device.id', value: { stringValue: deviceId } }
     ])
+  })
+
+  it('only generates a single device.id across multiple calls', async () => {
+    const persistence = new InMemoryPersistence()
+    const navigator = {
+      ...window.navigator,
+      userAgentData: undefined,
+      userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
+    }
+
+    // ensure no device ID is persisted
+    expect(await persistence.load('bugsnag-anonymous-id')).toBeUndefined()
+
+    const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
+    const configuration = createConfiguration<BrowserConfiguration>()
+
+    const resourceAttributes1 = resourceAttributesSource(configuration)
+    const resourceAttributes2 = resourceAttributesSource(configuration)
+    const resourceAttributes3 = resourceAttributesSource(configuration)
+
+    await new Promise<void>(resolve => { resolve() })
+    const deviceId = await persistence.load('bugsnag-anonymous-id')
+
+    expect(resourceAttributes1.toJson()).toStrictEqual([
+      { key: 'deployment.environment', value: { stringValue: 'production' } },
+      { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
+      { key: 'device.id', value: { stringValue: deviceId } }
+    ])
+
+    expect(resourceAttributes1.toJson()).toStrictEqual(resourceAttributes2.toJson())
+    expect(resourceAttributes2.toJson()).toStrictEqual(resourceAttributes3.toJson())
+
+    // device ID is now available synchronously so we don't need to wait for it
+    // to be available on this call
+    const resourceAttributes4 = resourceAttributesSource(configuration)
+    expect(resourceAttributes3.toJson()).toStrictEqual(resourceAttributes4.toJson())
+
+    // device ID shouldn't have changed
+    expect(await persistence.load('bugsnag-anonymous-id')).toBe(deviceId)
   })
 
   it('does not generate a device.id if generateAnonymousId is false', async () => {

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -2,27 +2,38 @@
  * @jest-environment jsdom
  */
 
+import { InMemoryPersistence } from '@bugsnag/core-performance'
 import { createConfiguration } from '@bugsnag/js-performance-test-utilities'
 import { type BrowserConfiguration } from '../lib/config'
 import createResourceAttributesSource from '../lib/resource-attributes-source'
 
 describe('resourceAttributesSource', () => {
-  it('contains expected values', () => {
+  it('contains expected values', async () => {
+    const persistence = new InMemoryPersistence()
     const navigator = {
       ...window.navigator,
       userAgentData: undefined,
       userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
     }
 
-    const resourceAttributesSource = createResourceAttributesSource(navigator)
-    const resourceAttributes = resourceAttributesSource(createConfiguration<BrowserConfiguration>({ releaseStage: 'test', appVersion: '1.0.0' }))
+    await persistence.save('bugsnag-anonymous-id', 'c1234567890abcdefghijklmnop')
+
+    const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
+    const resourceAttributes = resourceAttributesSource(
+      createConfiguration<BrowserConfiguration>({ releaseStage: 'test', appVersion: '1.0.0' })
+    )
+
+    // wait for the anyonmous ID to be available (we don't actually need to load
+    // it, just wait for the next iteration of the event loop)
+    await persistence.load('bugsnag-anonymous-id')
 
     expect(resourceAttributes.toJson()).toEqual([
       { key: 'deployment.environment', value: { stringValue: 'test' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
       { key: 'service.version', value: { stringValue: '1.0.0' } },
-      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
+      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
+      { key: 'device.id', value: { stringValue: 'c1234567890abcdefghijklmnop' } }
     ])
   })
 
@@ -33,7 +44,7 @@ describe('resourceAttributesSource', () => {
       userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
     }
 
-    const resourceAttributesSource = createResourceAttributesSource(navigator)
+    const resourceAttributesSource = createResourceAttributesSource(navigator, new InMemoryPersistence())
     const resourceAttributes = resourceAttributesSource(createConfiguration())
 
     expect(resourceAttributes.toJson()).toEqual([
@@ -54,7 +65,7 @@ describe('resourceAttributesSource', () => {
       userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
     }
 
-    const resourceAttributesSource = createResourceAttributesSource(navigator)
+    const resourceAttributesSource = createResourceAttributesSource(navigator, new InMemoryPersistence())
     const resourceAttributes = resourceAttributesSource(createConfiguration())
 
     expect(resourceAttributes.toJson()).toEqual([
@@ -64,6 +75,27 @@ describe('resourceAttributesSource', () => {
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
       { key: 'browser.platform', value: { stringValue: 'macOS' } },
       { key: 'browser.mobile', value: { boolValue: false } }
+    ])
+  })
+
+  it('excludes device.id if it is not persisted', async () => {
+    const persistence = new InMemoryPersistence()
+    const navigator = {
+      ...window.navigator,
+      userAgentData: undefined,
+      userAgent: 'a jest test, (like Gecko and WebKit and also Blink) etc...'
+    }
+
+    const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
+    const resourceAttributes = resourceAttributesSource(createConfiguration())
+
+    await persistence.load('bugsnag-anonymous-id')
+
+    expect(resourceAttributes.toJson()).toEqual([
+      { key: 'deployment.environment', value: { stringValue: 'production' } },
+      { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
+      { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
     ])
   })
 })

--- a/packages/platforms/browser/tests/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/route-change-plugin.test.ts
@@ -71,8 +71,8 @@ describe('RouteChangePlugin', () => {
     testClient.start({ apiKey: VALID_API_KEY })
 
     history.back()
-    await jest.runOnlyPendingTimersAsync()
     jest.runAllTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     const firstSpan = expect.objectContaining({
       name: '[RouteChange]/first-route',
@@ -97,6 +97,7 @@ describe('RouteChangePlugin', () => {
 
     history.forward()
     jest.runAllTimers()
+    await jest.runOnlyPendingTimersAsync()
 
     expect(delivery).toHaveSentSpan(secondSpan)
 

--- a/packages/platforms/browser/tsconfig.json
+++ b/packages/platforms/browser/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../../tsconfig.json",
   "include": ["lib/*"],
   "compilerOptions": {
-    "types": ["./navigator-user-agent-data"]
+    "types": ["./navigator-user-agent-data", "./cuid"]
   }
 }

--- a/packages/test-utilities/lib/create-configuration.ts
+++ b/packages/test-utilities/lib/create-configuration.ts
@@ -6,6 +6,7 @@ function createConfiguration<C extends Configuration> (overrides: Partial<C> = {
     autoInstrumentNetworkRequests: false,
     apiKey: 'abcdefabcdefabcdefabcdefabcdef12',
     endpoint: '/traces',
+    generateAnonymousId: true,
     releaseStage: 'production',
     enabledReleaseStages: null,
     maximumBatchSize: 100,

--- a/packages/test-utilities/lib/resource-attributes-source.ts
+++ b/packages/test-utilities/lib/resource-attributes-source.ts
@@ -1,6 +1,6 @@
 import { ResourceAttributes, type Configuration, type ResourceAttributeSource } from '@bugsnag/core-performance'
 
-const resourceAttributesSource: ResourceAttributeSource<Configuration> = () => {
+const resourceAttributesSource: ResourceAttributeSource<Configuration> = async () => {
   return new ResourceAttributes('test', '3.4.5', 'bugsnag.performance.core', '1.2.3')
 }
 

--- a/test/browser/features/device-id.feature
+++ b/test/browser/features/device-id.feature
@@ -1,0 +1,15 @@
+Feature: Device ID persistence
+
+  Scenario: persisted device ID is used if present
+    # load the page and persist an ID
+    Given I navigate to the test URL "/retry-scenario"
+    And I wait to receive a sampling request
+    And I store the device ID "c1234567890abcdefghijklmnop"
+
+    # reload the page to prove the ID was persisted and not just available in
+    # memory somehow
+    When I navigate to the test URL "/retry-scenario"
+    And I wait to receive a sampling request
+    And I click the element "send-first-span"
+    And I wait for 1 span
+    Then the trace payload field "resourceSpans.0.resource" string attribute "device.id" equals "c1234567890abcdefghijklmnop"

--- a/test/browser/features/fixtures/package.json
+++ b/test/browser/features/fixtures/package.json
@@ -5,6 +5,7 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "rollup": "^3.18.0"
   }

--- a/test/browser/features/fixtures/packages/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/rollup.config.mjs
@@ -1,4 +1,5 @@
 import nodeResolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
 
 export default {
   input: 'src/index.js',
@@ -6,5 +7,5 @@ export default {
     file: 'dist/bundle.js',
     format: 'iife'
   },
-  plugins: [nodeResolve({ browser: true })],
+  plugins: [nodeResolve({ browser: true }), commonjs()],
 }

--- a/test/browser/features/manual-spans.feature
+++ b/test/browser/features/manual-spans.feature
@@ -18,6 +18,7 @@ Feature: Manual creation of spans
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.browser"
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals the stored value "telemetry.sdk.version"
     And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals the stored value "environment"
+    And the trace payload field "resourceSpans.0.resource" string attribute "device.id" matches the regex "^c[0-9a-z]{20,32}$"
 
   @chromium_only @local_only
   Scenario: userAgentData is included in custom span

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -131,6 +131,11 @@ Then("the span named {string} is a valid full page load span") do |span_name|
   end
 end
 
+Given("I store the device ID {string}") do |device_id|
+  driver = Maze.driver.instance_variable_get(:@driver)
+  driver.execute_script("localStorage.setItem('bugsnag-anonymous-id', '#{device_id}')")
+end
+
 module Maze
   module Driver
     class Browser


### PR DESCRIPTION
## Goal

Add `device.id` as a resource attribute using `@bugsnag/cuid` and the `bugsnag-anonymous-id` key so the IDs are shared with the notifier: https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-browser-device/device.js

This required changing `ResourceAttributeSource` to be asynchronous as we need to fetch the device ID from persistence at least once but can't until we've read the `generateAnonymousId` config option