### PR TITLE
Start FullPageLoad spans earlier

### DIFF
--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -70,7 +70,7 @@ export class SpanInternal implements SpanContext {
   private readonly kind = Kind.Client // TODO: How do we define the initial Kind?
   private readonly events = new SpanEvents()
   private readonly attributes: SpanAttributes
-  private readonly name: string
+  name: string
   private endTime?: number
 
   constructor (id: string, traceId: string, name: string, startTime: number, attributes: SpanAttributes, parentSpanId?: string) {

--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -54,7 +54,7 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
       if (this.wasBackgrounded) return
 
       const route = configuration.routingProvider.resolveRoute(url)
-      span.name += `${route}`
+      span.name += route
 
       // Browser attributes
       span.setAttribute('bugsnag.span.category', 'full_page_load')

--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -52,7 +52,7 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
       return
     }
 
-    const span = this.spanFactory.startSpan('[FullPageLoad]', { startTime: 0 })
+    const span = this.spanFactory.startSpan('[FullPageLoad]', { startTime: 0, parentContext: null })
     const url = new URL(this.location.href)
 
     this.onSettle((endTime: number) => {

--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -47,15 +47,14 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
       return
     }
 
+    const span = this.spanFactory.startSpan('[FullPageLoad]', { startTime: 0 })
     const url = new URL(this.location.href)
 
     this.onSettle((endTime: number) => {
       if (this.wasBackgrounded) return
 
       const route = configuration.routingProvider.resolveRoute(url)
-
-      const startTime = 0
-      const span = this.spanFactory.startSpan(`[FullPageLoad]${route}`, { startTime })
+      span.name += `${route}`
 
       // Browser attributes
       span.setAttribute('bugsnag.span.category', 'full_page_load')


### PR DESCRIPTION
## Goal

Currently we start and end full page load spans after the page has settled so that we can resolve the route - however we now need to start (and end) child spans  such as resource load spans before the page has settled, so the full page load span needs to be started earlier.

This PR updates the full page load plugin to start the span as soon as the plugin is configured, and then update the name with the route once the page has settled.

The full page load span now also passes `parentContext: null` when starting the span to ensure that it is always a root span (with no parent)