### PR TITLE
Test every combination of start/end times

### DIFF
--- a/test/browser/features/fixtures/packages/manual-span/src/index.js
+++ b/test/browser/features/fixtures/packages/manual-span/src/index.js
@@ -4,7 +4,7 @@ const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 9, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 const spanOptions = {}
 
@@ -12,5 +12,29 @@ if (parameters.has('isFirstClass')) {
   spanOptions.isFirstClass = JSON.parse(parameters.get('isFirstClass'))
 }
 
-const span = BugsnagPerformance.startSpan("Custom/ManualSpanScenario", spanOptions)
-span.end()
+function getTime (type) {
+  switch (type) {
+    case 'date':
+      return new Date()
+    case 'number':
+      return performance.now()
+  }
+}
+
+const combinations = [
+  ['date', 'date'],
+  ['date', 'number'],
+  ['date', 'undefined'],
+  ['number', 'date'],
+  ['number', 'number'],
+  ['number', 'undefined'],
+  ['undefined', 'date'],
+  ['undefined', 'number'],
+  ['undefined', 'undefined'],
+]
+
+for (const combination of combinations) {
+  spanOptions.startTime = getTime(combination[0])
+  const span = BugsnagPerformance.startSpan("Custom/ManualSpanScenario", spanOptions)
+  span.end(getTime(combination[1]))
+}


### PR DESCRIPTION
## Goal

Ensure spans are still valid with every combination of start/end time provided to spans

## Testing

Updated manual span test to send every combination of start and end times 