### PR TITLE
Handle invalid inputs to startSpan

### DIFF
--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -5,7 +5,7 @@ import { type Logger } from './config'
 import { type IdGenerator } from './id-generator'
 import { type Processor } from './processor'
 import { type ReadonlySampler } from './sampler'
-import { type Span, SpanInternal, type SpanOptions, validateSpanOptions } from './span'
+import { SpanInternal, type Span, type SpanOptions } from './span'
 import { type SpanContextStorage } from './span-context'
 import { timeToNumber } from './time'
 import { isSpanContext } from './validation'
@@ -51,17 +51,15 @@ export class SpanFactory {
     this.openSpans = new WeakSet<SpanInternal>()
   }
 
-  startSpan (name: string, options?: SpanOptions) {
-    const cleanOptions = validateSpanOptions(name, options || {}, this.logger)
-
-    const safeStartTime = timeToNumber(this.clock, cleanOptions.startTime)
+  startSpan (name: string, options: SpanOptions) {
+    const safeStartTime = timeToNumber(this.clock, options.startTime)
     const spanId = this.idGenerator.generate(64)
 
     // if the parentContext option is not set use the current context
     // if parentContext is explicitly null, or there is no current context,
     // we are starting a new root span
-    const parentContext = isSpanContext(cleanOptions.parentContext) || cleanOptions.parentContext === null
-      ? cleanOptions.parentContext
+    const parentContext = isSpanContext(options.parentContext) || options.parentContext === null
+      ? options.parentContext
       : this.spanContextStorage.current
 
     const parentSpanId = parentContext ? parentContext.id : undefined
@@ -69,17 +67,17 @@ export class SpanFactory {
 
     const attributes = new SpanAttributes(this.spanAttributesSource())
 
-    if (typeof cleanOptions.isFirstClass === 'boolean') {
-      attributes.set('bugsnag.span.first_class', cleanOptions.isFirstClass)
+    if (typeof options.isFirstClass === 'boolean') {
+      attributes.set('bugsnag.span.first_class', options.isFirstClass)
     }
 
-    const span = new SpanInternal(spanId, traceId, cleanOptions.name, safeStartTime, attributes, parentSpanId)
+    const span = new SpanInternal(spanId, traceId, name, safeStartTime, attributes, parentSpanId)
 
     // don't track spans that are started while the app is backgrounded
     if (this.isInForeground) {
       this.openSpans.add(span)
 
-      if (!cleanOptions || cleanOptions.makeCurrentContext !== false) {
+      if (options.makeCurrentContext !== false) {
         this.spanContextStorage.push(span)
       }
     }

--- a/packages/core/lib/validation.ts
+++ b/packages/core/lib/validation.ts
@@ -1,6 +1,7 @@
 import { type Logger } from './config'
 import { type PersistedProbability } from './persistence'
 import { type SpanContext } from './span-context'
+import { type Time } from './time'
 
 export const isBoolean = (value: unknown): value is boolean =>
   value === true || value === false
@@ -38,3 +39,7 @@ export const isSpanContext = (value: unknown): value is SpanContext =>
     typeof value.id === 'string' &&
     typeof value.traceId === 'string' &&
     typeof value.isValid === 'function'
+
+export function isTime (value: unknown): value is Time {
+  return isNumber(value) || value instanceof Date
+}

--- a/packages/core/tests/span-context.test.ts
+++ b/packages/core/tests/span-context.test.ts
@@ -1,5 +1,28 @@
 import { type SpanContext, DefaultSpanContextStorage, spanContextEquals } from '../lib'
-import { ControllableBackgroundingListener } from '@bugsnag/js-performance-test-utilities'
+import {
+  ControllableBackgroundingListener,
+  InMemoryDelivery,
+  IncrementingClock,
+  VALID_API_KEY,
+  createTestClient
+} from '@bugsnag/js-performance-test-utilities'
+
+describe('SpanContext', () => {
+  describe('SpanContext.isValid()', () => {
+    it('returns false if the span has been ended', () => {
+      const delivery = new InMemoryDelivery()
+      const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+      const client = createTestClient({ deliveryFactory: () => delivery, clock })
+      client.start({ apiKey: VALID_API_KEY })
+
+      const span = client.startSpan('test span')
+      expect(span.isValid()).toEqual(true)
+
+      span.end()
+      expect(span.isValid()).toEqual(false)
+    })
+  })
+})
 
 describe('DefaultSpanContextStorage', () => {
   describe('SpanContextStorage.push()', () => {

--- a/packages/core/tests/span-context.test.ts
+++ b/packages/core/tests/span-context.test.ts
@@ -7,6 +7,8 @@ import {
   createTestClient
 } from '@bugsnag/js-performance-test-utilities'
 
+jest.useFakeTimers()
+
 describe('SpanContext', () => {
   describe('SpanContext.isValid()', () => {
     it('returns false if the span has been ended', () => {

--- a/packages/core/tests/span-factory.test.ts
+++ b/packages/core/tests/span-factory.test.ts
@@ -2,7 +2,6 @@ import { DefaultSpanContextStorage } from '@bugsnag/core-performance'
 import {
   ControllableBackgroundingListener,
   InMemoryDelivery,
-  InMemoryProcessor,
   IncrementingClock,
   IncrementingIdGenerator,
   StableIdGenerator,
@@ -28,373 +27,214 @@ beforeEach(() => {
 
 describe('SpanFactory', () => {
   describe('startSpan', () => {
-    describe('name', () => {
-      const invalidSpanNames: any[] = [
-        { type: 'bigint', name: BigInt(9007199254740991) },
-        { type: 'true', name: true },
-        { type: 'false', name: false },
-        { type: 'function', name: () => {} },
-        { type: 'object', name: { property: 'test' } },
-        { type: 'empty array', name: [] },
-        { type: 'array', name: [1, 2, 3] },
-        { type: 'symbol', name: Symbol('test') },
-        { type: 'null', name: null }
-      ]
+    describe('startTime', () => {})
 
-      it.each(invalidSpanNames)('stringifies and logs when span name is invalid ($type)', async ({ name }) => {
-        const spanFactory = new SpanFactory(
-          new InMemoryProcessor(),
-          new Sampler(1.0),
-          new StableIdGenerator(),
-          spanAttributesSource,
-          new IncrementingClock(),
-          new ControllableBackgroundingListener(),
-          jestLogger,
-          new DefaultSpanContextStorage(new ControllableBackgroundingListener())
-        )
+    describe('parentContext', () => {
+      it('sets traceId and parentSpanId from parentContext if specified', async () => {
+        const delivery = new InMemoryDelivery()
+        const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
+        client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        await jest.runOnlyPendingTimersAsync()
 
-        const span = spanFactory.startSpan(name)
-        expect(span.name).toEqual(String(name))
-        expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - name should be a string, got ${typeof name}`)
+        // push two spans onto the context stack
+        const span1 = client.startSpan('should become parent')
+        const span2 = client.startSpan('should not become parent')
+        expect(spanContextEquals(span2, client.currentSpanContext)).toBe(true)
+
+        // start a new child span with an invalid parent context
+        const childOfSpan1 = client.startSpan('child of span 1', { parentContext: span1 })
+        childOfSpan1.end()
+
+        await jest.runOnlyPendingTimersAsync()
+
+        // child span should be nested under the first span
+        expect(delivery).toHaveSentSpan(expect.objectContaining({
+          name: 'child of span 1',
+          parentSpanId: span1.id,
+          traceId: span1.traceId
+        }))
+
+        expect(jestLogger.warn).not.toHaveBeenCalled()
+      })
+
+      it('starts a new root span when parentContext is null', async () => {
+        const idGenerator = new IncrementingIdGenerator()
+        const delivery = new InMemoryDelivery()
+        const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
+        client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        await jest.runOnlyPendingTimersAsync()
+
+        const rootSpan = client.startSpan('root span')
+        expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
+
+        const newRootSpan = client.startSpan('new root span', { parentContext: null })
+        newRootSpan.end()
+
+        await jest.runOnlyPendingTimersAsync()
+
+        // new root span should have a new trace ID and no parentSpanId
+        expect(delivery).toHaveSentSpan(expect.objectContaining({
+          name: 'new root span',
+          parentSpanId: undefined,
+          traceId: `trace ID ${idGenerator.traceCount}`
+        }))
+
+        expect(jestLogger.warn).not.toHaveBeenCalled()
+      })
+
+      it('becomes a child of the current context when parentContext is undefined', async () => {
+        const delivery = new InMemoryDelivery()
+        const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
+        client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        await jest.runOnlyPendingTimersAsync()
+
+        const rootSpan = client.startSpan('root span')
+        expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
+
+        const childSpan = client.startSpan('new root span', { parentContext: undefined })
+        childSpan.end()
+
+        await jest.runOnlyPendingTimersAsync()
+
+        // new root span should have a new trace ID and no parentSpanId
+        expect(delivery).toHaveSentSpan(expect.objectContaining({
+          name: 'new root span',
+          parentSpanId: rootSpan.id,
+          traceId: rootSpan.traceId
+        }))
+
+        expect(jestLogger.warn).not.toHaveBeenCalled()
       })
     })
 
-    describe('options', () => {
-      describe('startTime', () => {
-        const invalidStartTimes: any[] = [
-          { type: 'string', startTime: 'i am not a startTime' },
-          { type: 'bigint', startTime: BigInt(9007199254740991) },
-          { type: 'true', startTime: true },
-          { type: 'false', startTime: false },
-          { type: 'function', startTime: () => {} },
-          { type: 'object', startTime: { property: 'test' } },
-          { type: 'empty array', startTime: [] },
-          { type: 'array', startTime: [1, 2, 3] },
-          { type: 'symbol', startTime: Symbol('test') },
-          { type: 'null', startTime: null }
-        ]
+    describe('makeCurrentContext', () => {
+      it('does not become the current SpanContext when SpanOptions.makeCurrentContext is false', async () => {
+        const client = createTestClient({ idGenerator: new IncrementingIdGenerator() })
+        client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        await jest.runOnlyPendingTimersAsync()
 
-        invalidStartTimes.push(...invalidStartTimes.map(
-          ({ type, startTime }) => ({
-            type: `{ startTime: ${type} }`,
-            startTime: { startTime }
-          }))
-        )
+        expect(client.currentSpanContext).toBeUndefined()
 
-        it.each(invalidStartTimes)('uses default clock implementation and logs if startTime is invalid ($type)', async (options) => {
-          const delivery = new InMemoryDelivery()
-          const clock = new IncrementingClock('1970-01-01T00:00:00Z')
-          const client = createTestClient({ deliveryFactory: () => delivery, clock })
+        const spanIsContext = client.startSpan('context span')
+        expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
 
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        const spanIsNotContext = client.startSpan('non context span', { makeCurrentContext: false })
+        expect(spanContextEquals(spanIsNotContext, client.currentSpanContext)).toBe(false)
+        expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
 
-          await jest.runOnlyPendingTimersAsync()
-
-          const span = client.startSpan('test span', options)
-          span.end()
-
-          await jest.runOnlyPendingTimersAsync()
-
-          expect(delivery).toHaveSentSpan(expect.objectContaining({
-            startTimeUnixNano: '1000000'
-          }))
-
-          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - startTime should be a number or Date, got ${typeof options.startTime}`)
-        })
-      })
-      describe('parentContext', () => {
-        it('sets traceId and parentSpanId from parentContext if specified', async () => {
-          const delivery = new InMemoryDelivery()
-          const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
-          await jest.runOnlyPendingTimersAsync()
-
-          // push two spans onto the context stack
-          const span1 = client.startSpan('should become parent')
-          const span2 = client.startSpan('should not become parent')
-          expect(spanContextEquals(span2, client.currentSpanContext)).toBe(true)
-
-          // start a new child span with an invalid parent context
-          const childOfSpan1 = client.startSpan('child of span 1', { parentContext: span1 })
-          childOfSpan1.end()
-
-          await jest.runOnlyPendingTimersAsync()
-
-          // child span should be nested under the first span
-          expect(delivery).toHaveSentSpan(expect.objectContaining({
-            name: 'child of span 1',
-            parentSpanId: span1.id,
-            traceId: span1.traceId
-          }))
-
-          expect(jestLogger.warn).not.toHaveBeenCalled()
-        })
-
-        it('starts a new root span when parentContext is null', async () => {
-          const idGenerator = new IncrementingIdGenerator()
-          const delivery = new InMemoryDelivery()
-          const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
-          await jest.runOnlyPendingTimersAsync()
-
-          const rootSpan = client.startSpan('root span')
-          expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
-
-          const newRootSpan = client.startSpan('new root span', { parentContext: null })
-          newRootSpan.end()
-
-          await jest.runOnlyPendingTimersAsync()
-
-          // new root span should have a new trace ID and no parentSpanId
-          expect(delivery).toHaveSentSpan(expect.objectContaining({
-            name: 'new root span',
-            parentSpanId: undefined,
-            traceId: `trace ID ${idGenerator.traceCount}`
-          }))
-
-          expect(jestLogger.warn).not.toHaveBeenCalled()
-        })
-
-        it('becomes a child of the current context when parentContext is undefined', async () => {
-          const delivery = new InMemoryDelivery()
-          const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
-          await jest.runOnlyPendingTimersAsync()
-
-          const rootSpan = client.startSpan('root span')
-          expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
-
-          const childSpan = client.startSpan('new root span', { parentContext: undefined })
-          childSpan.end()
-
-          await jest.runOnlyPendingTimersAsync()
-
-          // new root span should have a new trace ID and no parentSpanId
-          expect(delivery).toHaveSentSpan(expect.objectContaining({
-            name: 'new root span',
-            parentSpanId: rootSpan.id,
-            traceId: rootSpan.traceId
-          }))
-
-          expect(jestLogger.warn).not.toHaveBeenCalled()
-        })
-
-        const parentContextOptions: any[] = [
-          { type: 'true', parentContext: true },
-          { type: 'string', parentContext: 'yes please' },
-          { type: 'bigint', parentContext: BigInt(9007199254740991) },
-          { type: 'function', parentContext: () => {} },
-          { type: 'object', parentContext: { property: 'test' } },
-          { type: 'empty array', parentContext: [] },
-          { type: 'array', parentContext: [1, 2, 3] },
-          { type: 'symbol', parentContext: Symbol('test') }
-        ]
-
-        it.each(parentContextOptions)('becomes a child of the current context and logs when parentContext is invalid ($type)', async (options) => {
-          const delivery = new InMemoryDelivery()
-          const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
-          await jest.runOnlyPendingTimersAsync()
-
-          // push two spans onto the context stack
-          client.startSpan('root span')
-          const parentSpan = client.startSpan('parent span')
-          expect(spanContextEquals(parentSpan, client.currentSpanContext)).toBe(true)
-
-          // start a new child span with an invalid parent context
-          const childSpan = client.startSpan('child span', options)
-          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - parentContext should be a SpanContext, got ${typeof options.parentContext}`)
-
-          childSpan.end()
-          await jest.runOnlyPendingTimersAsync()
-
-          // child span should be nested under the parent span
-          expect(delivery).toHaveSentSpan(expect.objectContaining({
-            name: 'child span',
-            parentSpanId: parentSpan.id,
-            traceId: parentSpan.traceId
-          }))
-        })
-      })
-      describe('makeCurrentContext', () => {
-        it('does not become the current SpanContext when SpanOptions.makeCurrentContext is false', async () => {
-          const client = createTestClient({ idGenerator: new IncrementingIdGenerator() })
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
-          await jest.runOnlyPendingTimersAsync()
-
-          expect(client.currentSpanContext).toBeUndefined()
-
-          const spanIsContext = client.startSpan('context span')
-          expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
-
-          const spanIsNotContext = client.startSpan('non context span', { makeCurrentContext: false })
-          expect(spanContextEquals(spanIsNotContext, client.currentSpanContext)).toBe(false)
-          expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
-
-          expect(jestLogger.warn).not.toHaveBeenCalled()
-        })
-
-        it('becomes the current SpanContext when makeCurrentContext is true or undefined', async () => {
-          const client = createTestClient({ idGenerator: new IncrementingIdGenerator() })
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
-          await jest.runOnlyPendingTimersAsync()
-
-          expect(client.currentSpanContext).toBeUndefined()
-
-          const optionIsTrue = client.startSpan('context span', { makeCurrentContext: true })
-          expect(spanContextEquals(optionIsTrue, client.currentSpanContext)).toBe(true)
-
-          const optionIsUndefined = client.startSpan('context span', { makeCurrentContext: undefined })
-          expect(spanContextEquals(optionIsUndefined, client.currentSpanContext)).toBe(true)
-
-          expect(jestLogger.warn).not.toHaveBeenCalled()
-        })
-
-        const makeCurrentContextOptions: any[] = [
-          { type: 'string', makeCurrentContext: 'yes please' },
-          { type: 'bigint', makeCurrentContext: BigInt(9007199254740991) },
-          { type: 'function', makeCurrentContext: () => {} },
-          { type: 'object', makeCurrentContext: { property: 'test' } },
-          { type: 'empty array', makeCurrentContext: [] },
-          { type: 'array', makeCurrentContext: [1, 2, 3] },
-          { type: 'symbol', makeCurrentContext: Symbol('test') },
-          { type: 'null', makeCurrentContext: null }
-        ]
-
-        it.each(makeCurrentContextOptions)('becomes the current SpanContext and logs when makeCurrentContext is invalid ($type)', async (options) => {
-          const client = createTestClient()
-          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
-          await jest.runOnlyPendingTimersAsync()
-
-          expect(client.currentSpanContext).toBeUndefined()
-
-          const spanIsContext = client.startSpan('context span', options)
-          expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
-
-          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - makeCurrentContext should be true|false, got ${typeof options.makeCurrentContext}`)
-        })
-      })
-      describe('isFirstClass', () => {
-        it('omits first class span attribute by default', () => {
-          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-          const sampler = new Sampler(0.5)
-          const delivery = { send: jest.fn() }
-          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-          const backgroundingListener = new ControllableBackgroundingListener()
-          const spanFactory = new SpanFactory(
-            processor,
-            sampler,
-            new StableIdGenerator(),
-            spanAttributesSource,
-            new IncrementingClock(),
-            backgroundingListener,
-            jestLogger,
-            new DefaultSpanContextStorage(backgroundingListener)
-          )
-
-          const span = spanFactory.startSpan('name')
-
-          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-          expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
-        })
-
-        it('creates first class spans when isFirstClass is true', () => {
-          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-          const sampler = new Sampler(0.5)
-          const delivery = { send: jest.fn() }
-          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-          const backgroundingListener = new ControllableBackgroundingListener()
-          const spanFactory = new SpanFactory(
-            processor,
-            sampler,
-            new StableIdGenerator(),
-            spanAttributesSource,
-            new IncrementingClock(),
-            backgroundingListener,
-            jestLogger,
-            new DefaultSpanContextStorage(backgroundingListener)
-          )
-
-          const span = spanFactory.startSpan('name', { isFirstClass: true })
-          expect(jestLogger.warn).not.toHaveBeenCalled()
-
-          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-          expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(true)
-        })
-
-        it('does not create first class spans when isFirstClass is false', () => {
-          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-          const sampler = new Sampler(0.5)
-          const delivery = { send: jest.fn() }
-          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-          const backgroundingListener = new ControllableBackgroundingListener()
-          const spanFactory = new SpanFactory(
-            processor,
-            sampler,
-            new StableIdGenerator(),
-            spanAttributesSource,
-            new IncrementingClock(),
-            backgroundingListener,
-            jestLogger,
-            new DefaultSpanContextStorage(backgroundingListener)
-          )
-
-          const span = spanFactory.startSpan('name', { isFirstClass: false })
-          expect(jestLogger.warn).not.toHaveBeenCalled()
-
-          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-          expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(false)
-        })
-
-        it.each([
-          null,
-          1,
-          0,
-          'true',
-          'false',
-          [true, false]
-        ])('omits first class attribute and logs when isFirstClass is invalid (%s)', (isFirstClass) => {
-          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-          const sampler = new Sampler(0.5)
-          const delivery = { send: jest.fn() }
-          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-          const backgroundingListener = new ControllableBackgroundingListener()
-          const spanFactory = new SpanFactory(
-            processor,
-            sampler,
-            new StableIdGenerator(),
-            spanAttributesSource,
-            new IncrementingClock(),
-            backgroundingListener,
-            jestLogger,
-            new DefaultSpanContextStorage(backgroundingListener)
-          )
-
-          // @ts-expect-error 'isFirstClass' is the wrong type
-          const span = spanFactory.startSpan('name', { isFirstClass })
-
-          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - isFirstClass should be true|false, got ${typeof isFirstClass}`)
-
-          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-          expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
-        })
+        expect(jestLogger.warn).not.toHaveBeenCalled()
       })
 
-      it('handles null span options', () => {
+      it('becomes the current SpanContext when makeCurrentContext is true or undefined', async () => {
+        const client = createTestClient({ idGenerator: new IncrementingIdGenerator() })
+        client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        await jest.runOnlyPendingTimersAsync()
+
+        expect(client.currentSpanContext).toBeUndefined()
+
+        const optionIsTrue = client.startSpan('context span', { makeCurrentContext: true })
+        expect(spanContextEquals(optionIsTrue, client.currentSpanContext)).toBe(true)
+
+        const optionIsUndefined = client.startSpan('context span', { makeCurrentContext: undefined })
+        expect(spanContextEquals(optionIsUndefined, client.currentSpanContext)).toBe(true)
+
+        expect(jestLogger.warn).not.toHaveBeenCalled()
+      })
+    })
+    describe('isFirstClass', () => {
+      it('omits first class span attribute by default', () => {
+        const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+        const sampler = new Sampler(0.5)
+        const delivery = { send: jest.fn() }
+        const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+        const backgroundingListener = new ControllableBackgroundingListener()
         const spanFactory = new SpanFactory(
-          new InMemoryProcessor(),
-          new Sampler(1.0),
+          processor,
+          sampler,
           new StableIdGenerator(),
           spanAttributesSource,
           new IncrementingClock(),
-          new ControllableBackgroundingListener(),
+          backgroundingListener,
           jestLogger,
-          new DefaultSpanContextStorage(new ControllableBackgroundingListener())
+          new DefaultSpanContextStorage(backgroundingListener)
         )
 
-        // @ts-expect-error null options
-        const span = spanFactory.startSpan('name', null)
-        expect(span.name).toBe('name')
+        const span = spanFactory.startSpan('name', {})
+
+        // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+        expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
+      })
+
+      it('creates first class spans when isFirstClass is true', () => {
+        const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+        const sampler = new Sampler(0.5)
+        const delivery = { send: jest.fn() }
+        const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+        const backgroundingListener = new ControllableBackgroundingListener()
+        const spanFactory = new SpanFactory(
+          processor,
+          sampler,
+          new StableIdGenerator(),
+          spanAttributesSource,
+          new IncrementingClock(),
+          backgroundingListener,
+          jestLogger,
+          new DefaultSpanContextStorage(backgroundingListener)
+        )
+
+        const span = spanFactory.startSpan('name', { isFirstClass: true })
+        expect(jestLogger.warn).not.toHaveBeenCalled()
+
+        // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+        expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(true)
+      })
+
+      it('does not create first class spans when isFirstClass is false', () => {
+        const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+        const sampler = new Sampler(0.5)
+        const delivery = { send: jest.fn() }
+        const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+        const backgroundingListener = new ControllableBackgroundingListener()
+        const spanFactory = new SpanFactory(
+          processor,
+          sampler,
+          new StableIdGenerator(),
+          spanAttributesSource,
+          new IncrementingClock(),
+          backgroundingListener,
+          jestLogger,
+          new DefaultSpanContextStorage(backgroundingListener)
+        )
+
+        const span = spanFactory.startSpan('name', { isFirstClass: false })
+        expect(jestLogger.warn).not.toHaveBeenCalled()
+
+        // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+        expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(false)
+      })
+
+      it('omits first class attribute when isFirstClass is undefined', () => {
+        const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+        const sampler = new Sampler(0.5)
+        const delivery = { send: jest.fn() }
+        const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+        const backgroundingListener = new ControllableBackgroundingListener()
+        const spanFactory = new SpanFactory(
+          processor,
+          sampler,
+          new StableIdGenerator(),
+          spanAttributesSource,
+          new IncrementingClock(),
+          backgroundingListener,
+          jestLogger,
+          new DefaultSpanContextStorage(backgroundingListener)
+        )
+
+        const span = spanFactory.startSpan('name', {})
+        expect(jestLogger.warn).not.toHaveBeenCalled()
+
+        // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+        expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
       })
     })
   })

--- a/packages/core/tests/span-factory.test.ts
+++ b/packages/core/tests/span-factory.test.ts
@@ -27,8 +27,6 @@ beforeEach(() => {
 
 describe('SpanFactory', () => {
   describe('startSpan', () => {
-    describe('startTime', () => {})
-
     describe('parentContext', () => {
       it('sets traceId and parentSpanId from parentContext if specified', async () => {
         const delivery = new InMemoryDelivery()
@@ -91,14 +89,14 @@ describe('SpanFactory', () => {
         const rootSpan = client.startSpan('root span')
         expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
 
-        const childSpan = client.startSpan('new root span', { parentContext: undefined })
+        const childSpan = client.startSpan('child span', { parentContext: undefined })
         childSpan.end()
 
         await jest.runOnlyPendingTimersAsync()
 
-        // new root span should have a new trace ID and no parentSpanId
+        // child span should be a child of the root span
         expect(delivery).toHaveSentSpan(expect.objectContaining({
-          name: 'new root span',
+          name: 'child span',
           parentSpanId: rootSpan.id,
           traceId: rootSpan.traceId
         }))

--- a/packages/core/tests/span-factory.test.ts
+++ b/packages/core/tests/span-factory.test.ts
@@ -1,120 +1,401 @@
 import { DefaultSpanContextStorage } from '@bugsnag/core-performance'
 import {
   ControllableBackgroundingListener,
+  InMemoryDelivery,
+  InMemoryProcessor,
   IncrementingClock,
+  IncrementingIdGenerator,
   StableIdGenerator,
+  VALID_API_KEY,
+  createTestClient,
   spanAttributesSource
 } from '@bugsnag/js-performance-test-utilities'
 import {
   SpanFactory,
   spanToJson,
-  type SpanEnded
+  type SpanEnded,
+  spanContextEquals
 } from '../lib'
 import Sampler from '../lib/sampler'
 
+jest.useFakeTimers()
+
 const jestLogger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), info: jest.fn() }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 describe('SpanFactory', () => {
   describe('startSpan', () => {
-    it('omits first class span attribute by default', () => {
-      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-      const sampler = new Sampler(0.5)
-      const delivery = { send: jest.fn() }
-      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-      const backgroundingListener = new ControllableBackgroundingListener()
-      const spanFactory = new SpanFactory(
-        processor,
-        sampler,
-        new StableIdGenerator(),
-        spanAttributesSource,
-        new IncrementingClock(),
-        backgroundingListener,
-        jestLogger,
-        new DefaultSpanContextStorage(backgroundingListener)
-      )
+    describe('name', () => {
+      const invalidSpanNames: any[] = [
+        { type: 'bigint', name: BigInt(9007199254740991) },
+        { type: 'true', name: true },
+        { type: 'false', name: false },
+        { type: 'function', name: () => {} },
+        { type: 'object', name: { property: 'test' } },
+        { type: 'empty array', name: [] },
+        { type: 'array', name: [1, 2, 3] },
+        { type: 'symbol', name: Symbol('test') },
+        { type: 'null', name: null }
+      ]
 
-      const span = spanFactory.startSpan('name')
+      it.each(invalidSpanNames)('stringifies and logs when span name is invalid ($type)', async ({ name }) => {
+        const spanFactory = new SpanFactory(
+          new InMemoryProcessor(),
+          new Sampler(1.0),
+          new StableIdGenerator(),
+          spanAttributesSource,
+          new IncrementingClock(),
+          new ControllableBackgroundingListener(),
+          jestLogger,
+          new DefaultSpanContextStorage(new ControllableBackgroundingListener())
+        )
 
-      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-      expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
+        const span = spanFactory.startSpan(name)
+        expect(span.name).toEqual(String(name))
+        expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - name should be a string, got ${typeof name}`)
+      })
     })
 
-    it('creates first class spans when isFirstClass is true', () => {
-      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-      const sampler = new Sampler(0.5)
-      const delivery = { send: jest.fn() }
-      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-      const backgroundingListener = new ControllableBackgroundingListener()
-      const spanFactory = new SpanFactory(
-        processor,
-        sampler,
-        new StableIdGenerator(),
-        spanAttributesSource,
-        new IncrementingClock(),
-        backgroundingListener,
-        jestLogger,
-        new DefaultSpanContextStorage(backgroundingListener)
-      )
+    describe('options', () => {
+      describe('startTime', () => {
+        const invalidStartTimes: any[] = [
+          { type: 'string', startTime: 'i am not a startTime' },
+          { type: 'bigint', startTime: BigInt(9007199254740991) },
+          { type: 'true', startTime: true },
+          { type: 'false', startTime: false },
+          { type: 'function', startTime: () => {} },
+          { type: 'object', startTime: { property: 'test' } },
+          { type: 'empty array', startTime: [] },
+          { type: 'array', startTime: [1, 2, 3] },
+          { type: 'symbol', startTime: Symbol('test') },
+          { type: 'null', startTime: null }
+        ]
 
-      const span = spanFactory.startSpan('name', { isFirstClass: true })
+        invalidStartTimes.push(...invalidStartTimes.map(
+          ({ type, startTime }) => ({
+            type: `{ startTime: ${type} }`,
+            startTime: { startTime }
+          }))
+        )
 
-      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-      expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(true)
-    })
+        it.each(invalidStartTimes)('uses default clock implementation and logs if startTime is invalid ($type)', async (options) => {
+          const delivery = new InMemoryDelivery()
+          const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+          const client = createTestClient({ deliveryFactory: () => delivery, clock })
 
-    it('does not create first class spans when isFirstClass is false', () => {
-      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-      const sampler = new Sampler(0.5)
-      const delivery = { send: jest.fn() }
-      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-      const backgroundingListener = new ControllableBackgroundingListener()
-      const spanFactory = new SpanFactory(
-        processor,
-        sampler,
-        new StableIdGenerator(),
-        spanAttributesSource,
-        new IncrementingClock(),
-        backgroundingListener,
-        jestLogger,
-        new DefaultSpanContextStorage(backgroundingListener)
-      )
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
 
-      const span = spanFactory.startSpan('name', { isFirstClass: false })
+          await jest.runOnlyPendingTimersAsync()
 
-      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-      expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(false)
-    })
+          const span = client.startSpan('test span', options)
+          span.end()
 
-    it.each([
-      null,
-      undefined,
-      1,
-      0,
-      'true',
-      'false',
-      [true, false]
-    ])('omits first class attribute when isFirstClass is %s', (isFirstClass) => {
-      const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
-      const sampler = new Sampler(0.5)
-      const delivery = { send: jest.fn() }
-      const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
-      const backgroundingListener = new ControllableBackgroundingListener()
-      const spanFactory = new SpanFactory(
-        processor,
-        sampler,
-        new StableIdGenerator(),
-        spanAttributesSource,
-        new IncrementingClock(),
-        backgroundingListener,
-        jestLogger,
-        new DefaultSpanContextStorage(backgroundingListener)
-      )
+          await jest.runOnlyPendingTimersAsync()
 
-      // @ts-expect-error 'isFirstClass' is the wrong type
-      const span = spanFactory.startSpan('name', { isFirstClass })
+          expect(delivery).toHaveSentSpan(expect.objectContaining({
+            startTimeUnixNano: '1000000'
+          }))
 
-      // @ts-expect-error 'attributes' is private but very awkward to test otherwise
-      expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - startTime should be a number or Date, got ${typeof options.startTime}`)
+        })
+      })
+      describe('parentContext', () => {
+        it('sets traceId and parentSpanId from parentContext if specified', async () => {
+          const delivery = new InMemoryDelivery()
+          const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          // push two spans onto the context stack
+          const span1 = client.startSpan('should become parent')
+          const span2 = client.startSpan('should not become parent')
+          expect(spanContextEquals(span2, client.currentSpanContext)).toBe(true)
+
+          // start a new child span with an invalid parent context
+          const childOfSpan1 = client.startSpan('child of span 1', { parentContext: span1 })
+          childOfSpan1.end()
+
+          await jest.runOnlyPendingTimersAsync()
+
+          // child span should be nested under the first span
+          expect(delivery).toHaveSentSpan(expect.objectContaining({
+            name: 'child of span 1',
+            parentSpanId: span1.id,
+            traceId: span1.traceId
+          }))
+
+          expect(jestLogger.warn).not.toHaveBeenCalled()
+        })
+
+        it('starts a new root span when parentContext is null', async () => {
+          const idGenerator = new IncrementingIdGenerator()
+          const delivery = new InMemoryDelivery()
+          const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          const rootSpan = client.startSpan('root span')
+          expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
+
+          const newRootSpan = client.startSpan('new root span', { parentContext: null })
+          newRootSpan.end()
+
+          await jest.runOnlyPendingTimersAsync()
+
+          // new root span should have a new trace ID and no parentSpanId
+          expect(delivery).toHaveSentSpan(expect.objectContaining({
+            name: 'new root span',
+            parentSpanId: undefined,
+            traceId: `trace ID ${idGenerator.traceCount}`
+          }))
+
+          expect(jestLogger.warn).not.toHaveBeenCalled()
+        })
+
+        it('becomes a child of the current context when parentContext is undefined', async () => {
+          const delivery = new InMemoryDelivery()
+          const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          const rootSpan = client.startSpan('root span')
+          expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
+
+          const childSpan = client.startSpan('new root span', { parentContext: undefined })
+          childSpan.end()
+
+          await jest.runOnlyPendingTimersAsync()
+
+          // new root span should have a new trace ID and no parentSpanId
+          expect(delivery).toHaveSentSpan(expect.objectContaining({
+            name: 'new root span',
+            parentSpanId: rootSpan.id,
+            traceId: rootSpan.traceId
+          }))
+
+          expect(jestLogger.warn).not.toHaveBeenCalled()
+        })
+
+        const parentContextOptions: any[] = [
+          { type: 'true', parentContext: true },
+          { type: 'string', parentContext: 'yes please' },
+          { type: 'bigint', parentContext: BigInt(9007199254740991) },
+          { type: 'function', parentContext: () => {} },
+          { type: 'object', parentContext: { property: 'test' } },
+          { type: 'empty array', parentContext: [] },
+          { type: 'array', parentContext: [1, 2, 3] },
+          { type: 'symbol', parentContext: Symbol('test') }
+        ]
+
+        it.each(parentContextOptions)('becomes a child of the current context and logs when parentContext is invalid ($type)', async (options) => {
+          const delivery = new InMemoryDelivery()
+          const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          // push two spans onto the context stack
+          client.startSpan('root span')
+          const parentSpan = client.startSpan('parent span')
+          expect(spanContextEquals(parentSpan, client.currentSpanContext)).toBe(true)
+
+          // start a new child span with an invalid parent context
+          const childSpan = client.startSpan('child span', options)
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - parentContext should be a SpanContext, got ${typeof options.parentContext}`)
+
+          childSpan.end()
+          await jest.runOnlyPendingTimersAsync()
+
+          // child span should be nested under the parent span
+          expect(delivery).toHaveSentSpan(expect.objectContaining({
+            name: 'child span',
+            parentSpanId: parentSpan.id,
+            traceId: parentSpan.traceId
+          }))
+        })
+      })
+      describe('makeCurrentContext', () => {
+        it('does not become the current SpanContext when SpanOptions.makeCurrentContext is false', async () => {
+          const client = createTestClient({ idGenerator: new IncrementingIdGenerator() })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          expect(client.currentSpanContext).toBeUndefined()
+
+          const spanIsContext = client.startSpan('context span')
+          expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
+
+          const spanIsNotContext = client.startSpan('non context span', { makeCurrentContext: false })
+          expect(spanContextEquals(spanIsNotContext, client.currentSpanContext)).toBe(false)
+          expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
+
+          expect(jestLogger.warn).not.toHaveBeenCalled()
+        })
+
+        it('becomes the current SpanContext when makeCurrentContext is true or undefined', async () => {
+          const client = createTestClient({ idGenerator: new IncrementingIdGenerator() })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          expect(client.currentSpanContext).toBeUndefined()
+
+          const optionIsTrue = client.startSpan('context span', { makeCurrentContext: true })
+          expect(spanContextEquals(optionIsTrue, client.currentSpanContext)).toBe(true)
+
+          const optionIsUndefined = client.startSpan('context span', { makeCurrentContext: undefined })
+          expect(spanContextEquals(optionIsUndefined, client.currentSpanContext)).toBe(true)
+
+          expect(jestLogger.warn).not.toHaveBeenCalled()
+        })
+
+        const makeCurrentContextOptions: any[] = [
+          { type: 'string', makeCurrentContext: 'yes please' },
+          { type: 'bigint', makeCurrentContext: BigInt(9007199254740991) },
+          { type: 'function', makeCurrentContext: () => {} },
+          { type: 'object', makeCurrentContext: { property: 'test' } },
+          { type: 'empty array', makeCurrentContext: [] },
+          { type: 'array', makeCurrentContext: [1, 2, 3] },
+          { type: 'symbol', makeCurrentContext: Symbol('test') },
+          { type: 'null', makeCurrentContext: null }
+        ]
+
+        it.each(makeCurrentContextOptions)('becomes the current SpanContext and logs when makeCurrentContext is invalid ($type)', async (options) => {
+          const client = createTestClient()
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          expect(client.currentSpanContext).toBeUndefined()
+
+          const spanIsContext = client.startSpan('context span', options)
+          expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
+
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - makeCurrentContext should be true|false, got ${typeof options.makeCurrentContext}`)
+        })
+      })
+      describe('isFirstClass', () => {
+        it('omits first class span attribute by default', () => {
+          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+          const sampler = new Sampler(0.5)
+          const delivery = { send: jest.fn() }
+          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+          const backgroundingListener = new ControllableBackgroundingListener()
+          const spanFactory = new SpanFactory(
+            processor,
+            sampler,
+            new StableIdGenerator(),
+            spanAttributesSource,
+            new IncrementingClock(),
+            backgroundingListener,
+            jestLogger,
+            new DefaultSpanContextStorage(backgroundingListener)
+          )
+
+          const span = spanFactory.startSpan('name')
+
+          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+          expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
+        })
+
+        it('creates first class spans when isFirstClass is true', () => {
+          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+          const sampler = new Sampler(0.5)
+          const delivery = { send: jest.fn() }
+          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+          const backgroundingListener = new ControllableBackgroundingListener()
+          const spanFactory = new SpanFactory(
+            processor,
+            sampler,
+            new StableIdGenerator(),
+            spanAttributesSource,
+            new IncrementingClock(),
+            backgroundingListener,
+            jestLogger,
+            new DefaultSpanContextStorage(backgroundingListener)
+          )
+
+          const span = spanFactory.startSpan('name', { isFirstClass: true })
+          expect(jestLogger.warn).not.toHaveBeenCalled()
+
+          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+          expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(true)
+        })
+
+        it('does not create first class spans when isFirstClass is false', () => {
+          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+          const sampler = new Sampler(0.5)
+          const delivery = { send: jest.fn() }
+          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+          const backgroundingListener = new ControllableBackgroundingListener()
+          const spanFactory = new SpanFactory(
+            processor,
+            sampler,
+            new StableIdGenerator(),
+            spanAttributesSource,
+            new IncrementingClock(),
+            backgroundingListener,
+            jestLogger,
+            new DefaultSpanContextStorage(backgroundingListener)
+          )
+
+          const span = spanFactory.startSpan('name', { isFirstClass: false })
+          expect(jestLogger.warn).not.toHaveBeenCalled()
+
+          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+          expect(span.attributes.attributes.get('bugsnag.span.first_class')).toBe(false)
+        })
+
+        it.each([
+          null,
+          1,
+          0,
+          'true',
+          'false',
+          [true, false]
+        ])('omits first class attribute and logs when isFirstClass is invalid (%s)', (isFirstClass) => {
+          const clock = new IncrementingClock('1970-01-01T00:00:00.000Z')
+          const sampler = new Sampler(0.5)
+          const delivery = { send: jest.fn() }
+          const processor = { add: (span: SpanEnded) => delivery.send(spanToJson(span, clock)) }
+          const backgroundingListener = new ControllableBackgroundingListener()
+          const spanFactory = new SpanFactory(
+            processor,
+            sampler,
+            new StableIdGenerator(),
+            spanAttributesSource,
+            new IncrementingClock(),
+            backgroundingListener,
+            jestLogger,
+            new DefaultSpanContextStorage(backgroundingListener)
+          )
+
+          // @ts-expect-error 'isFirstClass' is the wrong type
+          const span = spanFactory.startSpan('name', { isFirstClass })
+
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options \n - isFirstClass should be true|false, got ${typeof isFirstClass}`)
+
+          // @ts-expect-error 'attributes' is private but very awkward to test otherwise
+          expect(span.attributes.attributes.has('bugsnag.span.first_class')).toBe(false)
+        })
+      })
+
+      it('handles null span options', () => {
+        const spanFactory = new SpanFactory(
+          new InMemoryProcessor(),
+          new Sampler(1.0),
+          new StableIdGenerator(),
+          spanAttributesSource,
+          new IncrementingClock(),
+          new ControllableBackgroundingListener(),
+          jestLogger,
+          new DefaultSpanContextStorage(new ControllableBackgroundingListener())
+        )
+
+        // @ts-expect-error null options
+        const span = spanFactory.startSpan('name', null)
+        expect(span.name).toBe('name')
+      })
     })
   })
 })

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -7,8 +7,7 @@ import {
   StableIdGenerator,
   VALID_API_KEY,
   createTestClient,
-  spanAttributesSource,
-  IncrementingIdGenerator
+  spanAttributesSource
 } from '@bugsnag/js-performance-test-utilities'
 import {
   InMemoryPersistence,
@@ -112,174 +111,6 @@ describe('Span', () => {
         end: expect.any(Function),
         isValid: expect.any(Function)
       })
-    })
-
-    const invalidStartTimes: any[] = [
-      { type: 'string', startTime: 'i am not a startTime' },
-      { type: 'bigint', startTime: BigInt(9007199254740991) },
-      { type: 'true', startTime: true },
-      { type: 'false', startTime: false },
-      { type: 'function', startTime: () => {} },
-      { type: 'object', startTime: { property: 'test' } },
-      { type: 'empty array', startTime: [] },
-      { type: 'array', startTime: [1, 2, 3] },
-      { type: 'symbol', startTime: Symbol('test') },
-      { type: 'null', startTime: null },
-      { type: 'undefined', startTime: undefined }
-    ]
-
-    invalidStartTimes.push(...invalidStartTimes.map(
-      ({ type, startTime }) => ({
-        type: `{ startTime: ${type} }`,
-        startTime: { startTime }
-      }))
-    )
-
-    it.each(invalidStartTimes)('uses default clock implementation if startTime is invalid ($type)', async ({ startTime }) => {
-      const delivery = new InMemoryDelivery()
-      const clock = new IncrementingClock('1970-01-01T00:00:00Z')
-      const client = createTestClient({ deliveryFactory: () => delivery, clock })
-      client.start({ apiKey: VALID_API_KEY })
-
-      const span = client.startSpan('test span', startTime)
-      span.end()
-
-      await jest.runOnlyPendingTimersAsync()
-
-      expect(delivery).toHaveSentSpan(expect.objectContaining({
-        startTimeUnixNano: '1000000'
-      }))
-    })
-
-    const makeCurrentContextOptions: any[] = [
-      { type: 'true', makeCurrentContext: true },
-      { type: 'string', makeCurrentContext: 'yes please' },
-      { type: 'bigint', makeCurrentContext: BigInt(9007199254740991) },
-      { type: 'function', makeCurrentContext: () => {} },
-      { type: 'object', makeCurrentContext: { property: 'test' } },
-      { type: 'empty array', makeCurrentContext: [] },
-      { type: 'array', makeCurrentContext: [1, 2, 3] },
-      { type: 'symbol', makeCurrentContext: Symbol('test') },
-      { type: 'null', makeCurrentContext: null },
-      { type: 'undefined', makeCurrentContext: undefined }
-    ]
-
-    it.each(makeCurrentContextOptions)('becomes the current SpanContext when makeCurrentContext is not false ($type)', (options) => {
-      const client = createTestClient()
-      client.start({ apiKey: VALID_API_KEY })
-      expect(client.currentSpanContext).toBeUndefined()
-
-      const spanIsContext = client.startSpan('context span', options)
-      expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
-    })
-
-    it('does not become the current SpanContext when SpanOptions.makeCurrentContext is false', () => {
-      const idGenerator = {
-        count: 0,
-        generate (bits: 64 | 128) {
-          if (bits === 64) {
-            this.count++
-            return `span ID ${this.count}`
-          }
-
-          return 'a trace ID'
-        }
-      }
-
-      const client = createTestClient({ idGenerator })
-      client.start({ apiKey: VALID_API_KEY })
-      expect(client.currentSpanContext).toBeUndefined()
-
-      const spanIsContext = client.startSpan('context span')
-      expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
-
-      const spanIsNotContext = client.startSpan('non context span', { makeCurrentContext: false })
-      expect(spanContextEquals(spanIsNotContext, client.currentSpanContext)).toBe(false)
-      expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
-    })
-
-    it('sets traceId and parentSpanId from parentContext if specified', async () => {
-      const idGenerator = new IncrementingIdGenerator()
-      const delivery = new InMemoryDelivery()
-      const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
-      client.start({ apiKey: VALID_API_KEY })
-
-      // push two spans onto the context stack
-      const span1 = client.startSpan('should become parent')
-      const span2 = client.startSpan('should not become parent')
-      expect(spanContextEquals(span2, client.currentSpanContext)).toBe(true)
-
-      // start a new child span with an invalid parent context
-      const childOfSpan1 = client.startSpan('child of span 1', { parentContext: span1 })
-      childOfSpan1.end()
-
-      await jest.runOnlyPendingTimersAsync()
-
-      // child span should be nested under the first span
-      expect(delivery).toHaveSentSpan(expect.objectContaining({
-        name: 'child of span 1',
-        parentSpanId: span1.id,
-        traceId: span1.traceId
-      }))
-    })
-
-    it('starts a new root span when parentContext is null', async () => {
-      const idGenerator = new IncrementingIdGenerator()
-      const delivery = new InMemoryDelivery()
-      const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
-      client.start({ apiKey: VALID_API_KEY })
-
-      const rootSpan = client.startSpan('root span')
-      expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
-
-      const newRootSpan = client.startSpan('new root span', { parentContext: null })
-      newRootSpan.end()
-
-      await jest.runOnlyPendingTimersAsync()
-
-      // new root span should have a new trace ID and no parentSpanId
-      expect(delivery).toHaveSentSpan(expect.objectContaining({
-        name: 'new root span',
-        parentSpanId: undefined,
-        traceId: `trace ID ${idGenerator.traceCount}`
-      }))
-    })
-
-    const parentContextOptions: any[] = [
-      { type: 'true', parentContext: true },
-      { type: 'string', parentContext: 'yes please' },
-      { type: 'bigint', parentContext: BigInt(9007199254740991) },
-      { type: 'function', parentContext: () => {} },
-      { type: 'object', parentContext: { property: 'test' } },
-      { type: 'empty array', parentContext: [] },
-      { type: 'array', parentContext: [1, 2, 3] },
-      { type: 'symbol', parentContext: Symbol('test') },
-      { type: 'undefined', parentContext: undefined }
-    ]
-
-    it.each(parentContextOptions)('defaults to the current context when parentContext is invalid ($type)', async (options) => {
-      const idGenerator = new IncrementingIdGenerator()
-      const delivery = new InMemoryDelivery()
-      const client = createTestClient({ idGenerator, deliveryFactory: () => delivery })
-      client.start({ apiKey: VALID_API_KEY })
-
-      // push two spans onto the context stack
-      client.startSpan('root span')
-      const parentSpan = client.startSpan('parent span')
-      expect(spanContextEquals(parentSpan, client.currentSpanContext)).toBe(true)
-
-      // start a new child span with an invalid parent context
-      const childSpan = client.startSpan('child span', options)
-      childSpan.end()
-
-      await jest.runOnlyPendingTimersAsync()
-
-      // child span should be nested under the parent span
-      expect(delivery).toHaveSentSpan(expect.objectContaining({
-        name: 'child span',
-        parentSpanId: parentSpan.id,
-        traceId: parentSpan.traceId
-      }))
     })
   })
 
@@ -597,23 +428,6 @@ describe('Span', () => {
 
       span1.end()
       expect(client.currentSpanContext).toBeUndefined()
-    })
-  })
-})
-
-describe('SpanContext', () => {
-  describe('SpanContext.isValid()', () => {
-    it('returns false if the span has been ended', () => {
-      const delivery = new InMemoryDelivery()
-      const clock = new IncrementingClock('1970-01-01T00:00:00Z')
-      const client = createTestClient({ deliveryFactory: () => delivery, clock })
-      client.start({ apiKey: VALID_API_KEY })
-
-      const span = client.startSpan('test span')
-      expect(span.isValid()).toEqual(true)
-
-      span.end()
-      expect(span.isValid()).toEqual(false)
     })
   })
 })

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -4,6 +4,7 @@ import {
   ControllableBackgroundingListener,
   InMemoryDelivery,
   IncrementingClock,
+  IncrementingIdGenerator,
   StableIdGenerator,
   VALID_API_KEY,
   createTestClient,
@@ -26,6 +27,10 @@ const jestLogger = {
   error: jest.fn(),
   info: jest.fn()
 }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 describe('SpanInternal', () => {
   describe('.setAttribute()', () => {
@@ -110,6 +115,217 @@ describe('Span', () => {
         traceId: expect.any(String),
         end: expect.any(Function),
         isValid: expect.any(Function)
+      })
+    })
+
+    describe('name', () => {
+      const invalidSpanNames: any[] = [
+        { type: 'bigint', name: BigInt(9007199254740991) },
+        { type: 'true', name: true },
+        { type: 'false', name: false },
+        { type: 'function', name: () => {} },
+        { type: 'object', name: { property: 'test' } },
+        { type: 'empty array', name: [] },
+        { type: 'array', name: [1, 2, 3] },
+        { type: 'symbol', name: Symbol('test') },
+        { type: 'null', name: null }
+      ]
+
+      it.each(invalidSpanNames)('stringifies and logs when span name is invalid ($type)', async ({ name }) => {
+        const delivery = new InMemoryDelivery()
+        const client = createTestClient({ deliveryFactory: () => delivery })
+        client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        await jest.runOnlyPendingTimersAsync()
+
+        const span = client.startSpan(name, {})
+        expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - name should be a string, got ${typeof name}`)
+
+        span.end()
+        await jest.runOnlyPendingTimersAsync()
+
+        expect(delivery).toHaveSentSpan(expect.objectContaining({
+          name: String(name)
+        }))
+      })
+    })
+
+    describe('options', () => {
+      const invalidSpanOptions: any[] = [
+        { type: 'string', options: 'invalid' },
+        { type: 'bigint', options: BigInt(9007199254740991) },
+        { type: 'true', options: true },
+        { type: 'false', options: false },
+        { type: 'function', options: () => {} },
+        { type: 'empty array', options: [] },
+        { type: 'array', options: [1, 2, 3] },
+        { type: 'symbol', options: Symbol('test') },
+        { type: 'null', options: null }
+      ]
+
+      it.each(invalidSpanOptions)('uses the default values and logs when options is invalid ($type)', async ({ options }) => {
+        const delivery = new InMemoryDelivery()
+        const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+        const client = createTestClient({ deliveryFactory: () => delivery, clock })
+
+        client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+        await jest.runOnlyPendingTimersAsync()
+
+        // add a root span to the context
+        const rootSpan = client.startSpan('root-span')
+        expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
+
+        // start a span with invalid options
+        const span = client.startSpan('test-span', options)
+        expect(jestLogger.warn).toHaveBeenCalledWith('Invalid span options\n  - options is not an object')
+
+        // span should become the current context by default
+        expect(spanContextEquals(span, client.currentSpanContext)).toBe(true)
+
+        span.end()
+        await jest.runOnlyPendingTimersAsync()
+
+        expect(delivery.requests.length).toBe(1)
+        const delivered = delivery.requests[0].resourceSpans[0].scopeSpans[0].spans[0]
+
+        // span should become a child of the current context by default
+        expect(delivered.parentSpanId).toEqual(rootSpan.id)
+        expect(delivered.traceId).toEqual(rootSpan.traceId)
+
+        // span should not have a first class attribute by default
+        expect(delivered).not.toHaveAttribute('bugnsag.span.first_class')
+      })
+
+      describe('startTime', () => {
+        const invalidStartTimes: any[] = [
+          { type: 'string', startTime: 'i am not a startTime' },
+          { type: 'bigint', startTime: BigInt(9007199254740991) },
+          { type: 'true', startTime: true },
+          { type: 'false', startTime: false },
+          { type: 'function', startTime: () => {} },
+          { type: 'object', startTime: { property: 'test' } },
+          { type: 'empty array', startTime: [] },
+          { type: 'array', startTime: [1, 2, 3] },
+          { type: 'symbol', startTime: Symbol('test') },
+          { type: 'null', startTime: null }
+        ]
+
+        invalidStartTimes.push(...invalidStartTimes.map(
+          ({ type, startTime }) => ({
+            type: `{ startTime: ${type} }`,
+            startTime: { startTime }
+          }))
+        )
+
+        it.each(invalidStartTimes)('uses default clock implementation and logs if startTime is invalid ($type)', async (options) => {
+          const delivery = new InMemoryDelivery()
+          const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+          const client = createTestClient({ deliveryFactory: () => delivery, clock })
+
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+
+          await jest.runOnlyPendingTimersAsync()
+
+          const span = client.startSpan('test span', options)
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - startTime should be a number or Date, got ${typeof options.startTime}`)
+
+          span.end()
+          await jest.runOnlyPendingTimersAsync()
+
+          expect(delivery).toHaveSentSpan(expect.objectContaining({
+            startTimeUnixNano: '1000000'
+          }))
+        })
+      })
+      describe('parentContext', () => {
+        const parentContextOptions: any[] = [
+          { type: 'true', parentContext: true },
+          { type: 'string', parentContext: 'yes please' },
+          { type: 'bigint', parentContext: BigInt(9007199254740991) },
+          { type: 'function', parentContext: () => {} },
+          { type: 'object', parentContext: { property: 'test' } },
+          { type: 'empty array', parentContext: [] },
+          { type: 'array', parentContext: [1, 2, 3] },
+          { type: 'symbol', parentContext: Symbol('test') }
+        ]
+
+        it.each(parentContextOptions)('defaults to undefined and logs when parentContext is invalid ($type)', async (options) => {
+          const delivery = new InMemoryDelivery()
+          const client = createTestClient({ idGenerator: new IncrementingIdGenerator(), deliveryFactory: () => delivery })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          // push two spans onto the context stack
+          client.startSpan('root span')
+          const parentSpan = client.startSpan('parent span')
+          expect(spanContextEquals(parentSpan, client.currentSpanContext)).toBe(true)
+
+          // start a new child span with an invalid parent context
+          const childSpan = client.startSpan('child span', options)
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - parentContext should be a SpanContext, got ${typeof options.parentContext}`)
+
+          childSpan.end()
+          await jest.runOnlyPendingTimersAsync()
+
+          // child span should be nested under the parent span
+          expect(delivery).toHaveSentSpan(expect.objectContaining({
+            name: 'child span',
+            parentSpanId: parentSpan.id,
+            traceId: parentSpan.traceId
+          }))
+        })
+      })
+      describe('makeCurrentContext', () => {
+        const makeCurrentContextOptions: any[] = [
+          { type: 'string', makeCurrentContext: 'yes please' },
+          { type: 'bigint', makeCurrentContext: BigInt(9007199254740991) },
+          { type: 'function', makeCurrentContext: () => {} },
+          { type: 'object', makeCurrentContext: { property: 'test' } },
+          { type: 'empty array', makeCurrentContext: [] },
+          { type: 'array', makeCurrentContext: [1, 2, 3] },
+          { type: 'symbol', makeCurrentContext: Symbol('test') },
+          { type: 'null', makeCurrentContext: null }
+        ]
+
+        it.each(makeCurrentContextOptions)('becomes the current SpanContext and logs when makeCurrentContext is invalid ($type)', async (options) => {
+          const client = createTestClient()
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          expect(client.currentSpanContext).toBeUndefined()
+
+          const spanIsContext = client.startSpan('context span', options)
+
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - makeCurrentContext should be true|false, got ${typeof options.makeCurrentContext}`)
+          expect(spanContextEquals(spanIsContext, client.currentSpanContext)).toBe(true)
+        })
+      })
+
+      describe('isFirstClass', () => {
+        it.each([
+          null,
+          1,
+          0,
+          'true',
+          'false',
+          [true, false]
+        ])('omits first class attribute and logs when isFirstClass is invalid (%s)', async (isFirstClass) => {
+          const delivery = new InMemoryDelivery()
+          const client = createTestClient({ deliveryFactory: () => delivery })
+          client.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+          await jest.runOnlyPendingTimersAsync()
+
+          // @ts-expect-error 'isFirstClass' is the wrong type
+          const span = client.startSpan('name', { isFirstClass })
+          expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - isFirstClass should be true|false, got ${typeof isFirstClass}`)
+
+          span.end()
+          await jest.runOnlyPendingTimersAsync()
+
+          expect(delivery.requests.length).toBe(1)
+
+          const delivered = delivery.requests[0].resourceSpans[0].scopeSpans[0].spans[0]
+          expect(delivered).not.toHaveAttribute('bugnsag.span.first_class')
+        })
       })
     })
   })

--- a/packages/core/tests/validation.test.ts
+++ b/packages/core/tests/validation.test.ts
@@ -173,4 +173,43 @@ describe('validation', () => {
       expect(validation.isBoolean(value)).toBe(true)
     })
   })
+
+  describe('isSpanContext', () => {
+    it.each(nonObjects)('fails validation with $type', ({ value }) => {
+      expect(validation.isSpanContext(value)).toBe(false)
+    })
+
+    const invalidSpanContexts: any[] = [
+      { id: 1234, traceId: '5678', isValid: () => true },
+      { id: '1234', traceId: 5678, isValid: () => true },
+      { id: '1234', traceId: '5678', isValid: true }
+    ]
+
+    it.each(invalidSpanContexts)('fails validation with %s', (value) => {
+      expect(validation.isSpanContext(value)).toBe(false)
+    })
+
+    it('passes with valid SpanContext type', () => {
+      const spanContext = {
+        id: '1234',
+        traceId: '5678',
+        isValid: () => true
+      }
+
+      expect(validation.isSpanContext(spanContext)).toBe(true)
+
+      spanContext.isValid = () => false
+      expect(validation.isSpanContext(spanContext)).toBe(true)
+    })
+  })
+
+  describe('isTime', () => {
+    it.each([-1, 0, 1, 10000, new Date().getTime(), performance.now(), new Date()])('passes validation with %s', (value) => {
+      expect(validation.isTime(value)).toBe(true)
+    })
+
+    it.each(['', 'string', true, false, undefined, null, NaN, Infinity, -Infinity, () => {}, [], {}])('fails validation with %s', (value) => {
+      expect(validation.isTime(value)).toBe(false)
+    })
+  })
 })

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -15,6 +15,21 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
     let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
 
     configuration.routingProvider.listenForRouteChanges((route, trigger, options) => {
+      let warnings = ''
+      if (typeof route !== 'string') {
+        warnings += `\n - route should be a string, got ${typeof route}`
+        route = String(route)
+      }
+
+      if (typeof trigger !== 'string') {
+        warnings += `\n - trigger should be a string, got ${typeof trigger}`
+        trigger = String(trigger)
+      }
+
+      if (warnings.length > 0) {
+        configuration.logger.warn(`Invalid route change span options ${warnings}`)
+      }
+
       const span = this.spanFactory.startSpan(`[RouteChange]${route}`, {
         startTime: options ? options.startTime : undefined
       })

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -1,6 +1,28 @@
-import { type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
+import { type SpanOptionSchema, isString, coreSpanOptionSchema, validateSpanOptions, type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
 import { type BrowserConfiguration } from '../config'
 import getAbsoluteUrl from '../request-tracker/url-helpers'
+import { type RouteChangeSpanOptions } from '../routing-provider'
+
+// exclude isFirstClass from the route change option schema
+const { isFirstClass, ...baseSpanOptionSchema } = coreSpanOptionSchema
+const routeChangeSpanOptionSchema: SpanOptionSchema = {
+  ...baseSpanOptionSchema,
+  route: {
+    getDefaultValue: (value) => String(value),
+    message: 'should be a string',
+    validate: isString
+  },
+  trigger: {
+    getDefaultValue: (value) => String(value),
+    message: 'should be a string',
+    validate: isString
+  }
+}
+
+interface InternalRouteChangeSpanOptions extends RouteChangeSpanOptions {
+  route: string
+  trigger: string
+}
 
 export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
   constructor (
@@ -15,30 +37,31 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
     let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
 
     configuration.routingProvider.listenForRouteChanges((route, trigger, options) => {
-      let warnings = ''
-      if (typeof route !== 'string') {
-        warnings += `\n - route should be a string, got ${typeof route}`
-        route = String(route)
+      // create internal options for validation
+      const routeChangeSpanOptions = {
+        ...options,
+        route,
+        trigger
       }
 
-      if (typeof trigger !== 'string') {
-        warnings += `\n - trigger should be a string, got ${typeof trigger}`
-        trigger = String(trigger)
-      }
+      const cleanOptions = validateSpanOptions<InternalRouteChangeSpanOptions>(
+        '[RouteChange]',
+        routeChangeSpanOptions,
+        routeChangeSpanOptionSchema,
+        configuration.logger
+      )
 
-      if (warnings.length > 0) {
-        configuration.logger.warn(`Invalid route change span options ${warnings}`)
-      }
+      // update the span name using the validated route
+      cleanOptions.name += cleanOptions.options.route
+      const span = this.spanFactory.startSpan(cleanOptions.name, cleanOptions.options)
 
-      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, options)
-
-      const url = getAbsoluteUrl(route, this.document.baseURI)
+      const url = getAbsoluteUrl(cleanOptions.options.route, this.document.baseURI)
 
       span.setAttribute('bugsnag.span.category', 'route_change')
       span.setAttribute('bugsnag.browser.page.route', route)
       span.setAttribute('bugsnag.browser.page.url', url)
       span.setAttribute('bugsnag.browser.page.previous_route', previousRoute)
-      span.setAttribute('bugsnag.browser.page.route_change.trigger', trigger)
+      span.setAttribute('bugsnag.browser.page.route_change.trigger', cleanOptions.options.trigger)
 
       previousRoute = route
 

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -4,9 +4,11 @@ import getAbsoluteUrl from '../request-tracker/url-helpers'
 import { type RouteChangeSpanOptions } from '../routing-provider'
 
 // exclude isFirstClass from the route change option schema
-const { isFirstClass, ...baseSpanOptionSchema } = coreSpanOptionSchema
+const { startTime, parentContext, makeCurrentContext } = coreSpanOptionSchema
 const routeChangeSpanOptionSchema: SpanOptionSchema = {
-  ...baseSpanOptionSchema,
+  startTime,
+  parentContext,
+  makeCurrentContext,
   route: {
     getDefaultValue: (value) => String(value),
     message: 'should be a string',

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -30,9 +30,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
         configuration.logger.warn(`Invalid route change span options ${warnings}`)
       }
 
-      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, {
-        startTime: options ? options.startTime : undefined
-      })
+      const span = this.spanFactory.startSpan(`[RouteChange]${route}`, options)
 
       const url = getAbsoluteUrl(route, this.document.baseURI)
 

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -179,20 +179,20 @@ describe('RouteChangePlugin', () => {
     }))
   })
 
-  const invalidRoutes: any[] = [
-    // eslint-disable-next-line compat/compat
-    { type: 'bigint', route: BigInt(9007199254740991) },
-    { type: 'true', route: true },
-    { type: 'false', route: false },
-    { type: 'function', route: () => {} },
-    { type: 'object', route: { property: 'test' } },
-    { type: 'empty array', route: [] },
-    { type: 'array', route: [1, 2, 3] },
-    { type: 'symbol', route: Symbol('test') },
-    { type: 'null', route: null }
-  ]
-
   describe('validation', () => {
+    const invalidRoutes: any[] = [
+      // eslint-disable-next-line compat/compat
+      { type: 'bigint', route: BigInt(9007199254740991) },
+      { type: 'true', route: true },
+      { type: 'false', route: false },
+      { type: 'function', route: () => {} },
+      { type: 'object', route: { property: 'test' } },
+      { type: 'empty array', route: [] },
+      { type: 'array', route: [1, 2, 3] },
+      { type: 'symbol', route: Symbol('test') },
+      { type: 'null', route: null }
+    ]
+
     it.each(invalidRoutes)('handles invalid routes ($type)', async ({ route }) => {
       const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
       const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
@@ -223,6 +223,54 @@ describe('RouteChangePlugin', () => {
       expect(delivery).toHaveSentSpan(expect.objectContaining({
         name: `[RouteChange]${String(route)}`
       }))
+    })
+
+    const invalidTriggers: any[] = [
+      // eslint-disable-next-line compat/compat
+      { type: 'bigint', trigger: BigInt(9007199254740991) },
+      { type: 'true', trigger: true },
+      { type: 'false', trigger: false },
+      { type: 'function', trigger: () => {} },
+      { type: 'object', trigger: { property: 'test' } },
+      { type: 'empty array', trigger: [] },
+      { type: 'array', trigger: [1, 2, 3] },
+      { type: 'symbol', trigger: Symbol('test') },
+      { type: 'null', trigger: null }
+    ]
+
+    it.each(invalidTriggers)('handles invalid triggers ($type)', async ({ trigger }) => {
+      const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
+      const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+      const routingProvider = new DefaultRoutingProvider()
+      let routeChangeCallback: StartRouteChangeCallback = jest.fn()
+      routingProvider.listenForRouteChanges = (startRouteChangeSpan) => {
+        routeChangeCallback = startRouteChangeSpan
+      }
+
+      const delivery = new InMemoryDelivery()
+      const testClient = createTestClient({
+        deliveryFactory: () => delivery,
+        schema: createSchema(window.location.hostname, routingProvider),
+        plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location, document)]
+      })
+
+      testClient.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+      await jest.runOnlyPendingTimersAsync()
+
+      // trigger the route change
+      const span = routeChangeCallback('/route', trigger)
+      expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - trigger should be a string, got ${typeof trigger}`)
+
+      span.end()
+
+      await jest.runOnlyPendingTimersAsync()
+
+      expect(delivery).toHaveSentSpan(expect.objectContaining({
+        name: '[RouteChange]/route'
+      }))
+
+      const routeChangeSpan = delivery.requests[0].resourceSpans[0].scopeSpans[0].spans[0]
+      expect(routeChangeSpan).toHaveAttribute('bugsnag.browser.page.route_change.trigger', String(trigger))
     })
   })
 })

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -8,12 +8,21 @@ import { RouteChangePlugin } from '../../lib/auto-instrumentation/route-change-p
 import { createSchema } from '../../lib/config'
 import { createDefaultRoutingProvider } from '../../lib/default-routing-provider'
 import { type OnSettle } from '../../lib/on-settle'
+import { type StartRouteChangeCallback } from '../../lib/routing-provider'
 
 jest.useFakeTimers()
+
+const jestLogger = {
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn()
+}
 
 afterEach(() => {
   history.replaceState({}, 'unused', 'https://bugsnag.com/route-change-plugin')
   jest.clearAllTimers()
+  jest.clearAllMocks()
 })
 
 describe('RouteChangePlugin', () => {
@@ -168,5 +177,52 @@ describe('RouteChangePlugin', () => {
     expect(delivery).not.toHaveSentSpan(expect.objectContaining({
       name: '[RouteChange]/second-route'
     }))
+  })
+
+  const invalidRoutes: any[] = [
+    // eslint-disable-next-line compat/compat
+    { type: 'bigint', route: BigInt(9007199254740991) },
+    { type: 'true', route: true },
+    { type: 'false', route: false },
+    { type: 'function', route: () => {} },
+    { type: 'object', route: { property: 'test' } },
+    { type: 'empty array', route: [] },
+    { type: 'array', route: [1, 2, 3] },
+    { type: 'symbol', route: Symbol('test') },
+    { type: 'null', route: null }
+  ]
+
+  describe('validation', () => {
+    it.each(invalidRoutes)('handles invalid routes ($type)', async ({ route }) => {
+      const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
+      const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+      const routingProvider = new DefaultRoutingProvider()
+      let routeChangeCallback: StartRouteChangeCallback = jest.fn()
+      routingProvider.listenForRouteChanges = (startRouteChangeSpan) => {
+        routeChangeCallback = startRouteChangeSpan
+      }
+
+      const delivery = new InMemoryDelivery()
+      const testClient = createTestClient({
+        deliveryFactory: () => delivery,
+        schema: createSchema(window.location.hostname, routingProvider),
+        plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location, document)]
+      })
+
+      testClient.start({ apiKey: VALID_API_KEY, logger: jestLogger })
+      await jest.runOnlyPendingTimersAsync()
+
+      // trigger the route change
+      const span = routeChangeCallback(route, 'trigger')
+      expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - route should be a string, got ${typeof route}`)
+
+      span.end()
+
+      await jest.runOnlyPendingTimersAsync()
+
+      expect(delivery).toHaveSentSpan(expect.objectContaining({
+        name: `[RouteChange]${String(route)}`
+      }))
+    })
   })
 })

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -34,7 +34,7 @@ class MockSpanFactory extends SpanFactory {
     this.createdSpans = processor.spans
   }
 
-  startSpan = jest.fn((name: string, options?: SpanOptions) => {
+  startSpan = jest.fn((name: string, options: SpanOptions) => {
     return super.startSpan(name, options)
   })
 


### PR DESCRIPTION
## Goal
This PR adds validation to inputs when starting spans, both via `BugsnagPerformance.startSpan` and the `startRouteChangeSpan` callback in routing providers.

Takes a similar approach to config validation, adding a generic validation function and a core span options schema that can be extended by different platforms/plugins (see `route-change-plugin.ts`)

If an input is invalid, a warning is logged and the default value is used instead. For all SpanOptions this is `undefined` and for span names the invalid input is converted to a string. 

## Testing
Updated and added unit tests for input validation and reorganised the span and span factory unit tests to split out tests for invalid options from the actual implementation of each option

