### PR TITLE
Validate bugsnag.browser.page.url

### DIFF
--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -1,6 +1,5 @@
-import { type SpanOptionSchema, isString, coreSpanOptionSchema, validateSpanOptions, type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
+import { coreSpanOptionSchema, isString, validateSpanOptions, type InternalConfiguration, type Plugin, type SpanFactory, type SpanOptionSchema } from '@bugsnag/core-performance'
 import { type BrowserConfiguration } from '../config'
-import getAbsoluteUrl from '../request-tracker/url-helpers'
 import { type RouteChangeSpanOptions } from '../routing-provider'
 
 // exclude isFirstClass from the route change option schema
@@ -38,7 +37,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
 
     let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
 
-    configuration.routingProvider.listenForRouteChanges((route, trigger, options) => {
+    configuration.routingProvider.listenForRouteChanges((url, route, trigger, options) => {
       // create internal options for validation
       const routeChangeSpanOptions = {
         ...options,
@@ -56,8 +55,6 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
       // update the span name using the validated route
       cleanOptions.name += cleanOptions.options.route
       const span = this.spanFactory.startSpan(cleanOptions.name, cleanOptions.options)
-
-      const url = getAbsoluteUrl(cleanOptions.options.route, this.document.baseURI)
 
       span.setAttribute('bugsnag.span.category', 'route_change')
       span.setAttribute('bugsnag.browser.page.route', route)

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -37,7 +37,9 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
 
     let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
 
-    configuration.routingProvider.listenForRouteChanges((url, route, trigger, options) => {
+    configuration.routingProvider.listenForRouteChanges((url, trigger, options) => {
+      const route = configuration.routingProvider.resolveRoute(url)
+
       // create internal options for validation
       const routeChangeSpanOptions = {
         ...options,
@@ -58,7 +60,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
 
       span.setAttribute('bugsnag.span.category', 'route_change')
       span.setAttribute('bugsnag.browser.page.route', route)
-      span.setAttribute('bugsnag.browser.page.url', url)
+      span.setAttribute('bugsnag.browser.page.url', url.toString())
       span.setAttribute('bugsnag.browser.page.previous_route', previousRoute)
       span.setAttribute('bugsnag.browser.page.route_change.trigger', cleanOptions.options.trigger)
 

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -13,10 +13,10 @@ export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Locat
     }
 
     listenForRouteChanges (startRouteChangeSpan: StartRouteChangeCallback) {
-      addEventListener('popstate', () => {
+      addEventListener('popstate', (ev) => {
         const url = new URL(location.href)
         const route = this.resolveRoute(url)
-        const span = startRouteChangeSpan(route, 'popstate')
+        const span = startRouteChangeSpan(location.href, route, 'popstate')
 
         onSettle((endTime) => {
           span.end(endTime)
@@ -31,7 +31,7 @@ export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Locat
         if (url) {
           const absoluteURL = new URL(getAbsoluteUrl(url.toString(), document.baseURI))
           const route = resolveRoute(absoluteURL)
-          const span = startRouteChangeSpan(route, 'pushState')
+          const span = startRouteChangeSpan(absoluteURL.toString(), route, 'pushState')
 
           onSettle((endTime) => {
             span.end(endTime)

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -15,23 +15,20 @@ export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Locat
     listenForRouteChanges (startRouteChangeSpan: StartRouteChangeCallback) {
       addEventListener('popstate', (ev) => {
         const url = new URL(location.href)
-        const route = this.resolveRoute(url)
-        const span = startRouteChangeSpan(location.href, route, 'popstate')
+        const span = startRouteChangeSpan(url, 'popstate')
 
         onSettle((endTime) => {
           span.end(endTime)
         })
       })
 
-      const resolveRoute = this.resolveRoute
       const originalPushState = history.pushState
       history.pushState = function (...args) {
         const url = args[2]
 
         if (url) {
           const absoluteURL = new URL(getAbsoluteUrl(url.toString(), document.baseURI))
-          const route = resolveRoute(absoluteURL)
-          const span = startRouteChangeSpan(absoluteURL.toString(), route, 'pushState')
+          const span = startRouteChangeSpan(absoluteURL, 'pushState')
 
           onSettle((endTime) => {
             span.end(endTime)

--- a/packages/platforms/browser/lib/routing-provider.ts
+++ b/packages/platforms/browser/lib/routing-provider.ts
@@ -1,7 +1,7 @@
 import { isObject, type Span, type SpanOptions } from '@bugsnag/core-performance'
 
 export type RouteChangeSpanOptions = Omit<SpanOptions, 'isFirstClass'>
-export type StartRouteChangeCallback = (url: URL, trigger: string, options?: RouteChangeSpanOptions) => Span
+export type StartRouteChangeCallback = (url: URL | string, trigger: string, options?: RouteChangeSpanOptions) => Span
 
 export interface RoutingProvider {
   resolveRoute: (url: URL) => string

--- a/packages/platforms/browser/lib/routing-provider.ts
+++ b/packages/platforms/browser/lib/routing-provider.ts
@@ -1,7 +1,7 @@
 import { isObject, type Span, type SpanOptions } from '@bugsnag/core-performance'
 
 export type RouteChangeSpanOptions = Omit<SpanOptions, 'isFirstClass'>
-export type StartRouteChangeCallback = (url: string, route: string, trigger: string, options?: RouteChangeSpanOptions) => Span
+export type StartRouteChangeCallback = (url: URL, trigger: string, options?: RouteChangeSpanOptions) => Span
 
 export interface RoutingProvider {
   resolveRoute: (url: URL) => string

--- a/packages/platforms/browser/lib/routing-provider.ts
+++ b/packages/platforms/browser/lib/routing-provider.ts
@@ -1,7 +1,7 @@
 import { isObject, type Span, type SpanOptions } from '@bugsnag/core-performance'
 
 export type RouteChangeSpanOptions = Omit<SpanOptions, 'isFirstClass'>
-export type StartRouteChangeCallback = (route: string, trigger: string, options?: RouteChangeSpanOptions) => Span
+export type StartRouteChangeCallback = (url: string, route: string, trigger: string, options?: RouteChangeSpanOptions) => Span
 
 export interface RoutingProvider {
   resolveRoute: (url: URL) => string

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -182,18 +182,18 @@ describe('RouteChangePlugin', () => {
   describe('validation', () => {
     const invalidRoutes: any[] = [
       // eslint-disable-next-line compat/compat
-      { type: 'bigint', route: BigInt(9007199254740991) },
-      { type: 'true', route: true },
-      { type: 'false', route: false },
-      { type: 'function', route: () => {} },
-      { type: 'object', route: { property: 'test' } },
-      { type: 'empty array', route: [] },
-      { type: 'array', route: [1, 2, 3] },
-      { type: 'symbol', route: Symbol('test') },
-      { type: 'null', route: null }
+      { type: 'bigint', url: BigInt(9007199254740991) },
+      { type: 'true', url: true },
+      { type: 'false', url: false },
+      { type: 'function', url: () => {} },
+      { type: 'object', url: { property: 'test' } },
+      { type: 'empty array', url: [] },
+      { type: 'array', url: [1, 2, 3] },
+      { type: 'symbol', url: Symbol('test') },
+      { type: 'null', url: null }
     ]
 
-    it.each(invalidRoutes)('handles invalid routes ($type)', async ({ route }) => {
+    it.each(invalidRoutes)('handles invalid urls ($type)', async ({ url }) => {
       const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
       const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
       const routingProvider = new DefaultRoutingProvider()
@@ -213,15 +213,15 @@ describe('RouteChangePlugin', () => {
       await jest.runOnlyPendingTimersAsync()
 
       // trigger the route change
-      const span = routeChangeCallback(route, 'trigger')
-      expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - route should be a string, got ${typeof route}`)
+      const span = routeChangeCallback(url, 'trigger')
+      expect(jestLogger.warn).toHaveBeenCalledWith('Invalid span options\n  - url should be a URL')
 
       span.end()
 
       await jest.runOnlyPendingTimersAsync()
 
-      expect(delivery).toHaveSentSpan(expect.objectContaining({
-        name: `[RouteChange]${String(route)}`
+      expect(delivery).not.toHaveSentSpan(expect.objectContaining({
+        name: `[RouteChange]${String(url)}`
       }))
     })
 
@@ -258,7 +258,7 @@ describe('RouteChangePlugin', () => {
       await jest.runOnlyPendingTimersAsync()
 
       // trigger the route change
-      const span = routeChangeCallback('/route', trigger)
+      const span = routeChangeCallback(new URL('https://bugsnag.com/route'), trigger, {})
       expect(jestLogger.warn).toHaveBeenCalledWith(`Invalid span options\n  - trigger should be a string, got ${typeof trigger}`)
 
       span.end()

--- a/packages/platforms/browser/tests/utilities/mock-routing-provider.ts
+++ b/packages/platforms/browser/tests/utilities/mock-routing-provider.ts
@@ -5,7 +5,7 @@ class MockRoutingProvider implements RoutingProvider {
   readonly resolveRoute = () => '/initial-route'
 
   listenForRouteChanges (startRouteChangeSpan: StartRouteChangeCallback) {
-    startRouteChangeSpan(location.href, '/new-route', 'pushState')
+    startRouteChangeSpan(new URL(location.href), 'pushState')
   }
 }
 

--- a/packages/platforms/browser/tests/utilities/mock-routing-provider.ts
+++ b/packages/platforms/browser/tests/utilities/mock-routing-provider.ts
@@ -5,7 +5,7 @@ class MockRoutingProvider implements RoutingProvider {
   readonly resolveRoute = () => '/initial-route'
 
   listenForRouteChanges (startRouteChangeSpan: StartRouteChangeCallback) {
-    startRouteChangeSpan('/new-route', 'pushState')
+    startRouteChangeSpan(location.href, '/new-route', 'pushState')
   }
 }
 

--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -16,7 +16,7 @@ Feature: Page Load spans
         And the span named "[FullPageLoad]/page-load-spans/" is a valid full page load span
 
         # All spans should have a page url attribute
-        And every span string attribute "bugsnag.browser.page.url" matches the regex "^http:\/\/.*:[0-9]{4}\/page-load-spans\/.*\/?endpoint=.*\&logs=.*\&api_key=.*$"
+        And every span string attribute "bugsnag.browser.page.url" matches the regex "^http:\/\/.*:[0-9]{4}\/page-load-spans\/.*\/\?endpoint=.*\&logs=.*\&api_key=.*$"
 
         # We expect the following spans to always be present
         And a span named "[PageLoadPhase/HTTPRequest]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"

--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -16,7 +16,7 @@ Feature: Page Load spans
         And the span named "[FullPageLoad]/page-load-spans/" is a valid full page load span
 
         # All spans should have a page url attribute
-        And every span string attribute "bugsnag.browser.page.url" matches the regex "^http:\/\/.*:[0-9]{4}\/page-load-spans\/.*\/\?endpoint=.*\&logs=.*\&api_key=.*$"
+        And every span string attribute "bugsnag.browser.page.url" matches the regex "^http(s)?:\/\/.*:[0-9]{4}\/page-load-spans\/\?endpoint=.*\&logs=.*\&api_key=.*$"
 
         # We expect the following spans to always be present
         And a span named "[PageLoadPhase/HTTPRequest]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"

--- a/test/browser/features/route-change-spans.feature
+++ b/test/browser/features/route-change-spans.feature
@@ -5,7 +5,8 @@ Feature: Route change spans
         And I click the element "change-route"
         When I wait to receive 1 traces
 
-        Then a span named "[RouteChange]/new-route" contains the attributes: 
+        Then every span string attribute "bugsnag.browser.page.url" matches the regex "^http(s)?:\/\/.*:[0-9]{4}\/new-route$"
+        And a span named "[RouteChange]/new-route" contains the attributes: 
             | attribute                                 | type         | value                | 
             | bugsnag.span.category                     | stringValue  | route_change         |
             | bugsnag.browser.page.title                | stringValue  | New Route            |
@@ -18,6 +19,7 @@ Feature: Route change spans
         And I click the element "go-to-anchor"
         When I wait to receive 1 traces
 
+        Then every span string attribute "bugsnag.browser.page.url" matches the regex "^http(s)?:\/\/.*:[0-9]{4}\/route-change-spans(\/)?\?endpoint=.*\&logs=.*\&api_key=.*#anchor-link$"
         Then a span named "[RouteChange]/route-change-spans/" contains the attributes: 
             | attribute                                 | type         | value                | 
             | bugsnag.span.category                     | stringValue  | route_change         |


### PR DESCRIPTION
## Goal

Ensure `bugsnag.browser.page.url` attribute accurately reflects the new url after a route change

## Changeset

Added a new url parameter to `startRouteChangeSpan` callback in `listenForRouteChanges`

## Testing

Updated end to end tests