### PR TITLE
Run desktop browser tests against the CDN build in full pipeline

### DIFF
--- a/.buildkite/browser-pipeline.full.yml
+++ b/.buildkite/browser-pipeline.full.yml
@@ -1,4 +1,16 @@
 steps:
+  - label: ":docker: Build BrowserStack Maze Runner image"
+    key: "browser-maze-runner-bs"
+    timeout_in_minutes: 20
+    plugins:
+      - docker-compose#v4.12.0:
+          build: browser-maze-runner-bs
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
+          cache-from: browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
+      - docker-compose#v4.12.0:
+          push: browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
+    env:
+      USE_CDN_BUILD: "${USE_CDN_BUILD}"
 
   - label: ":browserstack: {{ matrix }} Mobile Browser tests"
     matrix:
@@ -20,3 +32,7 @@ steps:
           - "./test/browser/maze_output/failed/**/*"
     concurrency: 2
     concurrency_group: "browserstack"
+
+  - label: ":pipeline_upload: Basic browser pipeline with CDN build"
+    commands:
+      - USE_CDN_BUILD=1 EXTRA_STEP_LABEL=" (CDN)" buildkite-agent pipeline upload .buildkite/browser-pipeline.yml

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -1,43 +1,35 @@
 steps:
-
   - group: "Browser Tests"
     steps:
-      - label: ":docker: Build BitBar Maze Runner image"
-        key: "browser-maze-runner-bb"
+      - label: ":docker: Build BitBar Maze Runner image${EXTRA_STEP_LABEL}"
+        key: "browser-maze-runner-bb-${USE_CDN_BUILD}"
         timeout_in_minutes: 20
         plugins:
           - docker-compose#v4.12.0:
               build: browser-maze-runner-bb
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-              cache-from: browser-maze-runner-bb:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
+              cache-from: browser-maze-runner-bb:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
           - docker-compose#v4.12.0:
-              push: browser-maze-runner-bb:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
+              push: browser-maze-runner-bb:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
+        env:
+          USE_CDN_BUILD: "${USE_CDN_BUILD}"
 
-      - label: ":docker: Build BrowserStack Maze Runner image"
-        key: "browser-maze-runner-bs"
-        timeout_in_minutes: 20
-        plugins:
-          - docker-compose#v4.12.0:
-              build: browser-maze-runner-bs
-              image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-              cache-from: browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
-          - docker-compose#v4.12.0:
-              push: browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
-
-      - label: ":docker: Build Legacy Maze Runner image"
-        key: "browser-maze-runner-legacy"
+      - label: ":docker: Build Legacy Maze Runner image${EXTRA_STEP_LABEL}"
+        key: "browser-maze-runner-legacy-${USE_CDN_BUILD}"
         timeout_in_minutes: 20
         plugins:
           - docker-compose#v4.12.0:
               build: browser-maze-runner-legacy
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-              cache-from: browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
+              cache-from: browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
           - docker-compose#v4.12.0:
-              push: browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}
+              push: browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
+        env:
+          USE_CDN_BUILD: "${USE_CDN_BUILD}"
 
       # BitBar
-      - label: ":bitbar: :{{ matrix.browser }}: {{ matrix.version }} tests"
-        depends_on: "browser-maze-runner-bb"
+      - label: ":bitbar: :{{ matrix.browser }}: {{ matrix.version }} tests${EXTRA_STEP_LABEL}"
+        depends_on: "browser-maze-runner-bb-${USE_CDN_BUILD}"
         timeout_in_minutes: 30
         plugins:
           docker-compose#v4.12.0:
@@ -63,8 +55,8 @@ steps:
             - with: { browser: safari, version: 16 }
 
       # BrowserStack
-      - label: ":browserstack: :{{ matrix.browser }}: {{ matrix.version }} Browser tests"
-        depends_on: "browser-maze-runner-legacy"
+      - label: ":browserstack: :{{ matrix.browser }}: {{ matrix.version }} Browser tests${EXTRA_STEP_LABEL}"
+        depends_on: "browser-maze-runner-legacy-${USE_CDN_BUILD}"
         timeout_in_minutes: 30
         plugins:
           docker-compose#v4.12.0:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ x-common-environment: &common-environment
   MAZE_REPEATER_API_KEY:
 
 services:
-
   license-finder:
     build:
       dockerfile: dockerfiles/Dockerfile.license-finder
@@ -33,6 +32,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.browser-feature-builder
       args:
         MAZE_RUNNER_VERSION: latest-v8-cli
+        USE_CDN_BUILD:
     environment:
       <<: *common-environment
       BITBAR_USERNAME:
@@ -58,6 +58,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.browser-feature-builder
       args:
         MAZE_RUNNER_VERSION: latest-v8-cli
+        USE_CDN_BUILD:
     environment: &browser-maze-runner-environment
       <<: *common-environment
       BROWSER_STACK_BROWSERS_USERNAME:

--- a/dockerfiles/Dockerfile.browser-feature-builder
+++ b/dockerfiles/Dockerfile.browser-feature-builder
@@ -10,7 +10,9 @@ COPY . .
 # Install packages
 RUN npm ci
 WORKDIR /app/test/browser
-RUN SKIP_FIXTURE_CLEANUP=true ruby ./features/support/build-packages.rb
+
+ARG USE_CDN_BUILD
+RUN USE_CDN_BUILD=$USE_CDN_BUILD SKIP_FIXTURE_CLEANUP=true ruby ./features/support/build-packages.rb
 
 # Don't rebuild packages during e2e tests
 ENV SKIP_BUILD_PACKAGES=true

--- a/test/browser/features/fixtures/.gitignore
+++ b/test/browser/features/fixtures/.gitignore
@@ -1,0 +1,4 @@
+/.bugsnag-browser-version
+/packages/bugsnag-performance*.js*
+/packages/*.tgz
+/package.json.backup

--- a/test/browser/features/fixtures/packages/batch-max-limit/index.html
+++ b/test/browser/features/fixtures/packages/batch-max-limit/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>batch-max-limit</h1>

--- a/test/browser/features/fixtures/packages/batch-timeout/index.html
+++ b/test/browser/features/fixtures/packages/batch-timeout/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>batch-timeout</h1>

--- a/test/browser/features/fixtures/packages/connection-failure/index.html
+++ b/test/browser/features/fixtures/packages/connection-failure/index.html
@@ -44,6 +44,6 @@
 
         <button id="send-span">send span</button>
 
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/empty-batch/index.html
+++ b/test/browser/features/fixtures/packages/empty-batch/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>empty-batch</h1>

--- a/test/browser/features/fixtures/packages/enabled-release-stages-disabled/index.html
+++ b/test/browser/features/fixtures/packages/enabled-release-stages-disabled/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>Configuration</h1>

--- a/test/browser/features/fixtures/packages/enabled-release-stages/index.html
+++ b/test/browser/features/fixtures/packages/enabled-release-stages/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>Configuration</h1>

--- a/test/browser/features/fixtures/packages/manual-span/index.html
+++ b/test/browser/features/fixtures/packages/manual-span/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>manual-span</h1>

--- a/test/browser/features/fixtures/packages/navigation-changes/index.html
+++ b/test/browser/features/fixtures/packages/navigation-changes/index.html
@@ -13,6 +13,6 @@
           go to another page
         </a>
 
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/nested-spans/index.html
+++ b/test/browser/features/fixtures/packages/nested-spans/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>nested-spans</h1>

--- a/test/browser/features/fixtures/packages/network-spans/index.html
+++ b/test/browser/features/fixtures/packages/network-spans/index.html
@@ -12,6 +12,6 @@
         <button id="fetch-success">fetch-success</button>
         <button id="failed-requests">failed-requests</button>
 
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/oldest-batch-removed/index.html
+++ b/test/browser/features/fixtures/packages/oldest-batch-removed/index.html
@@ -9,6 +9,6 @@
         <button id="send-first-span">send first span</button>
         <button id="send-retry-spans">send spans</button>
         <button id="send-final-span">send final span</button>
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/one-span-per-trace/index.html
+++ b/test/browser/features/fixtures/packages/one-span-per-trace/index.html
@@ -9,6 +9,6 @@
 
         <button id="send-span">send span</button>
 
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/page-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/page-load-spans/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
         <title>Page load spans</title>
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>page-load-spans</h1>

--- a/test/browser/features/fixtures/packages/pre-start-spans/index.html
+++ b/test/browser/features/fixtures/packages/pre-start-spans/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>pre-start-spans</h1>

--- a/test/browser/features/fixtures/packages/resource-load-spans/index.html
+++ b/test/browser/features/fixtures/packages/resource-load-spans/index.html
@@ -14,6 +14,6 @@
         <h1>resource-load-spans</h1>
         <div id="image-container"></div>
         <button id="end-span">end span</button>
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
+++ b/test/browser/features/fixtures/packages/resource-load-spans/src/index.js
@@ -6,7 +6,7 @@ const endpoint = parameters.get("endpoint")
 
 const span = BugsnagPerformance.startSpan("[Custom]/resource-load-spans")
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 3, batchInactivityTimeoutMs: 3000, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 4, batchInactivityTimeoutMs: 3000, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
 
 document.getElementById("end-span").addEventListener("click", () => {
     const node = document.getElementById("image-container")

--- a/test/browser/features/fixtures/packages/retry-scenario/index.html
+++ b/test/browser/features/fixtures/packages/retry-scenario/index.html
@@ -8,6 +8,6 @@
         <h1>retry-scenario</h1>
         <button id="send-first-span">send first span</button>
         <button id="send-second-span">send second span</button>
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/rollup.config.mjs
@@ -15,4 +15,12 @@ export default {
     nodeResolve({ browser: true, jail: path.resolve(`${__dirname}/..`) }),
     commonjs()
   ],
+  onLog (level, log, defaultHandler) {
+    // turn warnings into errors
+    if (level === 'warn') {
+      level = 'error'
+    }
+
+    defaultHandler(level, log)
+  },
 }

--- a/test/browser/features/fixtures/packages/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/rollup.config.mjs
@@ -1,5 +1,9 @@
 import nodeResolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
+import path from 'path'
+import url from 'url'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 export default {
   input: 'src/index.js',
@@ -7,5 +11,8 @@ export default {
     file: 'dist/bundle.js',
     format: 'iife'
   },
-  plugins: [nodeResolve({ browser: true }), commonjs()],
+  plugins: [
+    nodeResolve({ browser: true, jail: path.resolve(`${__dirname}/..`) }),
+    commonjs()
+  ],
 }

--- a/test/browser/features/fixtures/packages/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/rollup.config.mjs
@@ -5,16 +5,29 @@ import url from 'url'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
+const isCdnBuild = process.env.USE_CDN_BUILD === "1" || process.env.USE_CDN_BUILD === "true"
+const cdnOutputOptions = {
+  // import BugsnagPerformance from the CDN build
+  banner: process.env.DEBUG
+    ? 'import BugsnagPerformance from "/bugsnag-performance.js"\n'
+    : 'import BugsnagPerformance from "/bugsnag-performance.min.js"\n',
+  globals: {
+    '@bugsnag/browser-performance': 'BugsnagPerformance',
+  },
+}
+
 export default {
   input: 'src/index.js',
   output: {
     file: 'dist/bundle.js',
-    format: 'iife'
+    format: 'iife',
+    ...(isCdnBuild ? cdnOutputOptions : {}),
   },
   plugins: [
     nodeResolve({ browser: true, jail: path.resolve(`${__dirname}/..`) }),
     commonjs()
   ],
+  ...(isCdnBuild ? { external: ['@bugsnag/browser-performance'] } : {}),
   onLog (level, log, defaultHandler) {
     // turn warnings into errors
     if (level === 'warn') {

--- a/test/browser/features/fixtures/packages/route-change-spans/index.html
+++ b/test/browser/features/fixtures/packages/route-change-spans/index.html
@@ -8,6 +8,6 @@
       <body>
         <div id="app"></div>
         <script src="./dist/app.js"></script>
-        <script src="./dist/bundle.js"></script>
+        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/route-change-spans/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/route-change-spans/rollup.config.mjs
@@ -29,5 +29,13 @@ export default {
       preventAssignment: false,
       'process.env.NODE_ENV': '"development"'
     })
-  ]
+  ],
+  onLog (level, log, defaultHandler) {
+    // turn warnings into errors
+    if (level === 'warn') {
+      level = 'error'
+    }
+
+    defaultHandler(level, log)
+  },
 }

--- a/test/browser/features/fixtures/packages/route-change-spans/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/route-change-spans/rollup.config.mjs
@@ -1,7 +1,11 @@
-import nodeResolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import babel from '@rollup/plugin-babel';
-import replace from '@rollup/plugin-replace';
+import nodeResolve from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+import babel from '@rollup/plugin-babel'
+import replace from '@rollup/plugin-replace'
+import path from 'path'
+import url from 'url'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 export default {
   input: 'src/app.jsx',
@@ -12,7 +16,8 @@ export default {
   plugins: [
     nodeResolve({
       extensions: ['.js', 'jsx'],
-      browser: true
+      browser: true,
+      jail: path.resolve(`${__dirname}/../..`),
     }),
     babel({
       babelHelpers: 'bundled',

--- a/test/browser/features/fixtures/packages/route-change-spans/src/app.jsx
+++ b/test/browser/features/fixtures/packages/route-change-spans/src/app.jsx
@@ -22,7 +22,7 @@ function Navigation() {
   )
 }
 
-export default function App() {
+function App() {
   return (
     <Router>
       <Navigation />

--- a/test/browser/features/lib/build-mode.rb
+++ b/test/browser/features/lib/build-mode.rb
@@ -1,0 +1,21 @@
+class BuildMode
+  def initialize
+    if File.exist?("#{__dir__}/../fixtures/packages/bugsnag-performance.js")
+      @mode = :cdn
+    else
+      @mode = :npm
+    end
+  end
+
+  def mode_name
+    @mode.to_s.upcase
+  end
+
+  def cdn?
+    @mode == :cdn
+  end
+
+  def npm?
+    @mode == :npm
+  end
+end

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -1,7 +1,7 @@
 Feature: Resource Load Spans
-
+  @skip_on_cdn_build
   @requires_resource_load_spans
-  Scenario: Resource load spans are automatically instrumented
+  Scenario: Resource load spans are automatically instrumented (NPM build)
     Given I navigate to the test URL "/resource-load-spans"
     And I wait to receive a sampling request
 
@@ -24,4 +24,34 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.url" matches the regex "^http:\/\/.*:[0-9]{4}\/favicon\.png\?height=100&width=100$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.flavor" equals "1.1"
-    
+
+  @skip_on_npm_build
+  @requires_resource_load_spans
+  Scenario: Resource load spans are automatically instrumented (CDN build)
+    Given I navigate to the test URL "/resource-load-spans"
+    And I wait to receive a sampling request
+
+    When I click the element "end-span"
+    And I wait to receive 1 trace
+
+    # Custom span (parent)
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.name" equals "[Custom]/resource-load-spans"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.spanId" is stored as the value "parent_span_id"
+
+    # App bundle
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/resource-load-spans\/dist\/bundle\.js$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parent_span_id"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "resource_load"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" equals "1.1"
+
+    # CDN bundle
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/bugsnag-performance(?:\.min)?\.js$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "resource_load"
+
+    # Image
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.name" matches the regex "^\[ResourceLoad\]http:\/\/.*:[0-9]{4}\/favicon.png$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.parentSpanId" equals the stored value "parent_span_id"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" string attribute "bugsnag.span.category" equals "resource_load"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" string attribute "http.url" matches the regex "^http:\/\/.*:[0-9]{4}\/favicon\.png\?height=100&width=100$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" string attribute "http.flavor" equals "1.1"

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -1,3 +1,5 @@
+SDK_VERSION = File.read("#{__dir__}/../fixtures/.bugsnag-browser-version")
+
 When("I navigate to the test URL {string}") do |test_path|
   path = $url_generator.for_path(test_path)
   step("I navigate to the URL \"#{path}\"")
@@ -10,9 +12,8 @@ When("I navigate to the test URL {string}") do |test_path|
   Maze::Store.values["environment"] = environment
   Maze::Store.values["bugsnag.browser.page.url"] = url
 
-  # store app version from package.json
-  package = JSON.parse(File.read("./features/fixtures/node_modules/@bugsnag/browser-performance/package.json"))
-  Maze::Store.values["telemetry.sdk.version"] = package["version"]
+  # store package version that we stashed away in build-packages.rb
+  Maze::Store.values["telemetry.sdk.version"] = SDK_VERSION
 end
 
 When("I set the HTTP status code for the next {int} {string} requests to {int}") do |count, http_verb, status_code|

--- a/test/browser/features/support/build-packages.rb
+++ b/test/browser/features/support/build-packages.rb
@@ -1,15 +1,25 @@
-# set the SKIP_BUILD_PACKAGES environment variable to disable building
-return if ENV.key?("SKIP_BUILD_PACKAGES")
+def environment_variable_enabled?(name)
+  value = ENV[name]
 
-require 'open3'
-require 'logger'
+  value == "1" || value == "true"
+end
+
+# set the SKIP_BUILD_PACKAGES environment variable to disable building
+return if environment_variable_enabled?("SKIP_BUILD_PACKAGES")
+
+require "json"
+require "open3"
+require "logger"
 
 # this file is run by Maze Runner automatically (where $logger is defined) and
 # by the browser dockerfile when building for CI (where $logger is NOT defined)
-$logger = Logger.new(STDOUT) unless $logger
+$logger ||= Logger.new(STDOUT)
 
 ROOT = "#{__dir__}/../../../.."
 FIXTURES_DIRECTORY = "#{__dir__}/../fixtures"
+BUILD_MODE = environment_variable_enabled?("USE_CDN_BUILD") ? :cdn : :npm
+
+$logger.info("Building in #{BUILD_MODE} mode")
 
 PACKAGE_NAMES = [
   "@bugsnag/core-performance",
@@ -55,24 +65,55 @@ begin
   Dir.chdir(ROOT) do
     run("ENABLE_TEST_CONFIGURATION=1 npm run build -- --scope #{PACKAGE_NAMES.join(" --scope ")}")
 
-    PACKAGE_DIRECTORIES.each do |package|
-      run("npm pack #{package} --pack-destination #{FIXTURES_DIRECTORY}")
+    if BUILD_MODE == :npm
+      # in NPM mode pack each package into the fixture directory
+      PACKAGE_DIRECTORIES.each do |package|
+        run("npm pack #{package} --pack-destination #{FIXTURES_DIRECTORY}")
+      end
+    else
+      # in CDN mode copy the bundles & sourcemaps (for debugging) into the
+      # fixture directory
+      run("cp build/bugsnag-performance*.js* #{FIXTURES_DIRECTORY}/packages/")
     end
   end
 
   Dir.chdir(FIXTURES_DIRECTORY) do
-    run("npm install --no-package-lock --no-save *.tgz")
-    run("npm run build --workspaces")
+    # backup the package json so we can undo the changes we're about to make
+    run("cp package.json package.json.backup")
+
+    install_command = "npm install --no-package-lock"
+    build_command = "npm run build --workspaces"
+
+    if BUILD_MODE == :npm
+      # in NPM mode we need to also install the tarballs from 'npm pack'
+      install_command += " *.tgz"
+    else
+      # in CDN mode we need to tell the JS build to also use CDN mode
+      build_command = "USE_CDN_BUILD=1 " + build_command
+    end
+
+    run(install_command)
+    run(build_command)
+
+    # store the browser package version in a file for the cucumber steps to use
+    package = JSON.parse(File.read("#{ROOT}/packages/platforms/browser/package.json"))
+    bugsnag_browser_version = package["version"]
+
+    File.open(".bugsnag-browser-version", "w") do |file|
+      file.write(bugsnag_browser_version)
+    end
   end
 ensure
   run("rm -f #{FIXTURES_DIRECTORY}/*.tgz")
+  run("mv #{FIXTURES_DIRECTORY}/package.json.backup #{FIXTURES_DIRECTORY}/package.json")
 end
 
 # this at_exit is after the above commands on purpose - if they fail then we
 # DON'T want these cleanup commands to run so it's easier to debug
-unless ENV.key?("SKIP_FIXTURE_CLEANUP") || ENV.key?("DEBUG")
+unless environment_variable_enabled?("SKIP_FIXTURE_CLEANUP") || environment_variable_enabled?("DEBUG")
   at_exit do
     Dir.chdir(FIXTURES_DIRECTORY) do
+      run("rm -f #{FIXTURES_DIRECTORY}/packages/bugsnag-performance*.js*")
       run("rm -rf node_modules")
       run("npm run clean --workspaces")
     end

--- a/test/browser/features/support/maze-config.rb
+++ b/test/browser/features/support/maze-config.rb
@@ -1,11 +1,15 @@
 require_relative '../lib/browser'
+require_relative '../lib/build-mode'
 require_relative '../lib/url-generator'
 
+$build_mode = BuildMode.new
 $browser = Browser.new(Maze.config.browser)
 
 Maze.hooks.before_all do
   Maze.config.document_server_root = File.realpath("#{__dir__}/../fixtures/packages")
   Maze.config.enforce_bugsnag_integrity = false
+
+  $logger.info("Running in #{$build_mode.mode_name} mode")
 end
 
 Maze.hooks.before do

--- a/test/browser/features/support/skip.rb
+++ b/test/browser/features/support/skip.rb
@@ -2,6 +2,14 @@ Before('@skip') do
   skip_this_scenario("Skipping scenario")
 end
 
-Before ('@skip_on_device') do
+Before('@skip_on_device') do
   skip_this_scenario("Skipping scenario: Not suitable for mobile devices") if $browser.mobile?
+end
+
+Before("@skip_on_cdn_build") do
+  skip_this_scenario("Skipping scenario: Not suitable for CDN build") if $build_mode.cdn?
+end
+
+Before("@skip_on_npm_build") do
+  skip_this_scenario("Skipping scenario: Not suitable for NPM build") if $build_mode.npm?
 end


### PR DESCRIPTION
## Goal

This PR extends the "full build" pipeline to run the basic pipeline against the CDN build

The full pipeline uploads the basic pipeline with the `USE_CDN_BUILD` environment variable defined, which ultimately causes the fixtures to use the CDN build instead of `npm pack`-ing the packages and installing those

The CDN bundle is then imported in the existing test fixture JS files so that it reflects real-world usage (as opposed to bundling the CDN build into the fixture bundles)

This required a lot of supporting changes to the way we prepare and build the fixtures but is all controlled by the `USE_CDN_BUILD` environment variable in the existing `build_packages.rb` script & rollup config

## Testing

A manually triggered full build passes: https://buildkite.com/bugsnag/bugsnag-js-performance/builds/1662

You can tell if the CDN build is being used because it logs a message at `INFO` level:

<img width="260" alt="image" src="https://github.com/bugsnag/bugsnag-js-performance/assets/282732/8dc79549-324a-4ac8-812c-fff1797a7c2f">  <img width="249" alt="image" src="https://github.com/bugsnag/bugsnag-js-performance/assets/282732/5cbed552-446a-40b0-8cd5-12510e0b35f8">

The resource load test has been split into two (one for the NPM build and one for the CDN build because the CDN bundle is an extra resource load) so you can also look at which version has been run