### PR TITLE
Remove 'Bugsnag-Sent-At' header

### DIFF
--- a/packages/platforms/browser/lib/delivery.ts
+++ b/packages/platforms/browser/lib/delivery.ts
@@ -47,8 +47,7 @@ function createBrowserDeliveryFactory (fetch: Fetch, backgroundingListener: Back
             headers: {
               'Bugsnag-Api-Key': apiKey,
               'Content-Type': 'application/json',
-              'Bugsnag-Span-Sampling': `1.0:${spanCount}`,
-              'Bugsnag-Sent-At': (new Date()).toISOString()
+              'Bugsnag-Span-Sampling': `1.0:${spanCount}`
             }
           })
 

--- a/packages/platforms/browser/tests/delivery.test.ts
+++ b/packages/platforms/browser/tests/delivery.test.ts
@@ -6,9 +6,6 @@ import { type DeliveryPayload } from '@bugsnag/core-performance'
 import { ControllableBackgroundingListener } from '@bugsnag/js-performance-test-utilities'
 import createBrowserDeliveryFactory from '../lib/delivery'
 
-// the format of the Bugsnag-Sent-At header: YYYY-MM-DDTHH:mm:ss.sssZ
-const SENT_AT_FORMAT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
-
 describe('Browser Delivery', () => {
   it('delivers a span', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
@@ -43,8 +40,7 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1.0:1',
-        'Content-Type': 'application/json',
-        'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
+        'Content-Type': 'application/json'
       }
     })
   })
@@ -85,8 +81,7 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1.0:1',
-        'Content-Type': 'application/json',
-        'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
+        'Content-Type': 'application/json'
       }
     })
   })
@@ -128,8 +123,7 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1.0:1',
-        'Content-Type': 'application/json',
-        'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
+        'Content-Type': 'application/json'
       }
     })
   })
@@ -167,8 +161,7 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1.0:0',
-        'Content-Type': 'application/json',
-        'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
+        'Content-Type': 'application/json'
       }
     })
 


### PR DESCRIPTION
## Goal

This reverts commit 15928b2c75d08dfdcdcf6505267d73274f3cd304.

This causes a CORS error because "Bugsnag-Sent-At" is not in "Access-Control-Allow-Headers":

> Access to fetch at 'https://otlp.bugsnag.com/v1/traces' from origin '$origin' has been blocked by CORS policy: Request header field bugsnag-sent-at is not allowed by Access-Control-Allow-Headers in preflight response.

This wasn't caught by e2e tests because it's in Maze Runner's list of allowed headers