### PR TITLE
[PLAT-10176] Referrer attribute testing

### DIFF
--- a/test/browser/features/fixtures/packages/page-load-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/page-load-spans/src/index.js
@@ -4,4 +4,4 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 13, batchInactivityTimeoutMs: 3000, autoInstrumentNetworkRequests: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 13, batchInactivityTimeoutMs: 5000, autoInstrumentNetworkRequests: false })

--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -11,8 +11,7 @@ Feature: Page Load spans
             | bugsnag.span.category             | stringValue      | full_page_load            |
             | bugsnag.browser.page.title        | stringValue      | New title                 |
             | bugsnag.browser.page.route        | stringValue      | /page-load-spans/         |
-        # Skipping until the referrer handling is implemented for mobile devices [PLAT-10176]
-           #| bugsnag.browser.page.referrer     | stringValue      | /                         |
+            | bugsnag.browser.page.referrer     | stringValue      |                           |
         
         # Validate all web vitals events and attributes are present, depending on browser support (browser-steps.rb)  
         And the span named "[FullPageLoad]/page-load-spans/" is a valid full page load span

--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -11,8 +11,7 @@ Feature: Page Load spans
             | bugsnag.span.category             | stringValue      | full_page_load            |
             | bugsnag.browser.page.title        | stringValue      | New title                 |
             | bugsnag.browser.page.route        | stringValue      | /page-load-spans/         |
-            | bugsnag.browser.page.referrer     | stringValue      |                           |
-        
+
         # Validate all web vitals events and attributes are present, depending on browser support (browser-steps.rb)  
         And the span named "[FullPageLoad]/page-load-spans/" is a valid full page load span
 

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -127,7 +127,7 @@ Then("the span named {string} is a valid full page load span") do |span_name|
 
   Maze.check.true(
     referrer == scenario_referrer,
-    "Attribute does not match, expected #{scenario_referrer}, got #{referrer}"
+    "Referrer attribute does not match, expected #{scenario_referrer}, got #{referrer}"
   )
 
   if supports_cumulative_layout_shift

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -112,13 +112,6 @@ Then("the span named {string} is a valid full page load span") do |span_name|
     )
   end
 
-  def get_attribute_value_from_span(span, attribute, attr_type)
-    attributes = span['attributes']
-    attribute = attributes.find { |a| a['key'] == attribute }
-    value = attribute&.dig 'value', attr_type
-    attr_type == 'intValue' && value.is_a?(String) ? value.to_i : value
-  end
-
   # Check the string attribute "referrer" is equal to document.referrer
   referrer = get_attribute_value_from_span(span, "bugsnag.browser.page.referrer", "stringValue")
 
@@ -219,4 +212,11 @@ module Maze
       end
     end
   end
+end
+
+def get_attribute_value_from_span(span, attribute, attr_type)
+  attributes = span['attributes']
+  attribute = attributes.find { |a| a['key'] == attribute }
+  value = attribute&.dig 'value', attr_type
+  attr_type == 'intValue' && value.is_a?(String) ? value.to_i : value
 end


### PR DESCRIPTION
## Goal

Test the `bugsnag.browser.page.referrer` attribute is validated in end to end tests