### PR TITLE
Store both the raw and scaled probability on spans

### DIFF
--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -132,7 +132,7 @@ export class BatchProcessor<C extends Configuration> implements Processor {
     const probability = this.sampler.spanProbability
 
     for (const span of this.batch) {
-      if (span.samplingProbability < probability) {
+      if (span.samplingProbability.raw < probability.raw) {
         span.samplingProbability = probability
       }
 

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -24,8 +24,13 @@ export const enum Kind {
 // this prevents the wrong kind of number being assigned to the span's
 // samplingProbability
 // this exists only in the type system; at runtime it's a regular number
-declare const validSpanProbability: unique symbol
-export type SpanProbability = number & { [validSpanProbability]: true }
+declare const validScaledProbability: unique symbol
+export type ScaledProbability = number & { [validScaledProbability]: true }
+
+export interface SpanProbability {
+  readonly scaled: ScaledProbability
+  readonly raw: number
+}
 
 export interface SpanEnded {
   readonly id: string // 64 bit random string

--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -1,6 +1,6 @@
 import {
   type SpanEnded,
-  type SpanProbability,
+  type ScaledProbability,
   SpanAttributes,
   traceIdToSamplingRate,
   SpanEvents
@@ -20,7 +20,10 @@ export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded 
     traceId,
     samplingRate: traceIdToSamplingRate(traceId),
     endTime: 23456,
-    samplingProbability: Math.floor(0.5 * 0xffffffff) as SpanProbability,
+    samplingProbability: {
+      raw: 0.5,
+      scaled: Math.floor(0.5 * 0xffffffff) as ScaledProbability
+    },
     ...overrides
   }
 }


### PR DESCRIPTION
## Goal

Currently we only store the scaled probability value on a `SpanEnded` as its `samplingProbability`. However, we need the raw value (between 0-1) in order to calculate the `Bugsnag-Span-Sampling` header and to store in the `bugsnag.sampling.p` attribute

This PR updates `samplingProbability` to be an object with both the raw and scaled probability values