### PR TITLE
Add code coverage script and config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,14 @@ const moduleNameMapper = Object.fromEntries(
 )
 
 module.exports = {
+  collectCoverageFrom: [
+    '**/packages/*/**/*.ts',
+    '!**/packages/*/**/*.d.ts',
+    '!**/packages/*/**/tests/**/*',
+    '!<rootDir>/packages/test-utilities/**/*',
+    '!<rootDir>/test/**/*'
+  ],
+  coverageReporters: ['json-summary', 'text'],
   transform: {
     '^.+\\.m?[tj]sx?$': [
       'ts-jest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^18.11.18",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.50.0",
+        "coverage-diff": "^3.2.0",
         "eslint": "^8.33.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-config-standard-with-typescript": "^34.0.0",
@@ -5383,6 +5384,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/coverage-diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/coverage-diff/-/coverage-diff-3.2.0.tgz",
+      "integrity": "sha512-ZapsZXZZTQAEfWlUoObrpkvRnMYHbi99T96XRJlrbcZkIKpDvSmVxfJ0dPwjI3eTbl122hVMTmEwielS7qvTfg==",
+      "dev": true,
+      "dependencies": {
+        "markdown-table": "2.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -9745,6 +9755,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -12037,6 +12060,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -f build/* && lerna run --stream --parallel clean",
     "test:lint": "eslint --max-warnings=0 .",
     "test:unit": "jest",
+    "test:coverage": "jest --coverage",
     "test:test-container-registry-login": "aws ecr get-login-password --profile=opensource --region=us-west-1 | docker login --username AWS --password-stdin 855461928731.dkr.ecr.us-west-1.amazonaws.com"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
+    "coverage-diff": "^3.2.0",
     "eslint": "^8.33.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-with-typescript": "^34.0.0",


### PR DESCRIPTION
## Goal

Adds an npm script and jest configuration for generating code coverage reports, as well as a dev dependency on `coverage-diff` for generating the comparison table for the PR comment

PR'd separately because the coverage script and configuration are needed in both of the branches being compared