### PR TITLE
Fix unit test timeouts

### DIFF
--- a/packages/core/tests/batch-processor.test.ts
+++ b/packages/core/tests/batch-processor.test.ts
@@ -206,6 +206,7 @@ describe('BatchProcessor', () => {
     batchProcessor.add(createEndedSpan())
 
     delivery.setNextSamplingProbability(0.0)
+    delivery.setNextSamplingProbability(0.0)
 
     expect(sampler.probability).toBe(1.0)
 

--- a/packages/core/tests/probability-fetcher.test.ts
+++ b/packages/core/tests/probability-fetcher.test.ts
@@ -26,6 +26,8 @@ describe('ProbabilityFetcher', () => {
 
   it('retries if delivery fails until a new probability is retrieved', async () => {
     const delivery = new InMemoryDelivery()
+    delivery.setNextSamplingProbability(undefined)
+
     const fetcher = new ProbabilityFetcher(delivery)
 
     const fetcherPromise = fetcher.getNewProbability()
@@ -33,13 +35,19 @@ describe('ProbabilityFetcher', () => {
     // 1 request is made immediately, but no sampling probability is returned
     expect(delivery.samplingRequests).toHaveLength(1)
 
+    delivery.setNextSamplingProbability(undefined)
+
     // after 30 seconds another request should be made
     await jest.advanceTimersByTimeAsync(30_000)
     expect(delivery.samplingRequests).toHaveLength(2)
 
+    delivery.setNextSamplingProbability(undefined)
+
     // etc..
     await jest.advanceTimersByTimeAsync(30_000)
     expect(delivery.samplingRequests).toHaveLength(3)
+
+    delivery.setNextSamplingProbability(undefined)
 
     // etc..
     await jest.advanceTimersByTimeAsync(30_000)

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -334,6 +334,8 @@ describe('Span', () => {
 
     it('will always be discarded when probability is 0', async () => {
       const delivery = new InMemoryDelivery()
+      delivery.setNextSamplingProbability(0.0)
+
       const persistence = new InMemoryPersistence()
       await persistence.save('bugsnag-sampling-probability', { value: 0.0, time: Date.now() })
 
@@ -351,12 +353,15 @@ describe('Span', () => {
     })
 
     it('will sample spans based on their traceId', async () => {
-      const delivery = new InMemoryDelivery()
-      const persistence = new InMemoryPersistence()
-
       // 0.14 as the second span's trace ID results in a sampling rate greater
       // than this but the other two are smaller
-      await persistence.save('bugsnag-sampling-probability', { value: 0.14, time: Date.now() })
+      const samplingProbability = 0.14
+
+      const delivery = new InMemoryDelivery()
+      delivery.setNextSamplingProbability(samplingProbability)
+
+      const persistence = new InMemoryPersistence()
+      await persistence.save('bugsnag-sampling-probability', { value: samplingProbability, time: Date.now() })
 
       // trace IDs with known sampling rates; this allows us to check that the
       // first span is sampled and the second is discarded with a specific

--- a/packages/test-utilities/lib/in-memory-delivery.ts
+++ b/packages/test-utilities/lib/in-memory-delivery.ts
@@ -15,7 +15,9 @@ class InMemoryDelivery implements Delivery {
     }
 
     const state = this.responseStateStack.pop() || 'success' as ResponseState
-    const samplingProbability = this.samplingProbabilityStack.pop()
+    const samplingProbability = this.samplingProbabilityStack.length
+      ? this.samplingProbabilityStack.pop()
+      : 1.0
 
     return Promise.resolve({ state, samplingProbability })
   }

--- a/packages/test-utilities/lib/in-memory-delivery.ts
+++ b/packages/test-utilities/lib/in-memory-delivery.ts
@@ -5,7 +5,7 @@ class InMemoryDelivery implements Delivery {
   public samplingRequests: DeliveryPayload[] = []
 
   private readonly responseStateStack: ResponseState[] = []
-  private readonly samplingProbabilityStack: number[] = []
+  private readonly samplingProbabilityStack: Array<number | undefined> = []
 
   send (payload: DeliveryPayload) {
     if (payload.resourceSpans.length === 0) {
@@ -24,8 +24,8 @@ class InMemoryDelivery implements Delivery {
     this.responseStateStack.push(state)
   }
 
-  setNextSamplingProbability (samplingProbability: number): void {
-    if (samplingProbability < 0 || samplingProbability > 1) {
+  setNextSamplingProbability (samplingProbability?: number): void {
+    if (samplingProbability !== undefined && (samplingProbability < 0 || samplingProbability > 1)) {
       throw new Error(`Invalid sampling probability. Expected a number >= 0 && <= 1, got: ${samplingProbability}`)
     }
 


### PR DESCRIPTION
## Goal

Fix infinite timeouts in unit tests caused by `InMemoryDelivery` not returning a `samplingProbability` unless explicitly configured to do so

Now it will always return `samplingProbability: 1.0` if there is no override on its stack of probabilities

This ensures [`ProbabilityFetcher#getNewProbability`](https://github.com/bugsnag/bugsnag-js-performance/blob/ba836677042a81fcfa3bba0de44c7589d8e598a8/packages/core/lib/probability-fetcher.ts#L17-L30) will always resolve with a value

As part of this `InMemoryDelivery` must now also allow `undefined` to be set as a `samplingProbability` so that it can be told to not return one at all