### PR TITLE
[PLAT-10231] ResourceLoad spans

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -30,7 +30,7 @@ export interface ClientOptions<S extends CoreSchema, C extends Configuration> {
   resourceAttributesSource: ResourceAttributeSource<C>
   spanAttributesSource: SpanAttributesSource
   schema: S
-  plugins: (spanFactory: SpanFactory) => Array<Plugin<C>>
+  plugins: (spanFactory: SpanFactory, spanContextStorage: SpanContextStorage) => Array<Plugin<C>>
   persistence: Persistence
   spanContextStorage?: SpanContextStorage
 }
@@ -51,7 +51,7 @@ export function createClient<S extends CoreSchema, C extends Configuration> (opt
     options.schema.logger.defaultValue,
     spanContextStorage
   )
-  const plugins = options.plugins(spanFactory)
+  const plugins = options.plugins(spanFactory, spanContextStorage)
 
   return {
     start: (config: C | string) => {

--- a/packages/core/lib/span-context.ts
+++ b/packages/core/lib/span-context.ts
@@ -22,6 +22,7 @@ export interface SpanContextStorage extends Iterable<SpanContext> {
   push: (context: SpanContext) => void
   pop: (context: SpanContext) => void
   readonly current: SpanContext | undefined
+  readonly first: SpanContext | undefined
 }
 
 export class DefaultSpanContextStorage implements SpanContextStorage {
@@ -52,6 +53,13 @@ export class DefaultSpanContextStorage implements SpanContextStorage {
     }
 
     this.removeClosedContexts()
+  }
+
+  get first () {
+    this.removeClosedContexts()
+    return this.contextStack.length > 0
+      ? this.contextStack[0]
+      : undefined
   }
 
   get current () {

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -51,10 +51,6 @@ export class SpanFactory {
     this.openSpans = new WeakSet<SpanInternal>()
   }
 
-  get firstSpanContext () {
-    return this.spanContextStorage.first
-  }
-
   startSpan (name: string, options: SpanOptions = {}) {
     const safeStartTime = timeToNumber(this.clock, options ? options.startTime : undefined)
     const spanId = this.idGenerator.generate(64)

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -51,6 +51,10 @@ export class SpanFactory {
     this.openSpans = new WeakSet<SpanInternal>()
   }
 
+  get firstSpanContext () {
+    return this.spanContextStorage.first
+  }
+
   startSpan (name: string, options: SpanOptions = {}) {
     const safeStartTime = timeToNumber(this.clock, options ? options.startTime : undefined)
     const spanId = this.idGenerator.generate(64)

--- a/packages/platforms/browser/lib/auto-instrumentation/index.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/index.ts
@@ -1,3 +1,4 @@
 export * from './full-page-load-plugin'
 export * from './network-request-plugin'
+export * from './resource-load-plugin'
 export * from './route-change-plugin'

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -58,6 +58,7 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
             makeCurrentContext: false
           })
 
+          span.setAttribute('bugsnag.span.category', 'resource_load')
           span.setAttribute('http.url', entry.name)
           span.setAttribute('http.flavor', getHTTPFlavor(entry.nextHopProtocol))
           span.setAttribute('http.response_content_length', entry.encodedBodySize)

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -1,4 +1,4 @@
-import { type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
+import { type SpanContextStorage, type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
 import { type BrowserConfiguration } from '../config'
 
 interface ResourceTiming extends PerformanceResourceTiming {
@@ -34,6 +34,7 @@ function resourceLoadSupported (PerformanceObserverClass: typeof PerformanceObse
 export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
   constructor (
     private readonly spanFactory: SpanFactory,
+    private readonly spanContextStorage: SpanContextStorage,
     private readonly PerformanceObserverClass: typeof PerformanceObserver
   ) {}
 
@@ -48,7 +49,7 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
          continue
        }
 
-        const parentContext = this.spanFactory.firstSpanContext
+        const parentContext = this.spanContextStorage.first
 
         if (parentContext) {
           const url = new URL(entry.name)

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -44,13 +44,16 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
       const entries = list.getEntries() as ResourceTiming[]
 
       for (const entry of entries) {
-        if (['fetch', 'xmlhttprequest'].includes(entry.initiatorType)) continue
+        if (entry.initiatorType === 'fetch' || entry.initiatorType === 'xmlhttprequest') {
+         continue
+       }
 
         const parentContext = this.spanFactory.firstSpanContext
 
         if (parentContext) {
           const url = new URL(entry.name)
-          const name = url.href.replace(url.search, '')
+          url.search = ''
+          const name = url.href
 
           const span = this.spanFactory.startSpan(`[ResourceLoad]${name}`, {
             parentContext,

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -44,7 +44,7 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
       const entries = list.getEntries() as ResourceTiming[]
 
       for (const entry of entries) {
-        if (['fetch', 'xmlhttprequest'].includes(entry.initiatorType)) return
+        if (['fetch', 'xmlhttprequest'].includes(entry.initiatorType)) continue
 
         const parentContext = this.spanFactory.firstSpanContext
 
@@ -61,8 +61,11 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
           span.setAttribute('bugsnag.span.category', 'resource_load')
           span.setAttribute('http.url', entry.name)
           span.setAttribute('http.flavor', getHTTPFlavor(entry.nextHopProtocol))
-          span.setAttribute('http.response_content_length', entry.encodedBodySize)
-          span.setAttribute('http.response_content_length_uncompressed', entry.decodedBodySize)
+
+          if (entry.encodedBodySize && entry.decodedBodySize) {
+            span.setAttribute('http.response_content_length', entry.encodedBodySize)
+            span.setAttribute('http.response_content_length_uncompressed', entry.decodedBodySize)
+          }
 
           if (entry.responseStatus) {
             span.setAttribute('http.status_code', entry.responseStatus)

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -44,6 +44,8 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
       const entries = list.getEntries() as ResourceTiming[]
 
       for (const entry of entries) {
+        if (['fetch', 'xmlhttprequest'].includes(entry.initiatorType)) return
+
         const parentContext = this.spanFactory.firstSpanContext
 
         if (parentContext) {

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -1,0 +1,42 @@
+import { type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
+import { type BrowserConfiguration } from '../config'
+
+interface ResourceTiming extends PerformanceResourceTiming {
+  responseStatus?: number // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus
+}
+
+export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
+  constructor (
+    private readonly spanFactory: SpanFactory,
+    private readonly PerformanceObserverClass: typeof PerformanceObserver
+  ) {}
+
+  configure (configuration: InternalConfiguration<BrowserConfiguration>) {
+    const observer = new this.PerformanceObserverClass((list) => {
+      const entries = list.getEntries() as ResourceTiming[]
+
+      for (const entry of entries) {
+        // TODO: get the first context from spanContextStorage
+        // if no current context - don't do anything
+
+        const url = new URL(entry.name)
+        const name = url.href.replace(url.search, '')
+
+        const span = this.spanFactory.startSpan(`[ResourceLoad]${name}`, {
+          startTime: entry.startTime,
+          makeCurrentContext: false
+        })
+
+        span.setAttribute('http.url', entry.name)
+
+        if (entry.responseStatus) {
+          span.setAttribute('http.status_code', entry.responseStatus)
+        }
+
+        this.spanFactory.endSpan(span, entry.responseEnd)
+      }
+    })
+
+    observer.observe({ type: 'resource', buffered: true })
+  }
+}

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -5,7 +5,7 @@ interface ResourceTiming extends PerformanceResourceTiming {
   responseStatus?: number // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus
 }
 
-export function getHTTPFlavor (protocol: string) {
+export function getHttpVersion (protocol: string) {
   switch (protocol) {
     case 'http/1.0':
       return '1.0'
@@ -46,8 +46,8 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
 
       for (const entry of entries) {
         if (entry.initiatorType === 'fetch' || entry.initiatorType === 'xmlhttprequest') {
-         continue
-       }
+          continue
+        }
 
         const parentContext = this.spanContextStorage.first
 
@@ -64,7 +64,7 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
 
           span.setAttribute('bugsnag.span.category', 'resource_load')
           span.setAttribute('http.url', entry.name)
-          span.setAttribute('http.flavor', getHTTPFlavor(entry.nextHopProtocol))
+          span.setAttribute('http.flavor', getHttpVersion(entry.nextHopProtocol))
 
           if (entry.encodedBodySize && entry.decodedBodySize) {
             span.setAttribute('http.response_content_length', entry.encodedBodySize)

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -39,7 +39,7 @@ const BugsnagPerformance = createClient({
   deliveryFactory: createBrowserDeliveryFactory(window.fetch, backgroundingListener),
   idGenerator,
   schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
-  plugins: (spanFactory) => [
+  plugins: (spanFactory, spanContextStorage) => [
     onSettle,
     new FullPageLoadPlugin(
       document,
@@ -52,7 +52,7 @@ const BugsnagPerformance = createClient({
     ),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
     new RouteChangePlugin(spanFactory, window.location),
-    new ResourceLoadPlugin(spanFactory, window.PerformanceObserver)
+    new ResourceLoadPlugin(spanFactory, spanContextStorage, window.PerformanceObserver)
   ],
   persistence
 })

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -50,9 +50,11 @@ const BugsnagPerformance = createClient({
       backgroundingListener,
       performance
     ),
+    // ResourceLoadPlugin should always come after FullPageLoad plugin, as it should use that
+    // span context as the parent of it's spans
+    new ResourceLoadPlugin(spanFactory, spanContextStorage, window.PerformanceObserver),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
-    new RouteChangePlugin(spanFactory, window.location),
-    new ResourceLoadPlugin(spanFactory, spanContextStorage, window.PerformanceObserver)
+    new RouteChangePlugin(spanFactory, window.location)
   ],
   persistence
 })

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@bugsnag/core-performance'
-import { FullPageLoadPlugin, NetworkRequestPlugin, RouteChangePlugin } from './auto-instrumentation'
+import { FullPageLoadPlugin, NetworkRequestPlugin, ResourceLoadPlugin, RouteChangePlugin } from './auto-instrumentation'
 import createBrowserBackgroundingListener from './backgrounding-listener'
 import createClock from './clock'
 import { createSchema } from './config'
@@ -51,7 +51,8 @@ const BugsnagPerformance = createClient({
       performance
     ),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
-    new RouteChangePlugin(spanFactory, window.location)
+    new RouteChangePlugin(spanFactory, window.location),
+    new ResourceLoadPlugin(spanFactory, PerformanceObserver)
   ],
   persistence
 })

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -52,7 +52,7 @@ const BugsnagPerformance = createClient({
     ),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
     new RouteChangePlugin(spanFactory, window.location),
-    new ResourceLoadPlugin(spanFactory, PerformanceObserver)
+    new ResourceLoadPlugin(spanFactory, window.PerformanceObserver)
   ],
   persistence
 })

--- a/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
@@ -59,6 +59,46 @@ describe('ResourceLoadPlugin', () => {
     }))
   })
 
+  it('does not create a ResourceLoad span for fetch/xhr resources', async () => {
+    const delivery = new InMemoryDelivery()
+    const manager = new PerformanceObserverManager()
+    const Observer = manager.createPerformanceObserverFakeClass()
+    const idGenerator = new IncrementingIdGenerator()
+
+    const client = createTestClient({
+      idGenerator,
+      deliveryFactory: () => delivery,
+      plugins: (spanFactory) => [
+        new ResourceLoadPlugin(spanFactory, Observer)
+      ]
+    })
+
+    client.start({ apiKey: VALID_API_KEY })
+
+    const span = client.startSpan('custom-span', { makeCurrentContext: false })
+
+    manager.queueEntry(createPerformanceResourceNavigationTimingFake({ name: 'https://bugsnag.com/image.jpg', initiatorType: 'fetch' }))
+    manager.queueEntry(createPerformanceResourceNavigationTimingFake({ name: 'https://bugsnag.com/image.jpg', initiatorType: 'xmlhttprequest' }))
+    manager.flushQueue()
+
+    span.end()
+
+    await jest.runOnlyPendingTimersAsync()
+
+    expect(delivery).toHaveSentSpan(expect.objectContaining({
+      name: 'custom-span',
+      spanId: 'span ID 1',
+      parentSpanId: undefined,
+      traceId: 'trace ID 1'
+    }))
+
+    expect(delivery).not.toHaveSentSpan(expect.objectContaining({
+      name: '[ResourceLoad]https://bugsnag.com/image.jpg'
+    }))
+
+    expect(delivery.requests[0].resourceSpans[0].scopeSpans[0].spans).toHaveLength(1)
+  })
+
   it('does not create a ResourceLoad span if there is no current context', async () => {
     const delivery = new InMemoryDelivery()
     const manager = new PerformanceObserverManager()

--- a/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { InMemoryDelivery, IncrementingIdGenerator, VALID_API_KEY, createTestClient } from '@bugsnag/js-performance-test-utilities'
+import { ResourceLoadPlugin } from '../../lib/auto-instrumentation/resource-load-plugin'
+import { PerformanceObserverManager } from '../utilities'
+import { createPerformanceResourceNavigationTimingFake } from '../utilities/performance-entry'
+
+describe('ResourceLoadPlugin', () => {
+  it('automatically creates a ResourceLoad span for a custom span', async () => {
+    jest.useFakeTimers()
+
+    const delivery = new InMemoryDelivery()
+    const manager = new PerformanceObserverManager()
+    const Observer = manager.createPerformanceObserverFakeClass()
+    const idGenerator = new IncrementingIdGenerator()
+
+    const client = createTestClient({
+      idGenerator,
+      deliveryFactory: () => delivery,
+      plugins: (spanFactory) => [
+        new ResourceLoadPlugin(spanFactory, Observer)
+      ]
+    })
+
+    client.start({ apiKey: VALID_API_KEY })
+
+    const span = client.startSpan('custom-span')
+
+    manager.queueEntry(createPerformanceResourceNavigationTimingFake({ name: 'https://bugsnag.com/image.jpg' }))
+    manager.flushQueue()
+
+    span.end()
+
+    await jest.runOnlyPendingTimersAsync()
+
+    expect(delivery).toHaveSentSpan(expect.objectContaining({
+      name: 'custom-span',
+      spanId: 'span ID 1',
+      parentSpanId: undefined,
+      traceId: 'trace ID 1'
+    }))
+
+    expect(delivery).toHaveSentSpan(expect.objectContaining({
+      name: '[ResourceLoad]https://bugsnag.com/image.jpg',
+      spanId: 'span ID 2',
+      parentSpanId: 'span ID 1',
+      traceId: 'trace ID 1'
+    }))
+  })
+})

--- a/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
@@ -19,8 +19,8 @@ describe('ResourceLoadPlugin', () => {
     const client = createTestClient({
       idGenerator,
       deliveryFactory: () => delivery,
-      plugins: (spanFactory) => [
-        new ResourceLoadPlugin(spanFactory, Observer)
+      plugins: (spanFactory, spanContextStorage) => [
+        new ResourceLoadPlugin(spanFactory, spanContextStorage, Observer)
       ]
     })
 
@@ -68,8 +68,8 @@ describe('ResourceLoadPlugin', () => {
     const client = createTestClient({
       idGenerator,
       deliveryFactory: () => delivery,
-      plugins: (spanFactory) => [
-        new ResourceLoadPlugin(spanFactory, Observer)
+      plugins: (spanFactory, spanContextStorage) => [
+        new ResourceLoadPlugin(spanFactory, spanContextStorage, Observer)
       ]
     })
 
@@ -108,8 +108,8 @@ describe('ResourceLoadPlugin', () => {
     const client = createTestClient({
       idGenerator,
       deliveryFactory: () => delivery,
-      plugins: (spanFactory) => [
-        new ResourceLoadPlugin(spanFactory, Observer)
+      plugins: (spanFactory, spanContextStorage) => [
+        new ResourceLoadPlugin(spanFactory, spanContextStorage, Observer)
       ]
     })
 

--- a/packages/platforms/browser/tests/utilities/performance-entry.ts
+++ b/packages/platforms/browser/tests/utilities/performance-entry.ts
@@ -40,13 +40,20 @@ type InitiatorType
   | 'iframe'
   | 'frame'
   | 'other'
+
 type DeliveryType = 'cache' | ''
+
+interface ServerTiming {
+  description: string
+  duration: number
+  name: string
+  toJSON: () => unknown
+}
 
 // https://www.w3.org/TR/resource-timing/#dom-performanceresourcetiming
 export interface PerformanceResourceTimingFake extends PerformanceEntryFake {
   entryType: 'resource'
   initiatorType: InitiatorType
-  deliveryType: DeliveryType
   nextHopProtocol: string
   workerStart: number
   redirectStart: number
@@ -60,6 +67,7 @@ export interface PerformanceResourceTimingFake extends PerformanceEntryFake {
   requestStart: number
   responseStart: number
   responseEnd: number
+  serverTiming: ServerTiming[]
   transferSize: number
   encodedBodySize: number
   decodedBodySize: number
@@ -70,7 +78,8 @@ export interface PerformanceResourceTimingFake extends PerformanceEntryFake {
 export type NavigationTimingType = 'navigate' | 'reload' | 'back_forward' | 'prerender'
 
 // https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming
-export interface PerformanceNavigationTimingFake extends Omit<PerformanceResourceTimingFake, 'entryType'>, PerformanceEntryFake {
+export interface PerformanceNavigationTimingFake extends Omit<PerformanceResourceTimingFake, 'entryType' | 'serverTiming'>, PerformanceEntryFake {
+  deliveryType: DeliveryType
   entryType: 'navigation'
   unloadEventStart: number
   unloadEventEnd: number
@@ -82,6 +91,37 @@ export interface PerformanceNavigationTimingFake extends Omit<PerformanceResourc
   loadEventEnd: number
   type: NavigationTimingType
   redirectCount: number
+}
+
+export function createPerformanceResourceNavigationTimingFake (overrides: Partial<PerformanceResourceTimingFake>): PerformanceResourceTimingFake {
+  return {
+    connectEnd: 0,
+    connectStart: 0,
+    decodedBodySize: 0,
+    domainLookupEnd: 0,
+    domainLookupStart: 0,
+    duration: 0,
+    encodedBodySize: 0,
+    entryType: 'resource',
+    fetchStart: 0,
+    initiatorType: 'img',
+    name: 'http://localhost:8000/image.jpg',
+    nextHopProtocol: 'h2',
+    redirectEnd: 0,
+    redirectStart: 0,
+    renderBlockingStatus: 'non-blocking',
+    requestStart: 0,
+    responseEnd: 0,
+    responseStart: 0,
+    responseStatus: 0,
+    secureConnectionStart: 0,
+    serverTiming: [],
+    startTime: 0,
+    transferSize: 0,
+    workerStart: 0,
+    toJSON,
+    ...overrides
+  }
 }
 
 export function createPerformanceNavigationTimingFake (

--- a/test/browser/features/fixtures/packages/page-load-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/page-load-spans/src/index.js
@@ -4,4 +4,4 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 11, batchInactivityTimeoutMs: 3000, autoInstrumentNetworkRequests: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 13, batchInactivityTimeoutMs: 3000, autoInstrumentNetworkRequests: false })

--- a/test/browser/features/fixtures/packages/resource-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/resource-load-spans/index.html
@@ -2,6 +2,11 @@
 <html>
     <head>
         <meta charset="utf-8" />
+        <!-- disable caching to ensure image resoure has consistent body size -->
+        <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+        <meta http-equiv="Pragma" content="no-cache" />
+        <meta http-equiv="Expires" content="0" />
+        <!-- use base64 encoded favicon to present resource load -->
         <link href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==" rel="icon" type="image/x-icon">
         <title>Resource load spans</title>
     </head>

--- a/test/browser/features/fixtures/packages/resource-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/resource-load-spans/index.html
@@ -2,7 +2,6 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
         <title>Resource load spans</title>
     </head>
     <body>

--- a/test/browser/features/fixtures/packages/resource-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/resource-load-spans/index.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <h1>resource-load-spans</h1>
-        <image src="/favicon.png?height=100&width=100" />
+        <div id="image-container"></div>
         <button id="end-span">end span</button>
         <script src="./dist/bundle.js"></script>
     </body>

--- a/test/browser/features/fixtures/packages/resource-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/resource-load-spans/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
+        <title>Resource load spans</title>
+    </head>
+    <body>
+        <h1>resource-load-spans</h1>
+        <image src="/favicon.png?height=100&width=100" />
+        <button id="end-span">end span</button>
+        <script src="./dist/bundle.js"></script>
+    </body>
+</html>

--- a/test/browser/features/fixtures/packages/resource-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/resource-load-spans/index.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
+        <link href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==" rel="icon" type="image/x-icon">
         <title>Resource load spans</title>
     </head>
     <body>

--- a/test/browser/features/fixtures/packages/resource-load-spans/package.json
+++ b/test/browser/features/fixtures/packages/resource-load-spans/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "resource-load-spans",
+    "private": true,
+    "scripts": {
+        "build": "rollup --config ../rollup.config.mjs",
+        "clean": "rm -rf dist"
+    }
+}

--- a/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
@@ -9,5 +9,11 @@ const span = BugsnagPerformance.startSpan("[Custom]/resource-load-spans")
 BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 3, batchInactivityTimeoutMs: 3000, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 document.getElementById("end-span").addEventListener("click", () => {
-    span.end()
+    const node = document.getElementById("image-container")
+    const img = new Image()
+    node.appendChild(img)
+    img.src = "/favicon.png?height=100&width=100"
+    img.onload = () => {
+        span.end()
+    }
 })

--- a/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
@@ -6,7 +6,7 @@ const endpoint = parameters.get("endpoint")
 
 const span = BugsnagPerformance.startSpan("[Custom]/resource-load-spans")
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 4, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 3, batchInactivityTimeoutMs: 3000, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 document.getElementById("end-span").addEventListener("click", () => {
     span.end()

--- a/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
@@ -14,6 +14,8 @@ document.getElementById("end-span").addEventListener("click", () => {
     node.appendChild(img)
     img.src = "/favicon.png?height=100&width=100"
     img.onload = () => {
-        span.end()
+        setTimeout(() => {
+            span.end()
+        }, 100)
     }
 })

--- a/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
@@ -1,0 +1,13 @@
+import BugsnagPerformance from "@bugsnag/browser-performance"
+
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get("api_key")
+const endpoint = parameters.get("endpoint")
+
+const span = BugsnagPerformance.startSpan("[Custom]/resource-load-spans")
+
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 4, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
+
+document.getElementById("end-span").addEventListener("click", () => {
+    span.end()
+})

--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -63,6 +63,25 @@ class Browser
     end
   end
 
+  def supports_performance_response_status?
+    case @name
+    when "chrome", "edge"
+      @version >= 109
+    else
+      false
+    end
+  end
+
+  def supports_performance_body_size?
+    case @name
+    when "safari", "ios"
+      # support added in Safari 16.4
+      @version >= 16
+    else
+      true
+    end
+  end
+
   def supports_performance_navigation_timing?
     case @name
     when "safari", "ios"

--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -72,13 +72,16 @@ class Browser
     end
   end
 
-  def supports_performance_body_size?
+  def supports_resource_load_spans?
     case @name
+    when "chrome"
+      @version >= 73
     when "safari", "ios"
-      # support added in Safari 16.4
-      @version >= 16
+      @version >= 13
+    when "firefox"
+      @version >= 67
     else
-      true
+      false
     end
   end
 

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -24,28 +24,3 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.url" matches the regex "^http:\/\/.*:[0-9]{4}\/favicon\.png\?height=100&width=100$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.flavor" equals "1.1"
     
-  @requires_performance_response_status
-  Scenario: Resource load spans http.status_code
-    Given I navigate to the test URL "/resource-load-spans"
-    And I wait to receive a sampling request
-
-    When I click the element "end-span"
-    And I wait to receive 1 trace
-
-    # App bundle
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
-    
-    # Image
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.status_code" equals 200
-
-  @requires_performance_body_size
-  Scenario: Resource load spans http.response_content
-    Given I navigate to the test URL "/resource-load-spans"
-    And I wait to receive a sampling request
-
-    When I click the element "end-span"
-    And I wait to receive 1 trace
-
-    # Image
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length_uncompressed" equals 2202
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length" equals 2202

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -8,8 +8,8 @@ Feature: Resource Load Spans
     And I wait to receive 1 trace
 
     # Custom span (parent)
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.name" equals "[Custom]/resource-load-spans"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.spanId" is stored as the value "parent_span_id"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.name" equals "[Custom]/resource-load-spans"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.spanId" is stored as the value "parent_span_id"
 
     # App bundle
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/resource-load-spans\/dist\/bundle\.js$"

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -1,0 +1,30 @@
+Feature: Resource Load Spans
+
+  Scenario: Resource load spans are automatically instrumented
+    Given I navigate to the test URL "/resource-load-spans"
+    And I wait to receive a sampling request
+
+    When I click the element "end-span"
+    And I wait to receive 1 trace
+
+    # Custom span (parent)
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.name" equals "[Custom]/resource-load-spans"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.spanId" is stored as the value "parent_span_id"
+
+    # App bundle
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/resource-load-spans\/dist\/bundle\.js$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parent_span_id"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" equals "1.1"
+
+    # Image on page
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/favicon.png$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "custom"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.url" matches the regex "^http:\/\/.*:[0-9]{4}\/favicon\.png\?height=100&width=100$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.status_code" equals 200
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length_uncompressed" equals 2202
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length" equals 2202
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.flavor" equals "1.1"
+    

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -1,5 +1,6 @@
 Feature: Resource Load Spans
 
+  @requires_resource_load_spans
   Scenario: Resource load spans are automatically instrumented
     Given I navigate to the test URL "/resource-load-spans"
     And I wait to receive a sampling request

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -15,16 +15,37 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/resource-load-spans\/dist\/bundle\.js$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "resource_load"
-    # And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" equals "1.1"
 
-    # Image on page
+    # Image
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/favicon.png$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.url" matches the regex "^http:\/\/.*:[0-9]{4}\/favicon\.png\?height=100&width=100$"
-    # And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.status_code" equals 200
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length_uncompressed" equals 2202
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length" equals 2202
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.flavor" equals "1.1"
     
+  @requires_performance_response_status
+  Scenario: Resource load spans http.status_code
+    Given I navigate to the test URL "/resource-load-spans"
+    And I wait to receive a sampling request
+
+    When I click the element "end-span"
+    And I wait to receive 1 trace
+
+    # App bundle
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
+    
+    # Image
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.status_code" equals 200
+
+  @requires_performance_body_size
+  Scenario: Resource load spans http.response_content
+    Given I navigate to the test URL "/resource-load-spans"
+    And I wait to receive a sampling request
+
+    When I click the element "end-span"
+    And I wait to receive 1 trace
+
+    # Image
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length_uncompressed" equals 2202
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length" equals 2202

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -15,7 +15,7 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/resource-load-spans\/dist\/bundle\.js$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
+    # And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" equals "1.1"
 
     # Image on page
@@ -23,7 +23,7 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "custom"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.url" matches the regex "^http:\/\/.*:[0-9]{4}\/favicon\.png\?height=100&width=100$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.status_code" equals 200
+    # And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.status_code" equals 200
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length_uncompressed" equals 2202
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length" equals 2202
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.flavor" equals "1.1"

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -14,14 +14,14 @@ Feature: Resource Load Spans
     # App bundle
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/resource-load-spans\/dist\/bundle\.js$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parent_span_id"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "resource_load"
     # And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" equals "1.1"
 
     # Image on page
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/favicon.png$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "custom"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.url" matches the regex "^http:\/\/.*:[0-9]{4}\/favicon\.png\?height=100&width=100$"
     # And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.status_code" equals 200
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "http.response_content_length_uncompressed" equals 2202

--- a/test/browser/features/support/requires-performance-body-size.rb
+++ b/test/browser/features/support/requires-performance-body-size.rb
@@ -1,0 +1,4 @@
+Before("@requires_performance_body_size") do
+    skip_this_scenario unless $browser.supports_performance_body_size?
+end
+  

--- a/test/browser/features/support/requires-performance-response-status.rb
+++ b/test/browser/features/support/requires-performance-response-status.rb
@@ -1,0 +1,4 @@
+Before("@requires_performance_response_status") do
+    skip_this_scenario unless $browser.supports_performance_response_status?
+end
+  

--- a/test/browser/features/support/requires-resource-load-spans.rb
+++ b/test/browser/features/support/requires-resource-load-spans.rb
@@ -1,0 +1,4 @@
+Before("@requires_resource_load_spans") do
+    skip_this_scenario unless $browser.supports_resource_load_spans?
+  end
+  


### PR DESCRIPTION
## Goal

Implement a new ResourceLoadPlugin in the browser client, to enable automatic instrumentation of resource load spans when there is an open span in the context stack

## Testing

Unit tests for automatic span creation with correct parentage
Unit test fetch/xhr requests do not create resource load spans
Unit test resource load spans are not created when there is no parent context
End to end tests for automated resource load spans with correct parentage