### PR TITLE
Add `isFirstClass` span option controlling the `bugsnag.span.first_class` attribute

### DIFF
--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -109,6 +109,7 @@ export class SpanInternal implements SpanContext {
 
 export interface SpanOptions {
   startTime?: Time
+  isFirstClass?: boolean
 }
 
 export class SpanFactory {
@@ -154,6 +155,11 @@ export class SpanFactory {
     const spanId = this.idGenerator.generate(64)
     const traceId = this.idGenerator.generate(128)
     const attributes = new SpanAttributes(this.spanAttributesSource())
+
+    if (options && typeof options.isFirstClass === 'boolean') {
+      attributes.set('bugsnag.span.first_class', options.isFirstClass)
+    }
+
     const span = new SpanInternal(spanId, traceId, name, safeStartTime, attributes)
 
     // don't track spans that are started while the app is backgrounded

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -96,6 +96,103 @@ describe('SpanInternal', () => {
   })
 })
 
+describe('SpanFactory', () => {
+  describe('startSpan', () => {
+    it('omits first class span attribute by default', () => {
+      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+      const sampler = new Sampler(0.5)
+      const delivery = { send: jest.fn() }
+      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+      const spanFactory = new SpanFactory(
+        processor,
+        sampler,
+        new StableIdGenerator(),
+        spanAttributesSource,
+        new IncrementingClock(),
+        new ControllableBackgroundingListener(),
+        jestLogger
+      )
+
+      const span = spanFactory.startSpan('name')
+
+      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+      expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
+    })
+
+    it('creates first class spans when isFirstClass is true', () => {
+      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+      const sampler = new Sampler(0.5)
+      const delivery = { send: jest.fn() }
+      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+      const spanFactory = new SpanFactory(
+        processor,
+        sampler,
+        new StableIdGenerator(),
+        spanAttributesSource,
+        new IncrementingClock(),
+        new ControllableBackgroundingListener(),
+        jestLogger
+      )
+
+      const span = spanFactory.startSpan('name', { isFirstClass: true })
+
+      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+      expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(true)
+    })
+
+    it('does not create first class spans when isFirstClass is false', () => {
+      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+      const sampler = new Sampler(0.5)
+      const delivery = { send: jest.fn() }
+      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+      const spanFactory = new SpanFactory(
+        processor,
+        sampler,
+        new StableIdGenerator(),
+        spanAttributesSource,
+        new IncrementingClock(),
+        new ControllableBackgroundingListener(),
+        jestLogger
+      )
+
+      const span = spanFactory.startSpan('name', { isFirstClass: false })
+
+      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+      expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(false)
+    })
+
+    it.each([
+      null,
+      undefined,
+      1,
+      0,
+      'true',
+      'false',
+      [true, false]
+    ])('omits first class attribute when isFirstClass is %s', (isFirstClass) => {
+      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+      const sampler = new Sampler(0.5)
+      const delivery = { send: jest.fn() }
+      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+      const spanFactory = new SpanFactory(
+        processor,
+        sampler,
+        new StableIdGenerator(),
+        spanAttributesSource,
+        new IncrementingClock(),
+        new ControllableBackgroundingListener(),
+        jestLogger
+      )
+
+      // @ts-expect-error 'isFirstClass' is the wrong type
+      const span = spanFactory.startSpan('name', { isFirstClass })
+
+      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+      expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
+    })
+  })
+})
+
 describe('Span', () => {
   describe('client.startSpan()', () => {
     it('returns a Span', () => {

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -16,7 +16,9 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
     let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
 
     configuration.routingProvider.listenForRouteChanges((route, trigger, options) => {
-      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, options)
+      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, {
+        startTime: options ? options.startTime : undefined
+      })
 
       span.setAttribute('bugsnag.span.category', 'route_change')
       span.setAttribute('bugsnag.browser.page.route', route)

--- a/packages/platforms/browser/lib/routing-provider.ts
+++ b/packages/platforms/browser/lib/routing-provider.ts
@@ -1,6 +1,7 @@
 import { isObject, type Span, type SpanOptions } from '@bugsnag/core-performance'
 
-export type StartRouteChangeCallback = (route: string, trigger: string, options?: SpanOptions) => Span
+export type RouteChangeSpanOptions = Omit<SpanOptions, 'isFirstClass'>
+export type StartRouteChangeCallback = (route: string, trigger: string, options?: RouteChangeSpanOptions) => Span
 
 export interface RoutingProvider {
   resolveRoute: (url: URL) => string

--- a/packages/platforms/browser/lib/span-attributes-source.ts
+++ b/packages/platforms/browser/lib/span-attributes-source.ts
@@ -4,7 +4,6 @@ const createSpanAttributesSource = (title: string, url: string): SpanAttributesS
   return () => {
     const spanAttributes = new Map<string, SpanAttribute>()
     spanAttributes.set('bugsnag.span.category', 'custom')
-    spanAttributes.set('bugsnag.span.first_class', true)
     spanAttributes.set('bugsnag.browser.page.url', url)
     spanAttributes.set('bugsnag.browser.page.title', title)
 

--- a/packages/platforms/browser/tests/span-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/span-attributes-source.test.ts
@@ -13,7 +13,6 @@ describe('spanAttributesSource', () => {
     const spanAttributes = spanAttributesSource()
     expect(Array.from(spanAttributes.entries())).toEqual([
       ['bugsnag.span.category', 'custom'],
-      ['bugsnag.span.first_class', true],
       ['bugsnag.browser.page.url', 'https://www.bugsnag.com'],
       ['bugsnag.browser.page.title', 'the page title']
     ])

--- a/test/browser/features/fixtures/packages/manual-span/src/index.js
+++ b/test/browser/features/fixtures/packages/manual-span/src/index.js
@@ -6,5 +6,11 @@ const endpoint = parameters.get('endpoint')
 
 BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
-const span = BugsnagPerformance.startSpan("Custom/ManualSpanScenario")
+const spanOptions = {}
+
+if (parameters.has('isFirstClass')) {
+  spanOptions.isFirstClass = JSON.parse(parameters.get('isFirstClass'))
+}
+
+const span = BugsnagPerformance.startSpan("Custom/ManualSpanScenario", spanOptions)
 span.end()

--- a/test/browser/features/manual-spans.feature
+++ b/test/browser/features/manual-spans.feature
@@ -19,6 +19,26 @@ Feature: Manual creation of spans
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals the stored value "telemetry.sdk.version"
     And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals the stored value "environment"
 
+  Scenario: isFirstClass span option can be set to false
+    Given I navigate to the test URL "/manual-span?isFirstClass=false"
+    And I wait to receive a sampling request
+    And I wait for 1 span
+
+    # Check the initial probability request
+    Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
+
+    And the trace "Bugsnag-Span-Sampling" header equals "1.0:1"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.span.first_class" is false
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.browser"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals the stored value "telemetry.sdk.version"
+    And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals the stored value "environment"
+
   @chromium_only @local_only
   Scenario: userAgentData is included in custom span
     Given I navigate to the test URL "/manual-span"

--- a/test/browser/features/route-change-spans.feature
+++ b/test/browser/features/route-change-spans.feature
@@ -8,13 +8,11 @@ Feature: Route change spans
         Then a span named "[RouteChange]/new-route" contains the attributes: 
             | attribute                                 | type         | value                | 
             | bugsnag.span.category                     | stringValue  | route_change         |
-            | bugsnag.span.first_class                  | boolValue    | true                 |
             | bugsnag.browser.page.title                | stringValue  | Route change spans   |
             | bugsnag.browser.page.route                | stringValue  | /new-route           |
             | bugsnag.browser.page.previous_route       | stringValue  | /route-change-spans/ |
             | bugsnag.browser.page.route_change.trigger | stringValue  | pushState            |
 
- 
     Scenario: Hyperlinks within a page
         Given I navigate to the test URL "/route-change-spans"
         And I click the element "go-to-anchor"
@@ -23,9 +21,7 @@ Feature: Route change spans
         Then a span named "[RouteChange]/route-change-spans/" contains the attributes: 
             | attribute                                 | type         | value                | 
             | bugsnag.span.category                     | stringValue  | route_change         |
-            | bugsnag.span.first_class                  | boolValue    | true                 |
             | bugsnag.browser.page.title                | stringValue  | Route change spans   |
             | bugsnag.browser.page.route                | stringValue  | /route-change-spans/ |
             | bugsnag.browser.page.previous_route       | stringValue  | /route-change-spans/ |
             | bugsnag.browser.page.route_change.trigger | stringValue  | popstate             |
- 


### PR DESCRIPTION
## Goal

Add `isFirstClass` span option controlling the `bugsnag.span.first_class` attribute

This defaults to `true` for all spans (custom, network, page load & route changes) and can be set to `false` for custom spans only

This necessitated changing the `StartRouteChangeCallback` options parameter to omit `isFirstClass` as route change spans are always first class (this is the same for network and page load spans but users can't supply options for those span types)