### PR TITLE
Don't warn when a span was discarded before ending

### DIFF
--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -181,7 +181,12 @@ export class SpanFactory {
   ) {
     // if the span doesn't exist here it shouldn't be processed
     if (!this.openSpans.delete(span)) {
-      this.logger.warn('Attempted to end a Span which has already ended or been discarded.')
+      // only warn if the span has already been ended explicitly rather than
+      // discarded by us
+      if (!span.isValid()) {
+        this.logger.warn('Attempted to end a Span which has already ended.')
+      }
+
       return
     }
 

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -433,22 +433,21 @@ describe('Span', () => {
       backgroundingListener.sendToBackground()
       movedToBackground.end()
 
-      expect(logger.warn).toHaveBeenCalledWith('Attempted to end a Span which has already ended or been discarded.')
-      expect(logger.warn).toHaveBeenCalledTimes(1)
+      expect(logger.warn).not.toHaveBeenCalled()
 
       // started in background and ended in foreground
       const movedToForeground = client.startSpan('moved-to-foreground')
       backgroundingListener.sendToForeground()
       movedToForeground.end()
 
-      expect(logger.warn).toHaveBeenCalledTimes(2)
+      expect(logger.warn).not.toHaveBeenCalled()
 
       // entirely in background
       backgroundingListener.sendToBackground()
       const backgroundSpan = client.startSpan('entirely-in-background')
       backgroundSpan.end()
 
-      expect(logger.warn).toHaveBeenCalledTimes(3)
+      expect(logger.warn).not.toHaveBeenCalled()
 
       // started and ended in foreground but backgrounded during span
       backgroundingListener.sendToForeground()
@@ -457,7 +456,7 @@ describe('Span', () => {
       backgroundingListener.sendToForeground()
       backgroundedDuringSpan.end()
 
-      expect(logger.warn).toHaveBeenCalledTimes(4)
+      expect(logger.warn).not.toHaveBeenCalled()
 
       // entirely in foreground (should be delivered)
       const inForeground = client.startSpan('entirely-in-foreground')
@@ -465,7 +464,7 @@ describe('Span', () => {
 
       await jest.runOnlyPendingTimersAsync()
 
-      expect(logger.warn).toHaveBeenCalledTimes(4)
+      expect(logger.warn).not.toHaveBeenCalled()
 
       expect(delivery).not.toHaveSentSpan(expect.objectContaining({
         name: 'moved-to-background'
@@ -517,7 +516,7 @@ describe('Span', () => {
 
       await jest.runOnlyPendingTimersAsync()
 
-      expect(logger.warn).toHaveBeenCalledWith('Attempted to end a Span which has already ended or been discarded.')
+      expect(logger.warn).toHaveBeenCalledWith('Attempted to end a Span which has already ended.')
       expect(delivery.requests).toHaveLength(1)
     })
   })


### PR DESCRIPTION
## Goal

It will be fairly common for a span to be discarded before being ended as we do this automatically when the page is backgrounded

Now we will only warn if a span is explicitly ended multiple times
