### PR TITLE
Correctly report sampling header

### DIFF
--- a/packages/core/lib/delivery.ts
+++ b/packages/core/lib/delivery.ts
@@ -1,8 +1,10 @@
-import { type JsonAttribute } from './attributes'
+import { type Configuration, type InternalConfiguration } from './config'
+import { type Clock } from './clock'
+import { type JsonAttribute, type ResourceAttributeSource } from './attributes'
 import { type JsonEvent } from './events'
-import { type Kind } from './span'
+import { type Kind, type SpanEnded, spanToJson } from './span'
 
-export type DeliveryFactory = (apiKey: string, endpoint: string) => Delivery
+export type DeliveryFactory = (endpoint: string) => Delivery
 
 export type ResponseState = 'success' | 'failure-discard' | 'failure-retryable'
 
@@ -12,7 +14,7 @@ interface Response {
 }
 
 export interface Delivery {
-  send: (payload: DeliveryPayload) => Promise<Response>
+  send: (payload: TracePayload) => Promise<Response>
 }
 
 interface Resource {
@@ -42,6 +44,88 @@ export interface DeliverySpan {
   endTimeUnixNano: string
   attributes: Array<JsonAttribute | undefined>
   events: JsonEvent[]
+}
+
+export interface TracePayload {
+  body: DeliveryPayload
+  headers: {
+    'Bugsnag-Api-Key': string
+    'Content-Type': 'application/json'
+    'Bugsnag-Span-Sampling': string
+    // we don't add 'Bugsnag-Sent-At' in the TracePayloadEncoder so that retried
+    // payloads get a new value each time delivery is attempted
+    // therefore it's 'undefined' when passed to delivery, which adds a value
+    // immediately before initiating the request
+    'Bugsnag-Sent-At'?: string
+  }
+}
+
+export class TracePayloadEncoder<C extends Configuration> {
+  private readonly clock: Clock
+  private readonly configuration: InternalConfiguration<C>
+  private readonly resourceAttributeSource: ResourceAttributeSource<C>
+
+  constructor (
+    clock: Clock,
+    configuration: InternalConfiguration<C>,
+    resourceAttributeSource: ResourceAttributeSource<C>
+  ) {
+    this.clock = clock
+    this.configuration = configuration
+    this.resourceAttributeSource = resourceAttributeSource
+  }
+
+  async encode (spans: SpanEnded[]): Promise<TracePayload> {
+    const resourceAttributes = await this.resourceAttributeSource(this.configuration)
+    const jsonSpans = Array(spans.length)
+
+    for (let i = 0; i < spans.length; ++i) {
+      jsonSpans[i] = spanToJson(spans[i], this.clock)
+    }
+
+    const deliveryPayload: DeliveryPayload = {
+      resourceSpans: [
+        {
+          resource: { attributes: resourceAttributes.toJson() },
+          scopeSpans: [{ spans: jsonSpans }]
+        }
+      ]
+    }
+
+    return {
+      body: deliveryPayload,
+      headers: {
+        'Bugsnag-Api-Key': this.configuration.apiKey,
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': this.generateSamplingHeader(spans)
+      }
+    }
+  }
+
+  generateSamplingHeader (spans: SpanEnded[]): string {
+    if (spans.length === 0) {
+      return '1:0'
+    }
+
+    const spanCounts: Record<string, number> = Object.create(null)
+
+    for (const span of spans) {
+      const existingValue = spanCounts[span.samplingProbability.raw] || 0
+
+      spanCounts[span.samplingProbability.raw] = existingValue + 1
+    }
+
+    const rawProbabilities = Object.keys(spanCounts)
+    const pairs = Array(rawProbabilities.length)
+
+    for (let i = 0; i < rawProbabilities.length; ++i) {
+      const rawProbability = rawProbabilities[i]
+
+      pairs[i] = `${rawProbability}:${spanCounts[rawProbability]}`
+    }
+
+    return pairs.join(';')
+  }
 }
 
 const retryCodes = new Set([402, 407, 408, 429])

--- a/packages/core/lib/probability-fetcher.ts
+++ b/packages/core/lib/probability-fetcher.ts
@@ -1,23 +1,28 @@
-import { type Delivery } from './delivery'
+import { type Delivery, type TracePayload } from './delivery'
 
 // the time to wait before retrying a failed request
 const RETRY_MILLISECONDS = 30 * 1000
 
-// the request body sent when fetching a new probability value; this is the
-// minimal body the server expects to receive
-const PROBABILITY_REQUEST = { resourceSpans: [] }
-
 class ProbabilityFetcher {
   private readonly delivery: Delivery
+  private readonly payload: TracePayload
 
-  constructor (delivery: Delivery) {
+  constructor (delivery: Delivery, apiKey: string) {
     this.delivery = delivery
+    this.payload = {
+      body: { resourceSpans: [] },
+      headers: {
+        'Bugsnag-Api-Key': apiKey,
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': '1.0:0'
+      }
+    }
   }
 
   async getNewProbability (): Promise<number> {
     // keep making requests until we get a new probability value from the server
     while (true) {
-      const response = await this.delivery.send(PROBABILITY_REQUEST)
+      const response = await this.delivery.send(this.payload)
 
       // in theory this should always be present, but it's possible the request
       // fails or there's a bug on the server side causing it not to be returned

--- a/packages/core/lib/retry-queue.ts
+++ b/packages/core/lib/retry-queue.ts
@@ -1,12 +1,12 @@
-import { type Delivery, type DeliveryPayload } from './delivery'
+import { type Delivery, type TracePayload } from './delivery'
 
 export interface RetryQueue {
-  add: (payload: DeliveryPayload, time: number) => void
+  add: (payload: TracePayload, time: number) => void
   flush: () => Promise<void>
 }
 
 interface PayloadWithTimestamp {
-  payload: DeliveryPayload
+  payload: TracePayload
   time: number
 }
 
@@ -18,7 +18,7 @@ export class InMemoryQueue implements RetryQueue {
 
   constructor (private delivery: Delivery, private retryQueueMaxSize: number) {}
 
-  add (payload: DeliveryPayload, time: number) {
+  add (payload: TracePayload, time: number) {
     this.payloads.push({ payload, time })
 
     let spanCount = this.payloads.reduce((count, { payload }) => count + countSpansInPayload(payload), 0)
@@ -68,11 +68,11 @@ export class InMemoryQueue implements RetryQueue {
   }
 }
 
-function countSpansInPayload (payload: DeliveryPayload) {
+function countSpansInPayload (payload: TracePayload) {
   let count = 0
 
-  for (let i = 0; i < payload.resourceSpans.length; ++i) {
-    const scopeSpans = payload.resourceSpans[i].scopeSpans
+  for (let i = 0; i < payload.body.resourceSpans.length; ++i) {
+    const scopeSpans = payload.body.resourceSpans[i].scopeSpans
 
     for (let j = 0; j < scopeSpans.length; ++j) {
       count += scopeSpans[j].spans.length

--- a/packages/core/tests/delivery.test.ts
+++ b/packages/core/tests/delivery.test.ts
@@ -1,0 +1,140 @@
+import { TracePayloadEncoder } from '../lib/delivery'
+import {
+  createConfiguration,
+  createEndedSpan,
+  createSamplingProbability,
+  IncrementingClock,
+  resourceAttributesSource
+} from '@bugsnag/js-performance-test-utilities'
+
+describe('TracePayloadEncoder', () => {
+  it('encodes spans into a TracePayload', async () => {
+    const encoder = new TracePayloadEncoder(
+      new IncrementingClock('1970-01-01T00:00:00Z'),
+      createConfiguration({ apiKey: 'an api key' }),
+      resourceAttributesSource
+    )
+
+    const spans = [
+      createEndedSpan({
+        id: '5b306f21daa04ddd',
+        name: 'span #1',
+        kind: 1,
+        traceId: '36d2995627e423c69b09bb8dd63157b0',
+        startTime: 1,
+        endTime: 2
+      }),
+      createEndedSpan({
+        id: '389cbf7a934bf299',
+        name: 'span #2',
+        kind: 1,
+        traceId: '6aa28c93e95d309b7b5d9888dd2d688d',
+        startTime: 3,
+        endTime: 4
+      }),
+      createEndedSpan({
+        id: 'e1bafc75f74e62ee',
+        name: 'span #3',
+        kind: 1,
+        traceId: '91024bae685205009ce9003f1d11aadd',
+        startTime: 5,
+        endTime: 6,
+        samplingProbability: createSamplingProbability(0.25)
+      })
+    ]
+
+    const actual = await encoder.encode(spans)
+
+    expect(actual).toStrictEqual({
+      body: {
+        resourceSpans: [
+          {
+            resource: {
+              attributes: [
+                { key: 'deployment.environment', value: { stringValue: 'test' } },
+                { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.core' } },
+                { key: 'telemetry.sdk.version', value: { stringValue: '1.2.3' } },
+                { key: 'service.version', value: { stringValue: '3.4.5' } }
+              ]
+            },
+            scopeSpans: [
+              {
+                spans: [
+                  {
+                    attributes: [],
+                    endTimeUnixNano: '2000000',
+                    events: [],
+                    kind: 1,
+                    name: 'span #1',
+                    parentSpanId: undefined,
+                    spanId: '5b306f21daa04ddd',
+                    startTimeUnixNano: '1000000',
+                    traceId: '36d2995627e423c69b09bb8dd63157b0'
+                  },
+                  {
+                    attributes: [],
+                    endTimeUnixNano: '4000000',
+                    events: [],
+                    kind: 1,
+                    name: 'span #2',
+                    parentSpanId: undefined,
+                    spanId: '389cbf7a934bf299',
+                    startTimeUnixNano: '3000000',
+                    traceId: '6aa28c93e95d309b7b5d9888dd2d688d'
+                  },
+                  {
+                    attributes: [],
+                    endTimeUnixNano: '6000000',
+                    events: [],
+                    kind: 1,
+                    name: 'span #3',
+                    parentSpanId: undefined,
+                    spanId: 'e1bafc75f74e62ee',
+                    startTimeUnixNano: '5000000',
+                    traceId: '91024bae685205009ce9003f1d11aadd'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      headers: {
+        'Bugsnag-Api-Key': 'an api key',
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': '0.5:2;0.25:1'
+      }
+    })
+  })
+
+  describe('Bugsnag-Span-Sampling header', () => {
+    it.each([
+      { spanProbabilities: [], expected: '1:0' },
+      { spanProbabilities: [1.0], expected: '1:1' },
+      { spanProbabilities: [0], expected: '0:1' },
+      { spanProbabilities: [1.0, 1, 1], expected: '1:3' },
+      { spanProbabilities: [0.1, 0.2, 0.3], expected: '0.1:1;0.2:1;0.3:1' },
+      { spanProbabilities: [0.75, 1, 1.0, 0.5, 0.5, 0.5], expected: '1:2;0.75:1;0.5:3' },
+      {
+        spanProbabilities: Array(25).fill(0.4).concat(Array(50).fill(0.8)).concat(Array(10).fill(1)),
+        expected: '1:10;0.4:25;0.8:50'
+      }
+    ])('generates "$expected" with span probabilities of "$spanProbabilities"', async ({ spanProbabilities, expected }) => {
+      const encoder = new TracePayloadEncoder(
+        new IncrementingClock(),
+        createConfiguration(),
+        resourceAttributesSource
+      )
+
+      const spans = spanProbabilities.map(
+        probability => createEndedSpan({
+          samplingProbability: createSamplingProbability(probability)
+        })
+      )
+
+      const payload = await encoder.encode(spans)
+
+      expect(payload.headers['Bugsnag-Span-Sampling']).toBe(expected)
+    })
+  })
+})

--- a/packages/core/tests/probability-fetcher.test.ts
+++ b/packages/core/tests/probability-fetcher.test.ts
@@ -8,7 +8,7 @@ describe('ProbabilityFetcher', () => {
     const delivery = new InMemoryDelivery()
     delivery.setNextSamplingProbability(0.25)
 
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
     const probability = await fetcher.getNewProbability()
 
     expect(probability).toBe(0.25)
@@ -18,7 +18,7 @@ describe('ProbabilityFetcher', () => {
     const delivery = new InMemoryDelivery()
     delivery.setNextSamplingProbability(0.0)
 
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
     const probability = await fetcher.getNewProbability()
 
     expect(probability).toBe(0.0)
@@ -28,7 +28,7 @@ describe('ProbabilityFetcher', () => {
     const delivery = new InMemoryDelivery()
     delivery.setNextSamplingProbability(undefined)
 
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
 
     const fetcherPromise = fetcher.getNewProbability()
 

--- a/packages/core/tests/probability-manager.test.ts
+++ b/packages/core/tests/probability-manager.test.ts
@@ -13,7 +13,7 @@ describe('ProbabilityManager', () => {
     delivery.setNextSamplingProbability(0.5)
 
     const sampler = new Sampler(0.75)
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
 
     await ProbabilityManager.create(
       persistence,
@@ -59,7 +59,7 @@ describe('ProbabilityManager', () => {
     delivery.setNextSamplingProbability(0.5)
 
     const sampler = new Sampler(0.5)
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
 
     await ProbabilityManager.create(
       persistence,
@@ -102,7 +102,7 @@ describe('ProbabilityManager', () => {
     delivery.setNextSamplingProbability(0.5)
 
     const sampler = new Sampler(0.5)
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
 
     await ProbabilityManager.create(
       persistence,
@@ -136,7 +136,7 @@ describe('ProbabilityManager', () => {
     delivery.setNextSamplingProbability(0.5)
 
     const sampler = new Sampler(0.75)
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
 
     const manager = await ProbabilityManager.create(
       persistence,
@@ -168,7 +168,7 @@ describe('ProbabilityManager', () => {
     delivery.setNextSamplingProbability(0.5)
 
     const sampler = new Sampler(0.75)
-    const fetcher = new ProbabilityFetcher(delivery)
+    const fetcher = new ProbabilityFetcher(delivery, 'api key')
 
     const manager = await ProbabilityManager.create(
       persistence,

--- a/packages/platforms/browser/tests/delivery.test.ts
+++ b/packages/platforms/browser/tests/delivery.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { type DeliveryPayload } from '@bugsnag/core-performance'
+import { type TracePayload } from '@bugsnag/core-performance'
 import { ControllableBackgroundingListener } from '@bugsnag/js-performance-test-utilities'
 import createBrowserDeliveryFactory from '../lib/delivery'
 
@@ -14,35 +14,42 @@ describe('Browser Delivery', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
     const backgroundingListener = new ControllableBackgroundingListener()
 
-    const deliveryPayload: DeliveryPayload = {
-      resourceSpans: [{
-        resource: { attributes: [{ key: 'test-key', value: { stringValue: 'test-value' } }] },
-        scopeSpans: [{
-          spans: [{
-            name: 'test-span',
-            kind: 1,
-            spanId: 'test-span-id',
-            traceId: 'test-trace-id',
-            endTimeUnixNano: '56789',
-            startTimeUnixNano: '12345',
-            attributes: [{ key: 'test-span', value: { intValue: '12345' } }],
-            events: []
+    const deliveryPayload: TracePayload = {
+      body: {
+        resourceSpans: [{
+          resource: { attributes: [{ key: 'test-key', value: { stringValue: 'test-value' } }] },
+          scopeSpans: [{
+            spans: [{
+              name: 'test-span',
+              kind: 1,
+              spanId: 'test-span-id',
+              traceId: 'test-trace-id',
+              endTimeUnixNano: '56789',
+              startTimeUnixNano: '12345',
+              attributes: [{ key: 'test-span', value: { intValue: '12345' } }],
+              events: []
+            }]
           }]
         }]
-      }]
+      },
+      headers: {
+        'Bugsnag-Api-Key': 'test-api-key',
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': '1:1'
+      }
     }
 
     const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
-    const delivery = deliveryFactory('test-api-key', '/test')
+    const delivery = deliveryFactory('/test')
     delivery.send(deliveryPayload)
 
     expect(fetch).toHaveBeenCalledWith('/test', {
       method: 'POST',
       keepalive: false,
-      body: JSON.stringify(deliveryPayload),
+      body: JSON.stringify(deliveryPayload.body),
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
-        'Bugsnag-Span-Sampling': '1.0:1',
+        'Bugsnag-Span-Sampling': '1:1',
         'Content-Type': 'application/json',
         'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
       }
@@ -53,26 +60,33 @@ describe('Browser Delivery', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
     const backgroundingListener = new ControllableBackgroundingListener()
 
-    const deliveryPayload: DeliveryPayload = {
-      resourceSpans: [{
-        resource: { attributes: [{ key: 'test-key', value: { stringValue: 'test-value' } }] },
-        scopeSpans: [{
-          spans: [{
-            name: 'test-span',
-            kind: 1,
-            spanId: 'test-span-id',
-            traceId: 'test-trace-id',
-            endTimeUnixNano: '56789',
-            startTimeUnixNano: '12345',
-            attributes: [{ key: 'test-span', value: { intValue: '12345' } }],
-            events: []
+    const deliveryPayload: TracePayload = {
+      body: {
+        resourceSpans: [{
+          resource: { attributes: [{ key: 'test-key', value: { stringValue: 'test-value' } }] },
+          scopeSpans: [{
+            spans: [{
+              name: 'test-span',
+              kind: 1,
+              spanId: 'test-span-id',
+              traceId: 'test-trace-id',
+              endTimeUnixNano: '56789',
+              startTimeUnixNano: '12345',
+              attributes: [{ key: 'test-span', value: { intValue: '12345' } }],
+              events: []
+            }]
           }]
         }]
-      }]
+      },
+      headers: {
+        'Bugsnag-Api-Key': 'test-api-key',
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': '1:1'
+      }
     }
 
     const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
-    const delivery = deliveryFactory('test-api-key', '/test')
+    const delivery = deliveryFactory('/test')
 
     backgroundingListener.sendToBackground()
 
@@ -81,10 +95,10 @@ describe('Browser Delivery', () => {
     expect(fetch).toHaveBeenCalledWith('/test', {
       method: 'POST',
       keepalive: true,
-      body: JSON.stringify(deliveryPayload),
+      body: JSON.stringify(deliveryPayload.body),
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
-        'Bugsnag-Span-Sampling': '1.0:1',
+        'Bugsnag-Span-Sampling': '1:1',
         'Content-Type': 'application/json',
         'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
       }
@@ -95,26 +109,33 @@ describe('Browser Delivery', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
     const backgroundingListener = new ControllableBackgroundingListener()
 
-    const deliveryPayload: DeliveryPayload = {
-      resourceSpans: [{
-        resource: { attributes: [{ key: 'test-key', value: { stringValue: 'test-value' } }] },
-        scopeSpans: [{
-          spans: [{
-            name: 'test-span',
-            kind: 1,
-            spanId: 'test-span-id',
-            traceId: 'test-trace-id',
-            endTimeUnixNano: '56789',
-            startTimeUnixNano: '12345',
-            attributes: [{ key: 'test-span', value: { intValue: '12345' } }],
-            events: []
+    const deliveryPayload: TracePayload = {
+      body: {
+        resourceSpans: [{
+          resource: { attributes: [{ key: 'test-key', value: { stringValue: 'test-value' } }] },
+          scopeSpans: [{
+            spans: [{
+              name: 'test-span',
+              kind: 1,
+              spanId: 'test-span-id',
+              traceId: 'test-trace-id',
+              endTimeUnixNano: '56789',
+              startTimeUnixNano: '12345',
+              attributes: [{ key: 'test-span', value: { intValue: '12345' } }],
+              events: []
+            }]
           }]
         }]
-      }]
+      },
+      headers: {
+        'Bugsnag-Api-Key': 'test-api-key',
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': '1:1'
+      }
     }
 
     const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
-    const delivery = deliveryFactory('test-api-key', '/test')
+    const delivery = deliveryFactory('/test')
 
     backgroundingListener.sendToBackground()
     backgroundingListener.sendToForeground()
@@ -124,10 +145,10 @@ describe('Browser Delivery', () => {
     expect(fetch).toHaveBeenCalledWith('/test', {
       method: 'POST',
       keepalive: false,
-      body: JSON.stringify(deliveryPayload),
+      body: JSON.stringify(deliveryPayload.body),
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
-        'Bugsnag-Span-Sampling': '1.0:1',
+        'Bugsnag-Span-Sampling': '1:1',
         'Content-Type': 'application/json',
         'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
       }
@@ -156,14 +177,22 @@ describe('Browser Delivery', () => {
     const backgroundingListener = new ControllableBackgroundingListener()
 
     const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
-    const delivery = deliveryFactory('test-api-key', '/test')
-    const deliveryPayload: DeliveryPayload = { resourceSpans: [] }
+    const delivery = deliveryFactory('/test')
+    const deliveryPayload: TracePayload = {
+      body: { resourceSpans: [] },
+      headers: {
+        'Bugsnag-Api-Key': 'test-api-key',
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': '1.0:0'
+      }
+    }
+
     const response = await delivery.send(deliveryPayload)
 
     expect(fetch).toHaveBeenCalledWith('/test', {
       method: 'POST',
       keepalive: false,
-      body: JSON.stringify(deliveryPayload),
+      body: JSON.stringify({ resourceSpans: [] }),
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1.0:0',
@@ -186,9 +215,17 @@ describe('Browser Delivery', () => {
     const backgroundingListener = new ControllableBackgroundingListener()
 
     const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
-    const delivery = deliveryFactory('test-api-key', '/test')
+    const delivery = deliveryFactory('/test')
+    const payload: TracePayload = {
+      body: { resourceSpans: [] },
+      headers: {
+        'Bugsnag-Api-Key': 'test-api-key',
+        'Content-Type': 'application/json',
+        'Bugsnag-Span-Sampling': '1.0:0'
+      }
+    }
 
-    const response = await delivery.send({ resourceSpans: [] })
+    const response = await delivery.send(payload)
 
     expect(response).toStrictEqual({
       state: 'success',

--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -1,5 +1,6 @@
 import {
   type SpanEnded,
+  type SpanProbability,
   type ScaledProbability,
   SpanAttributes,
   traceIdToSamplingRate,
@@ -7,8 +8,15 @@ import {
 } from '@bugsnag/core-performance'
 import { randomBytes } from 'crypto'
 
+export function createSamplingProbability (rawProbability: number): SpanProbability {
+  return {
+    raw: rawProbability,
+    scaled: Math.floor(rawProbability * 0xffffffff) as ScaledProbability
+  }
+}
+
 export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded {
-  const traceId = randomBytes(16).toString()
+  const traceId = overrides.traceId || randomBytes(16).toString('hex')
 
   return {
     attributes: new SpanAttributes(new Map()),
@@ -20,10 +28,7 @@ export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded 
     traceId,
     samplingRate: traceIdToSamplingRate(traceId),
     endTime: 23456,
-    samplingProbability: {
-      raw: 0.5,
-      scaled: Math.floor(0.5 * 0xffffffff) as ScaledProbability
-    },
+    samplingProbability: createSamplingProbability(0.5),
     ...overrides
   }
 }

--- a/packages/test-utilities/lib/in-memory-delivery.ts
+++ b/packages/test-utilities/lib/in-memory-delivery.ts
@@ -1,4 +1,9 @@
-import { type DeliveryPayload, type Delivery, type ResponseState } from '@bugsnag/core-performance'
+import {
+  type DeliveryPayload,
+  type Delivery,
+  type ResponseState,
+  type TracePayload
+} from '@bugsnag/core-performance'
 
 class InMemoryDelivery implements Delivery {
   public requests: DeliveryPayload[] = []
@@ -7,11 +12,11 @@ class InMemoryDelivery implements Delivery {
   private readonly responseStateStack: ResponseState[] = []
   private readonly samplingProbabilityStack: Array<number | undefined> = []
 
-  send (payload: DeliveryPayload) {
-    if (payload.resourceSpans.length === 0) {
-      this.samplingRequests.push(payload)
+  send (payload: TracePayload) {
+    if (payload.body.resourceSpans.length === 0) {
+      this.samplingRequests.push(payload.body)
     } else {
-      this.requests.push(payload)
+      this.requests.push(payload.body)
     }
 
     const state = this.responseStateStack.pop() || 'success' as ResponseState

--- a/test/browser/features/manual-spans.feature
+++ b/test/browser/features/manual-spans.feature
@@ -8,7 +8,7 @@ Feature: Manual creation of spans
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-    And the trace "Bugsnag-Span-Sampling" header equals "1.0:1"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:1"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
@@ -28,7 +28,7 @@ Feature: Manual creation of spans
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-    And the trace "Bugsnag-Span-Sampling" header equals "1.0:1"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:1"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Custom/ManualSpanScenario"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"


### PR DESCRIPTION
## Goal

Correctly report the `Bugsnag-Span-Sampling` header

This required a lot of changes as the current delivery system didn't have enough information to calculate the header

TO fix this, I've introduced a new `TracePayload` type that contains both a `body` and `headers`:

```ts
interface TracePayload {
  body: DeliveryPayload
  headers: {
    'Bugsnag-Api-Key': string
    'Content-Type': 'application/json'
    'Bugsnag-Span-Sampling': string
    // we don't add 'Bugsnag-Sent-At' in the TracePayloadEncoder so that retried
    // payloads get a new value each time delivery is attempted
    // therefore it's 'undefined' when passed to delivery, which adds a value
    // immediately before initiating the request
    'Bugsnag-Sent-At'?: string
  }
}
```

This is created by a new `TracePayloadEncoder`, which takes an array of `SpanEnded` and returns a `TracePayload`

The `BatchProcessor` then uses the `TracePayloadEncoder` to construct the payload before passing it to the delivery system

I originally intended for delivery to do the payload encoding, but this causes a lot of issues (mainly in our tests):

- many of our tests rely on asserting against delivery payloads
- the `TracePayloadEncoder` requires a configuration, clock & resource attribute source to construct the payload. Adding this to every place we use `InMemoryDelivery` is very awkward
- it's arguably better for encoding to be done in core before being passed to delivery; otherwise every platform's delivery needs to repeat the encoding step