### PR TITLE
[PLAT-10560] Remove empty http.flavor span attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- (browser) Only add `http.flavor` span attribute when it is a useful value [#255](https://github.com/bugsnag/bugsnag-js-performance/pull/255)
+
 ## v0.2.0 (2023-07-10)
 
 ### Added
@@ -10,7 +16,6 @@
 ### Fixed
 
 - (core) Correctly report the `Bugsnag-Span-Sampling` header [#256](https://github.com/bugsnag/bugsnag-js-performance/pull/256) [#257](https://github.com/bugsnag/bugsnag-js-performance/pull/257)
-
 
 ## v0.1.1 (2023-06-28)
 

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -7,6 +7,8 @@ interface ResourceTiming extends PerformanceResourceTiming {
 
 export function getHttpVersion (protocol: string) {
   switch (protocol) {
+    case '':
+      return undefined
     case 'http/1.0':
       return '1.0'
     case 'http/1.1':
@@ -21,7 +23,7 @@ export function getHttpVersion (protocol: string) {
     case 'spdy/3':
       return 'SPDY'
     default:
-      return undefined
+      return protocol
   }
 }
 

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -7,6 +7,8 @@ interface ResourceTiming extends PerformanceResourceTiming {
 
 export function getHttpVersion (protocol: string) {
   switch (protocol) {
+    case '':
+      return undefined
     case 'http/1.0':
       return '1.0'
     case 'http/1.1':
@@ -64,7 +66,11 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
 
           span.setAttribute('bugsnag.span.category', 'resource_load')
           span.setAttribute('http.url', entry.name)
-          span.setAttribute('http.flavor', getHttpVersion(entry.nextHopProtocol))
+
+          const httpFlavor = getHttpVersion(entry.nextHopProtocol)
+          if (httpFlavor) {
+            span.setAttribute('http.flavor', httpFlavor)
+          }
 
           if (entry.encodedBodySize && entry.decodedBodySize) {
             span.setAttribute('http.response_content_length', entry.encodedBodySize)

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -7,8 +7,6 @@ interface ResourceTiming extends PerformanceResourceTiming {
 
 export function getHttpVersion (protocol: string) {
   switch (protocol) {
-    case '':
-      return undefined
     case 'http/1.0':
       return '1.0'
     case 'http/1.1':
@@ -23,7 +21,7 @@ export function getHttpVersion (protocol: string) {
     case 'spdy/3':
       return 'SPDY'
     default:
-      return protocol
+      return undefined
   }
 }
 

--- a/packages/test-utilities/lib/span-attributes-source.ts
+++ b/packages/test-utilities/lib/span-attributes-source.ts
@@ -3,19 +3,6 @@ import { type SpanAttribute } from '@bugsnag/core-performance'
 function spanAttributesSource (): Map<string, SpanAttribute> {
   const spanAttributes = new Map()
 
-  spanAttributes.set('browser.page.url', '/unit-test/span-attributes-source')
-  spanAttributes.set('browser.page.route', '/unit-test/[case]')
-  spanAttributes.set('bugsnag.span.category', 'unit test')
-  spanAttributes.set('http.url', 'https://example.com')
-  spanAttributes.set('http.method', 'GET')
-  spanAttributes.set('http.status_code', 200)
-  spanAttributes.set('http.flavor', 2.0)
-  spanAttributes.set('http.request_content_length', 12_345)
-  spanAttributes.set('http.request_content_length_uncompressed', 20_000)
-  spanAttributes.set('http.response_content_length', 28_461)
-  spanAttributes.set('http.response_content_length_uncompressed', 40_000)
-  spanAttributes.set('http.retry_count', 2)
-
   return spanAttributes
 }
 


### PR DESCRIPTION
## Goal

To only add an `http.flavor` span attribute if it is a usable value.

## Testing

Updated unit tests