### PR TITLE
Make sure the $browser global is always available in e2e tests

### DIFF
--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -1,11 +1,7 @@
 require 'yaml'
 
 class Browser
-
-  def initialize(browser_spec, maze_uri, fixtures_uri)
-    @maze_uri = maze_uri
-    @fixtures_uri = fixtures_uri
-
+  def initialize(browser_spec)
     # e.g. "chrome_61", "edge_latest", "chrome"
     @name, version = browser_spec.split("_")
 
@@ -23,19 +19,6 @@ class Browser
   # we assume that android devices are always using the latest version of chrome
   def mobile?
     @name == "android" || @name == "ios" || @name == "iphone"
-  end
-
-  def url_for(path)
-    uri = URI.join(@fixtures_uri, path)
-    config_query_string = "endpoint=#{@maze_uri}/traces&logs=#{@maze_uri}/logs&api_key=#{$api_key}"
-
-    if uri.query
-      uri.query += "&#{config_query_string}"
-    else
-      uri.query = config_query_string
-    end
-
-    uri.to_s
   end
 
   def supports_fetch_keepalive?

--- a/test/browser/features/lib/url-generator.rb
+++ b/test/browser/features/lib/url-generator.rb
@@ -1,0 +1,19 @@
+class UrlGenerator
+  def initialize(maze_uri, fixtures_uri)
+    @maze_uri = maze_uri
+    @fixtures_uri = fixtures_uri
+  end
+
+  def for_path(path)
+    uri = URI.join(@fixtures_uri, path)
+    config_query_string = "endpoint=#{@maze_uri}/traces&logs=#{@maze_uri}/logs&api_key=#{$api_key}"
+
+    if uri.query
+      uri.query += "&#{config_query_string}"
+    else
+      uri.query = config_query_string
+    end
+
+    uri.to_s
+  end
+end

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -1,5 +1,5 @@
 When("I navigate to the test URL {string}") do |test_path|
-  path = $browser.url_for(test_path)
+  path = $url_generator.for_path(test_path)
   step("I navigate to the URL \"#{path}\"")
 
   # store environment based on hostname

--- a/test/browser/features/support/isolate-scenarios.rb
+++ b/test/browser/features/support/isolate-scenarios.rb
@@ -1,14 +1,14 @@
 Maze.hooks.after do
-  path = $browser.url_for("/")
+  url = $url_generator.for_path("/")
 
   begin
-    $logger.debug "Navigating to: #{path}"
-    Maze.driver.navigate.to path
+    $logger.debug "Navigating to: #{url}"
+    Maze.driver.navigate.to(url)
   rescue => exception
     $logger.error("#{exception.class} occurred during navigation attempt with message: #{exception.message}")
-    $logger.error("Restarting driver and retrying navigation to: #{path}")
+    $logger.error("Restarting driver and retrying navigation to: #{url}")
     Maze.driver.restart_driver
-    Maze.driver.navigate.to path
+    Maze.driver.navigate.to(url)
     # If a further error occurs it will get thrown as normal
   end
 

--- a/test/browser/features/support/maze-config.rb
+++ b/test/browser/features/support/maze-config.rb
@@ -1,11 +1,12 @@
 require_relative '../lib/browser'
+require_relative '../lib/url-generator'
 
+$browser = Browser.new(Maze.config.browser)
 
 Maze.hooks.before_all do
   Maze.config.document_server_root = File.realpath("#{__dir__}/../fixtures/packages")
   Maze.config.enforce_bugsnag_integrity = false
 end
-
 
 Maze.hooks.before do
   # Only needs running once, but the before_all hook gets invoked
@@ -19,8 +20,7 @@ Maze.hooks.before do
     document_address = "#{host}:#{Maze.config.document_server_port}"
   end
 
-  $browser = Browser.new(
-    Maze.config.browser,
+  $url_generator = UrlGenerator.new(
     URI("http://#{maze_address}"),
     URI("http://#{document_address}")
   )


### PR DESCRIPTION
## Goal

We need $browser to be available at all times so that we can use it for things like the 'skip' annotations. This was problematic as it was created in a 'before' hook, which run just before a scenario starts, so if a skip annotation required checking the $browser object then we'd crash

The $browser global needed to be in a before hook because it used the Maze Runner URLs for generating URLs to fixtures and those were only available after configuration is setup. This is now handled by a separate $url_generator object, which means the $browser object can be made available at all times