### PR TITLE
[PLAT-10342] First class span attributes

### DIFF
--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -3,7 +3,9 @@ import { isNumber } from './validation'
 
 export type SpanAttribute = string | number | boolean
 
-export type SpanAttributesSource = () => Map<string, SpanAttribute>
+export interface SpanAttributesSourceOptions { includeFirstClassAttributes: boolean }
+
+export type SpanAttributesSource = (options: SpanAttributesSourceOptions) => Map<string, SpanAttribute>
 
 export class SpanAttributes {
   private readonly attributes: Map<string, SpanAttribute>

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -65,7 +65,10 @@ export class SpanFactory {
     const parentSpanId = parentContext ? parentContext.id : undefined
     const traceId = parentContext ? parentContext.traceId : this.idGenerator.generate(128)
 
-    const attributes = new SpanAttributes(this.spanAttributesSource())
+    // Spans that don't specify whether they are first class or not are implicity first class
+    const includeFirstClassAttributes = options && typeof options.isFirstClass === 'boolean' ? options.isFirstClass : true
+
+    const attributes = new SpanAttributes(this.spanAttributesSource({ includeFirstClassAttributes }))
 
     if (options && typeof options.isFirstClass === 'boolean') {
       attributes.set('bugsnag.span.first_class', options.isFirstClass)

--- a/packages/platforms/browser/lib/span-attributes-source.ts
+++ b/packages/platforms/browser/lib/span-attributes-source.ts
@@ -1,11 +1,15 @@
 import type { SpanAttribute, SpanAttributesSource } from '@bugsnag/core-performance'
 
 const createSpanAttributesSource = (title: string, url: string): SpanAttributesSource => {
-  return () => {
+  return ({ includeFirstClassAttributes }) => {
     const spanAttributes = new Map<string, SpanAttribute>()
+
     spanAttributes.set('bugsnag.span.category', 'custom')
-    spanAttributes.set('bugsnag.browser.page.url', url)
-    spanAttributes.set('bugsnag.browser.page.title', title)
+
+    if (includeFirstClassAttributes) {
+      spanAttributes.set('bugsnag.browser.page.url', url)
+      spanAttributes.set('bugsnag.browser.page.title', title)
+    }
 
     return spanAttributes
   }

--- a/packages/platforms/browser/tests/span-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/span-attributes-source.test.ts
@@ -10,11 +10,22 @@ describe('spanAttributesSource', () => {
       'the page title',
       'https://www.bugsnag.com'
     )
-    const spanAttributes = spanAttributesSource()
+    const spanAttributes = spanAttributesSource({ includeFirstClassAttributes: true })
     expect(Array.from(spanAttributes.entries())).toEqual([
       ['bugsnag.span.category', 'custom'],
       ['bugsnag.browser.page.url', 'https://www.bugsnag.com'],
       ['bugsnag.browser.page.title', 'the page title']
+    ])
+  })
+
+  it('excludes url and title attributes when firstClass = false', () => {
+    const spanAttributesSource = createSpanAttributesSource(
+      'the page title',
+      'https://www.bugsnag.com'
+    )
+    const spanAttributes = spanAttributesSource({ includeFirstClassAttributes: false })
+    expect(Array.from(spanAttributes.entries())).toEqual([
+      ['bugsnag.span.category', 'custom']
     ])
   })
 })


### PR DESCRIPTION
## Goal

Exclude 'first class attributes' when `isFirstClass` option is set to `false`.

## Testing

Unit test that attributes are not set when a span is not first class