### PR TITLE
Remove 'samplingProbability' configuration option

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -56,7 +56,6 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
       ProbabilityManager.create(
         options.persistence,
         sampler,
-        configuration.samplingProbability,
         new ProbabilityFetcher(delivery)
       ).then((manager: ProbabilityManager) => {
         processor = new BatchProcessor(

--- a/packages/core/lib/probability-manager.ts
+++ b/packages/core/lib/probability-manager.ts
@@ -9,7 +9,6 @@ class ProbabilityManager {
   static async create (
     persistence: Persistence,
     sampler: ReadWriteSampler,
-    configuredProbability: number,
     probabilityFetcher: ProbabilityFetcher
   ) {
     const persistedProbability = await persistence.load('bugsnag-sampling-probability')
@@ -19,9 +18,8 @@ class ProbabilityManager {
 
     if (persistedProbability === undefined) {
       // If there is no stored probability:
-      // - Set the initial probability value to the value from
-      //   configuration (defaults to 1.0)
-      sampler.probability = configuredProbability
+      // - Set the initial probability value to the default
+      sampler.probability = 1.0
       initialProbabilityTime = 0
 
       // - Immediately fetch a new probability value

--- a/packages/core/tests/batch-processor.test.ts
+++ b/packages/core/tests/batch-processor.test.ts
@@ -197,7 +197,6 @@ describe('BatchProcessor', () => {
       await ProbabilityManager.create(
         new InMemoryPersistence(),
         sampler,
-        1.0,
         new ProbabilityFetcher(delivery)
       )
     )
@@ -216,6 +215,9 @@ describe('BatchProcessor', () => {
 
   it('discards ended spans if samplingRate is higher than the samplingProbability', async () => {
     const delivery = new InMemoryDelivery()
+    const persistence = new InMemoryPersistence()
+    await persistence.save('bugsnag-sampling-probability', { value: 0.5, time: Date.now() })
+
     const sampler = new Sampler(0.5)
     const batchProcessor = new BatchProcessor(
       delivery,
@@ -225,9 +227,8 @@ describe('BatchProcessor', () => {
       { add: jest.fn(), flush: jest.fn() },
       sampler,
       await ProbabilityManager.create(
-        new InMemoryPersistence(),
+        persistence,
         sampler,
-        0.5,
         new ProbabilityFetcher(delivery)
       )
     )
@@ -262,6 +263,9 @@ describe('BatchProcessor', () => {
 
   it('does not send a request if the entire batch is discarded', async () => {
     const delivery = new InMemoryDelivery()
+    const persistence = new InMemoryPersistence()
+    await persistence.save('bugsnag-sampling-probability', { value: 0.5, time: Date.now() })
+
     const sampler = new Sampler(0.5)
     const batchProcessor = new BatchProcessor(
       delivery,
@@ -271,9 +275,8 @@ describe('BatchProcessor', () => {
       { add: jest.fn(), flush: jest.fn() },
       sampler,
       await ProbabilityManager.create(
-        new InMemoryPersistence(),
+        persistence,
         sampler,
-        0.5,
         new ProbabilityFetcher(delivery)
       )
     )

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -124,41 +124,5 @@ describe('Schema validation', () => {
         expect(validConfig.appVersion).toBe('')
       })
     })
-
-    describe('samplingProbability', () => {
-      it('accepts a valid value', () => {
-        jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
-
-        const config = {
-          apiKey: VALID_API_KEY,
-          samplingProbability: 0.5
-        }
-
-        const validConfig = validateConfig(config, coreSchema)
-        expect(validConfig.samplingProbability).toBe(0.5)
-
-        expect(console.warn).not.toHaveBeenCalled()
-      })
-
-      it.each([
-        { value: 1.1, type: 'a value >1' },
-        { value: -0.1, type: 'a value <0' },
-        { value: NaN, type: 'NaN' },
-        { value: Infinity, type: 'Infinity' },
-        { value: -Infinity, type: '-Infinity' }
-      ])('replaces $type with the default', ({ value, type }) => {
-        jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
-
-        const config = {
-          apiKey: VALID_API_KEY,
-          samplingProbability: value
-        }
-
-        const validConfig = validateConfig(config, coreSchema)
-        expect(validConfig.samplingProbability).toBe(1.0)
-
-        expect(console.warn).toHaveBeenCalledWith('Invalid configuration\n  - samplingProbability should be a number between 0 and 1, got number')
-      })
-    })
   })
 })

--- a/packages/core/tests/probability-manager.test.ts
+++ b/packages/core/tests/probability-manager.test.ts
@@ -18,7 +18,6 @@ describe('ProbabilityManager', () => {
     await ProbabilityManager.create(
       persistence,
       sampler,
-      1.0,
       fetcher
     )
 
@@ -65,7 +64,6 @@ describe('ProbabilityManager', () => {
     await ProbabilityManager.create(
       persistence,
       sampler,
-      1.0,
       fetcher
     )
 
@@ -109,7 +107,6 @@ describe('ProbabilityManager', () => {
     await ProbabilityManager.create(
       persistence,
       sampler,
-      1.0,
       fetcher
     )
 
@@ -144,7 +141,6 @@ describe('ProbabilityManager', () => {
     const manager = await ProbabilityManager.create(
       persistence,
       sampler,
-      1.0,
       fetcher
     )
 
@@ -177,7 +173,6 @@ describe('ProbabilityManager', () => {
     const manager = await ProbabilityManager.create(
       persistence,
       sampler,
-      1.0,
       fetcher
     )
 

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -223,10 +223,7 @@ describe('Span', () => {
       const persistence = new InMemoryPersistence()
 
       const client = createTestClient({ deliveryFactory: () => delivery, persistence })
-      client.start({
-        apiKey: VALID_API_KEY,
-        samplingProbability: 1
-      })
+      client.start(VALID_API_KEY)
 
       await jest.runOnlyPendingTimersAsync()
 
@@ -241,12 +238,10 @@ describe('Span', () => {
     it('will always be discarded when probability is 0', async () => {
       const delivery = new InMemoryDelivery()
       const persistence = new InMemoryPersistence()
+      await persistence.save('bugsnag-sampling-probability', { value: 0.0, time: Date.now() })
 
       const client = createTestClient({ deliveryFactory: () => delivery, persistence })
-      client.start({
-        apiKey: VALID_API_KEY,
-        samplingProbability: 0
-      })
+      client.start(VALID_API_KEY)
 
       await jest.runOnlyPendingTimersAsync()
 
@@ -261,6 +256,10 @@ describe('Span', () => {
     it('will sample spans based on their traceId', async () => {
       const delivery = new InMemoryDelivery()
       const persistence = new InMemoryPersistence()
+
+      // 0.14 as the second span's trace ID results in a sampling rate greater
+      // than this but the other two are smaller
+      await persistence.save('bugsnag-sampling-probability', { value: 0.14, time: Date.now() })
 
       // trace IDs with known sampling rates; this allows us to check that the
       // first span is sampled and the second is discarded with a specific
@@ -293,12 +292,7 @@ describe('Span', () => {
         persistence
       })
 
-      client.start({
-        apiKey: VALID_API_KEY,
-        // 0.14 as the second span's trace ID results in a sampling rate greater
-        // than this but the other two are smaller
-        samplingProbability: 0.14
-      })
+      client.start(VALID_API_KEY)
 
       await jest.runOnlyPendingTimersAsync()
 
@@ -332,7 +326,6 @@ describe('Span', () => {
 
       client.start({
         apiKey: VALID_API_KEY,
-        samplingProbability: 1,
         logger
       })
 
@@ -409,7 +402,6 @@ describe('Span', () => {
 
       client.start({
         apiKey: VALID_API_KEY,
-        samplingProbability: 1,
         logger
       })
 

--- a/packages/test-utilities/lib/create-configuration.ts
+++ b/packages/test-utilities/lib/create-configuration.ts
@@ -18,7 +18,6 @@ function createConfiguration<C extends Configuration> (overrides: Partial<C> = {
       error: jest.fn()
     },
     appVersion: '',
-    samplingProbability: 1.0,
     networkInstrumentationIgnoreUrls: [],
     ...overrides
   } as unknown as InternalConfiguration<C>


### PR DESCRIPTION
## Goal

Remove 'samplingProbability' configuration option. Instead we use a default probability of 1.0 until we receive a value from the server