### PR TITLE
Page load and Route change span attributes

### DIFF
--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -66,6 +66,8 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
       // Browser attributes
       span.setAttribute('bugsnag.span.category', 'full_page_load')
       span.setAttribute('bugsnag.browser.page.referrer', this.document.referrer)
+      span.setAttribute('bugsnag.browser.page.title', this.document.title)
+      span.setAttribute('bugsnag.browser.page.url', url.toString())
       span.setAttribute('bugsnag.browser.page.route', route)
 
       this.webVitals.attachTo(span)

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -1,14 +1,13 @@
 import { type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
 import { type BrowserConfiguration } from '../config'
+import getAbsoluteUrl from '../request-tracker/url-helpers'
 
 export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
-  private readonly spanFactory: SpanFactory
-  private readonly location: Location
-
-  constructor (spanFactory: SpanFactory, location: Location) {
-    this.spanFactory = spanFactory
-    this.location = location
-  }
+  constructor (
+    private readonly spanFactory: SpanFactory,
+    private readonly location: Location,
+    private readonly document: Document
+  ) {}
 
   configure (configuration: InternalConfiguration<BrowserConfiguration>) {
     if (!configuration.autoInstrumentRouteChanges) return
@@ -20,14 +19,25 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
         startTime: options ? options.startTime : undefined
       })
 
+      const url = getAbsoluteUrl(route, this.document.baseURI)
+
       span.setAttribute('bugsnag.span.category', 'route_change')
       span.setAttribute('bugsnag.browser.page.route', route)
+      span.setAttribute('bugsnag.browser.page.url', url)
       span.setAttribute('bugsnag.browser.page.previous_route', previousRoute)
       span.setAttribute('bugsnag.browser.page.route_change.trigger', trigger)
 
       previousRoute = route
 
-      return this.spanFactory.toPublicApi(span)
+      return {
+        id: span.id,
+        traceId: span.traceId,
+        isValid: span.isValid,
+        end: (endTime) => {
+          span.setAttribute('bugsnag.browser.page.title', this.document.title)
+          this.spanFactory.toPublicApi(span).end(endTime)
+        }
+      }
     })
   }
 }

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -54,7 +54,7 @@ const BugsnagPerformance = createClient({
     // span context as the parent of it's spans
     new ResourceLoadPlugin(spanFactory, spanContextStorage, window.PerformanceObserver),
     new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
-    new RouteChangePlugin(spanFactory, window.location)
+    new RouteChangePlugin(spanFactory, window.location, document)
   ],
   persistence
 })

--- a/packages/platforms/browser/tests/routing-provider.test.ts
+++ b/packages/platforms/browser/tests/routing-provider.test.ts
@@ -23,7 +23,7 @@ describe('DefaultRoutingProvider', () => {
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, routingProvier),
-      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
+      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location, document)]
     })
 
     testClient.start({ apiKey: VALID_API_KEY })
@@ -45,7 +45,7 @@ describe('DefaultRoutingProvider', () => {
         clock,
         deliveryFactory: () => delivery,
         schema: createSchema(window.location.hostname, routingProvier),
-        plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location)]
+        plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location, document)]
       })
 
       testClient.start({ apiKey: VALID_API_KEY })


### PR DESCRIPTION
## Goal

To set url and title attributes when a page load or route change span settles, rather than when it's created

## Testing

Updated unit tests