### PR TITLE
Set category and phase attributes on page load phase spans

### DIFF
--- a/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
@@ -1,6 +1,18 @@
 import type { SpanContext, SpanFactory } from '@bugsnag/core-performance'
 import { type PerformanceWithTiming } from '../on-settle/load-event-end-settler'
 
+type PageLoadPhase
+  = 'Unload'
+  | 'Redirect'
+  | 'LoadFromCache'
+  | 'DNSLookup'
+  | 'TCPHandshake'
+  | 'TLS'
+  | 'HTTPRequest'
+  | 'HTTPResponse'
+  | 'DomContentLoadedEvent'
+  | 'LoadEvent'
+
 function shouldOmitSpan (startTime?: number, endTime?: number): boolean {
   return (startTime === undefined || endTime === undefined) ||
   (startTime === 0 && endTime === 0)
@@ -12,7 +24,7 @@ export const instrumentPageLoadPhaseSpans = (
   route: string,
   parentContext: SpanContext
 ) => {
-  function createPageLoadPhaseSpan (phase: string, startTime: number, endTime: number) {
+  function createPageLoadPhaseSpan (phase: PageLoadPhase, startTime: number, endTime: number) {
     if (shouldOmitSpan(startTime, endTime)) return
     const span = spanFactory.startSpan(`[PageLoadPhase/${phase}]${route}`, {
       startTime,

--- a/packages/platforms/browser/tests/auto-instrumentation/page-load-phase-spans.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/page-load-phase-spans.test.ts
@@ -37,78 +37,127 @@ describe('PageLoadPhase Spans', () => {
 
     instrumentPageLoadPhaseSpans(spanFactory, performance, '/page-load-phase-spans', fullPageLoadSpan)
 
-    expect(spanFactory.createdSpans).toStrictEqual([
-      expect.objectContaining({
-        name: '[PageLoadPhase/Unload]/page-load-phase-spans',
-        startTime: 2,
-        endTime: 3,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/Redirect]/page-load-phase-spans',
-        startTime: 4,
-        endTime: 5,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/LoadFromCache]/page-load-phase-spans',
-        startTime: 7,
-        endTime: 8,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/DNSLookup]/page-load-phase-spans',
-        startTime: 8,
-        endTime: 9,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/TCPHandshake]/page-load-phase-spans',
-        startTime: 10,
-        endTime: 11,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/TLS]/page-load-phase-spans',
-        startTime: 11,
-        endTime: 12,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/HTTPRequest]/page-load-phase-spans',
-        startTime: 13,
-        endTime: 14,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/HTTPResponse]/page-load-phase-spans',
-        startTime: 14,
-        endTime: 15,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/DomContentLoadedEvent]/page-load-phase-spans',
-        startTime: 17,
-        endTime: 18,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      }),
-      expect.objectContaining({
-        name: '[PageLoadPhase/LoadEvent]/page-load-phase-spans',
-        startTime: 20,
-        endTime: 21,
-        parentSpanId: PAGE_LOAD_ID,
-        traceId: PAGE_LOAD_TRACE_ID
-      })
-    ])
+    expect(spanFactory.createdSpans.length).toBe(10)
+
+    const unloadSpan = spanFactory.createdSpans[0]
+    expect(unloadSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/Unload]/page-load-phase-spans',
+      startTime: 2,
+      endTime: 3,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(unloadSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(unloadSpan).toHaveAttribute('bugsnag.phase', 'Unload')
+
+    const redirectSpan = spanFactory.createdSpans[1]
+    expect(redirectSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/Redirect]/page-load-phase-spans',
+      startTime: 4,
+      endTime: 5,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(redirectSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(redirectSpan).toHaveAttribute('bugsnag.phase', 'Redirect')
+
+    const loadFromCacheSpan = spanFactory.createdSpans[2]
+    expect(loadFromCacheSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/LoadFromCache]/page-load-phase-spans',
+      startTime: 7,
+      endTime: 8,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(loadFromCacheSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(loadFromCacheSpan).toHaveAttribute('bugsnag.phase', 'LoadFromCache')
+
+    const DNSLookupSpan = spanFactory.createdSpans[3]
+    expect(DNSLookupSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/DNSLookup]/page-load-phase-spans',
+      startTime: 8,
+      endTime: 9,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(DNSLookupSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(DNSLookupSpan).toHaveAttribute('bugsnag.phase', 'DNSLookup')
+
+    const TCPHandshakeSpan = spanFactory.createdSpans[4]
+    expect(TCPHandshakeSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/TCPHandshake]/page-load-phase-spans',
+      startTime: 10,
+      endTime: 11,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(TCPHandshakeSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(TCPHandshakeSpan).toHaveAttribute('bugsnag.phase', 'TCPHandshake')
+
+    const TLSSpan = spanFactory.createdSpans[5]
+    expect(TLSSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/TLS]/page-load-phase-spans',
+      startTime: 11,
+      endTime: 12,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(TLSSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(TLSSpan).toHaveAttribute('bugsnag.phase', 'TLS')
+
+    const HTTPRequestSpan = spanFactory.createdSpans[6]
+    expect(HTTPRequestSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/HTTPRequest]/page-load-phase-spans',
+      startTime: 13,
+      endTime: 14,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(HTTPRequestSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(HTTPRequestSpan).toHaveAttribute('bugsnag.phase', 'HTTPRequest')
+
+    const HTTPResponseSpan = spanFactory.createdSpans[7]
+    expect(HTTPResponseSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/HTTPResponse]/page-load-phase-spans',
+      startTime: 14,
+      endTime: 15,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(HTTPResponseSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(HTTPResponseSpan).toHaveAttribute('bugsnag.phase', 'HTTPResponse')
+
+    const domContentLoadedEventSpan = spanFactory.createdSpans[8]
+    expect(domContentLoadedEventSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/DomContentLoadedEvent]/page-load-phase-spans',
+      startTime: 17,
+      endTime: 18,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(domContentLoadedEventSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(domContentLoadedEventSpan).toHaveAttribute('bugsnag.phase', 'DomContentLoadedEvent')
+
+    const loadEventSpan = spanFactory.createdSpans[9]
+    expect(loadEventSpan).toEqual(expect.objectContaining({
+      name: '[PageLoadPhase/LoadEvent]/page-load-phase-spans',
+      startTime: 20,
+      endTime: 21,
+      parentSpanId: PAGE_LOAD_ID,
+      traceId: PAGE_LOAD_TRACE_ID
+    }))
+
+    expect(loadEventSpan).toHaveAttribute('bugsnag.span.category', 'page_load_phase')
+    expect(loadEventSpan).toHaveAttribute('bugsnag.phase', 'LoadEvent')
   })
 
   it('does not create a span if both timestamps are 0', () => {

--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -7,12 +7,12 @@ Feature: Page Load spans
         And I wait to receive 1 traces
 
         Then a span named "[FullPageLoad]/page-load-spans/" contains the attributes:
-            | attribute                         | type             | value                    |
-            | bugsnag.span.category             | stringValue      | full_page_load           |
-            | bugsnag.browser.page.title        | stringValue      | Page load spans          |
-            | bugsnag.browser.page.route        | stringValue      | /page-load-spans/        |
+            | attribute                         | type             | value                     |
+            | bugsnag.span.category             | stringValue      | full_page_load            |
+            | bugsnag.browser.page.title        | stringValue      | Page load spans           |
+            | bugsnag.browser.page.route        | stringValue      | /page-load-spans/         |
         # Skipping until the referrer handling is implemented for mobile devices [PLAT-10176]
-           #| bugsnag.browser.page.referrer     | stringValue      | /                        |
+           #| bugsnag.browser.page.referrer     | stringValue      | /                         |
         
         # Validate all web vitals events and attributes are present, depending on browser support (browser-steps.rb)  
         And the span named "[FullPageLoad]/page-load-spans/" is a valid full page load span
@@ -23,27 +23,31 @@ Feature: Page Load spans
         # We expect the following spans to always be present
         And a span named "[PageLoadPhase/HTTPRequest]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"
         And a span named "[PageLoadPhase/HTTPRequest]/page-load-spans/" contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | HTTPRequest           |
 
         And a span named "[PageLoadPhase/HTTPResponse]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"
         And a span named "[PageLoadPhase/HTTPResponse]/page-load-spans/" contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | HTTPResponse          |
 
         And a span named "[PageLoadPhase/DomContentLoadedEvent]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"
         And a span named "[PageLoadPhase/DomContentLoadedEvent]/page-load-spans/" contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | DomContentLoadedEvent |
 
         And a span named "[PageLoadPhase/LoadEvent]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"
         And a span named "[PageLoadPhase/LoadEvent]/page-load-spans/" contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | LoadEvent             |
 
         # The following spans may or may not be present in the trace. In most cases this is
         # because page load phase spans are not sent if the start and end times of the
@@ -52,43 +56,49 @@ Feature: Page Load spans
         # Redirect may have 0 start and end times
         And if a span named "[PageLoadPhase/Redirect]/page-load-spans/" exists, it has a parent named "[FullPageLoad]/page-load-spans/"
         And if a span named "[PageLoadPhase/Redirect]/page-load-spans/" exists, it contains the attributes:
-            | attribute                                 | type         | value           |
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 |
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | Redirect              |
 
         # Unload may have 0 start and end times
         And if a span named "[PageLoadPhase/Unload]/page-load-spans/" exists, it has a parent named "[FullPageLoad]/page-load-spans/"
         And if a span named "[PageLoadPhase/Unload]/page-load-spans/" exists, it contains the attributes:
-            | attribute                                 | type         | value           |
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 |
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | Unload                |
 
         # LoadFromCache may have 0 start and end times 
         And if a span named "[PageLoadPhase/LoadFromCache]/page-load-spans/" exists, it has a parent named "[FullPageLoad]/page-load-spans/"
         And if a span named "[PageLoadPhase/LoadFromCache]/page-load-spans/" exists, it contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | LoadFromCache         |
 
         # DNSLookup may have 0 start and end times
         And if a span named "[PageLoadPhase/DNSLookup]/page-load-spans/" exists, it has a parent named "[FullPageLoad]/page-load-spans/"
         And if a span named "[PageLoadPhase/DNSLookup]/page-load-spans/" exists, it contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | DNSLookup             |
 
         # TCPHandshake may have 0 start and end times 
         And if a span named "[PageLoadPhase/TCPHandshake]/page-load-spans/" exists, it has a parent named "[FullPageLoad]/page-load-spans/"
-        And a span named "[PageLoadPhase/TCPHandshake]/page-load-spans/" contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+        And if a span named "[PageLoadPhase/TCPHandshake]/page-load-spans/" exists, it contains the attributes:
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | TCPHandshake          |
 
         # TLS may have 0 start and end times
         And if a span named "[PageLoadPhase/TLS]/page-load-spans/" exists, it has a parent named "[FullPageLoad]/page-load-spans/"
         And if a span named "[PageLoadPhase/TLS]/page-load-spans/" exists, it contains the attributes:
-            | attribute                                 | type         | value           | 
-            | bugsnag.span.category                     | stringValue  | custom          |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans |
+            | attribute                                 | type         | value                 | 
+            | bugsnag.span.category                     | stringValue  | page_load_phase       |
+            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.phase                             | stringValue  | TLS                   |
 
 


### PR DESCRIPTION
## Goal

Sets the following required attributes for page load phase spans:

`bugsnag.span.category: page_load_phase`
`bugsnag.phase: Phase`