### PR TITLE
Add release script

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -28,6 +28,9 @@ cd /app/bugsnag-js-performance
 # "ci" rather than "install" ensures the process doesn't make the work tree dirty by modifying lockfiles
 npm ci
 
+# check if CDN packages changed – if they didn't we don't need to upload to the CDN
+BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/platforms/js$ || test $? = 1;)
+
 # increment package version numbers
 if [ -z "${RETRY_PUBLISH:-}" ]; then
   case $VERSION in
@@ -43,9 +46,6 @@ fi
 
 # build packages
 npm run build
-
-# check if CDN packages changed – if they didn't we don't need to upload to the CDN
-BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/platforms/js$ || test $? = 1;)
 
 # push version bump commit and tags
 git push origin

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -47,8 +47,8 @@ npm run build
 # check if CDN packages changed – if they didn't we don't need to upload to the CDN
 BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/platforms/js$ || test $? = 1;)
 
-# push git tags
-git push origin --tags
+# push version bump commit and tags
+git push origin
 
 # publish
 if [ -z "${RETRY_PUBLISH:-}" ]; then

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -15,11 +15,9 @@ if [[ -z ${VERSION:-} ]]; then error_missing_field "VERSION"; fi
 if [[ -z ${AWS_ACCESS_KEY_ID:-} ]]; then error_missing_field "AWS_ACCESS_KEY_ID"; fi
 if [[ -z ${AWS_SECRET_ACCESS_KEY:-} ]]; then error_missing_field "AWS_SECRET_ACCESS_KEY"; fi
 if [[ -z ${AWS_SESSION_TOKEN:-} ]]; then error_missing_field "AWS_SESSION_TOKEN"; fi
-
-# Set defaults for CDN upload if not set
-: "${BUCKET_NAME:=bugsnagcdn}"
-: "${DISTRIBUTION_ID:=E205JDPNKONLN7}"
-: "${AWS_REGION:=us-east-1}"
+if [[ -z ${AWS_REGION:-} ]]; then error_missing_field "AWS_REGION"; fi
+if [[ -z ${BUCKET_NAME:-} ]]; then error_missing_field "BUCKET_NAME"; fi
+if [[ -z ${DISTRIBUTION_ID:-} ]]; then error_missing_field "DISTRIBUTION_ID"; fi
 
 git clone --single-branch --recursive \
   --branch "$RELEASE_BRANCH" \

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+error_missing_field () {
+  echo "Missing required env var: $1"
+  exit 1
+}
+
+# Ensure all required variables are set before doing any work
+if [[ -z ${GITHUB_USER:-} ]]; then error_missing_field 'GITHUB_USER'; fi
+if [[ -z ${GITHUB_ACCESS_TOKEN:-} ]]; then error_missing_field "GITHUB_ACCESS_TOKEN"; fi
+if [[ -z ${RELEASE_BRANCH:-} ]]; then error_missing_field "RELEASE_BRANCH"; fi
+if [[ -z ${VERSION:-} ]]; then error_missing_field "VERSION"; fi
+
+git clone --single-branch --recursive \
+  --branch "$RELEASE_BRANCH" \
+  https://"$GITHUB_USER":"$GITHUB_ACCESS_TOKEN"@github.com/bugsnag/bugsnag-js-performance.git
+
+cd /app/bugsnag-js-performance
+
+# "ci" rather than "install" ensures the process doesn't make the work tree dirty by modifying lockfiles
+npm ci
+
+# increment package version numbers
+if [ -z "${RETRY_PUBLISH:-}" ]; then
+  case $VERSION in
+    "prerelease" | "prepatch" | "preminor" | "premajor")
+      npx lerna version "$VERSION" --dist-tag next --no-push
+      ;;
+
+    *)
+      npx lerna version "$VERSION" --no-push
+      ;;
+  esac
+fi
+
+# build packages
+npm run build
+
+# push git tags
+git push origin --tags
+
+# publish
+if [ -z "${RETRY_PUBLISH:-}" ]; then
+  npx lerna publish from-git
+else
+  npx lerna publish from-package
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,9 @@ services:
       AWS_ACCESS_KEY_ID:
       AWS_SESSION_TOKEN:
       AWS_SECRET_ACCESS_KEY:
+      AWS_REGION:
+      BUCKET_NAME:
+      DISTRIBUTION_ID:
       VERSION:
     volumes:
       - ~/.gitconfig:/home/releaser/.gitconfig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,10 @@ services:
       GITHUB_ACCESS_TOKEN:
       RELEASE_BRANCH:
       RETRY_PUBLISH:
+      FORCE_CDN_UPLOAD:
+      AWS_ACCESS_KEY_ID:
+      AWS_SESSION_TOKEN:
+      AWS_SECRET_ACCESS_KEY:
       VERSION:
     volumes:
       - ~/.gitconfig:/home/releaser/.gitconfig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,20 @@ services:
     volumes:
       - ./test/browser/maze_output:/app/test/browser/maze_output
 
+  release:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.release
+    environment:
+      GITHUB_USER:
+      GITHUB_ACCESS_TOKEN:
+      RELEASE_BRANCH:
+      RETRY_PUBLISH:
+      VERSION:
+    volumes:
+      - ~/.gitconfig:/home/releaser/.gitconfig
+      - ~/.npmrc:/home/releaser/.npmrc
+
 networks:
   default:
     name: ${BUILDKITE_JOB_ID:-core-maze-runner}

--- a/dockerfiles/Dockerfile.release
+++ b/dockerfiles/Dockerfile.release
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+RUN apk add --update git bash openssh-client curl
+
+RUN addgroup -S admins
+RUN adduser -S releaser -G admins
+
+WORKDIR /app
+
+RUN chown -R releaser:admins /app
+USER releaser
+
+COPY ./bin/release.sh ./
+
+CMD ./release.sh


### PR DESCRIPTION
Adapted the release script and process from the `@bugsnag/js` repo with a few tweaks for the performance library. 

Run in much the same way:
- `docker compose build release`
- (with relevant environment variables set) `docker compose run release`
