### PR TITLE
[PLAT-10511] Remove networkInstrumentationIgnoreUrls option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (browser) Only add `http.flavor` span attribute when it is a useful value [#255](https://github.com/bugsnag/bugsnag-js-performance/pull/255)
 
+### Removed
+
+- (browser) Remove the `networkInstrumentationIgnoreUrls` config option [#261](https://github.com/bugsnag/bugsnag-js-performance/pull/261)
+
 ## v0.2.0 (2023-07-10)
 
 ### Added

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -8,7 +8,7 @@ import { type SpanFactory, type Plugin, type InternalConfiguration } from '@bugs
 import { type BrowserConfiguration } from '../config'
 
 export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
-  private ignoredUrls: RegExp[] = []
+  private configEndpoint: string = ''
 
   constructor (
     private spanFactory: SpanFactory,
@@ -18,7 +18,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
 
   configure (configuration: InternalConfiguration<BrowserConfiguration>) {
     if (configuration.autoInstrumentNetworkRequests) {
-      this.ignoredUrls = [RegExp(configuration.endpoint)]
+      this.configEndpoint = configuration.endpoint
       this.xhrTracker.onStart(this.trackRequest)
       this.fetchTracker.onStart(this.trackRequest)
     }
@@ -45,6 +45,6 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   }
 
   private shouldTrackRequest (startContext: RequestStartContext): boolean {
-    return !this.ignoredUrls.some(url => url.test(startContext.url))
+    return !startContext.url.includes(this.configEndpoint)
   }
 }

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -18,10 +18,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
 
   configure (configuration: InternalConfiguration<BrowserConfiguration>) {
     if (configuration.autoInstrumentNetworkRequests) {
-      this.ignoredUrls = configuration.networkInstrumentationIgnoreUrls.map(
-        (url: string | RegExp): RegExp => typeof url === 'string' ? RegExp(url) : url
-      ).concat(RegExp(configuration.endpoint))
-
+      this.ignoredUrls = [RegExp(configuration.endpoint)]
       this.xhrTracker.onStart(this.trackRequest)
       this.fetchTracker.onStart(this.trackRequest)
     }

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -45,6 +45,6 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   }
 
   private shouldTrackRequest (startContext: RequestStartContext): boolean {
-    return !startContext.url.includes(this.configEndpoint)
+    return startContext.url !== this.configEndpoint
   }
 }

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -15,7 +15,6 @@ export interface BrowserSchema extends CoreSchema {
   generateAnonymousId: ConfigOption<boolean>
   routingProvider: ConfigOption<RoutingProvider>
   settleIgnoreUrls: ConfigOption<Array<string | RegExp>>
-  networkInstrumentationIgnoreUrls: ConfigOption<Array<string | RegExp>>
 }
 
 export interface BrowserConfiguration extends Configuration {
@@ -25,7 +24,6 @@ export interface BrowserConfiguration extends Configuration {
   generateAnonymousId?: boolean
   routingProvider?: RoutingProvider
   settleIgnoreUrls?: Array<string | RegExp>
-  networkInstrumentationIgnoreUrls?: Array<string | RegExp>
 }
 
 export function createSchema (hostname: string, defaultRoutingProvider: RoutingProvider): BrowserSchema {
@@ -61,11 +59,6 @@ export function createSchema (hostname: string, defaultRoutingProvider: RoutingP
       validate: isRoutingProvider
     },
     settleIgnoreUrls: {
-      defaultValue: [],
-      message: 'should be an array of string|RegExp',
-      validate: isStringOrRegExpArray
-    },
-    networkInstrumentationIgnoreUrls: {
       defaultValue: [],
       message: 'should be an array of string|RegExp',
       validate: isStringOrRegExpArray

--- a/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -103,48 +103,6 @@ describe('network span plugin', () => {
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
   })
 
-  it('does not track requests to an ignored url (string)', () => {
-    const plugin = new NetworkRequestPlugin(spanFactory, fetchTracker, xhrTracker)
-
-    plugin.configure(createConfiguration<BrowserConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
-      networkInstrumentationIgnoreUrls: [TEST_URL]
-    }))
-
-    fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).not.toHaveBeenCalled()
-  })
-
-  it('does not track requests to an ignored url (regex)', () => {
-    const plugin = new NetworkRequestPlugin(spanFactory, fetchTracker, xhrTracker)
-
-    const urlsToIgnore = [
-      // exactly 'https://www.bugsnag.com'
-      /^https:\/\/www\.bugsnag\.com$/,
-      // 'http://www.bugsnag.com' anywhere in the URL
-      /http:\/\/www\.bugsnag\.com/
-    ]
-
-    plugin.configure(createConfiguration<BrowserConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
-      networkInstrumentationIgnoreUrls: urlsToIgnore
-    }))
-
-    // matches the first URL to exclude
-    fetchTracker.start({ method: 'GET', url: 'https://www.bugsnag.com', startTime: 1 })
-    expect(spanFactory.startSpan).not.toHaveBeenCalled()
-
-    // matches the second URL to exclude
-    fetchTracker.start({ method: 'GET', url: 'http://example.com/a/b/c?x=http://www.bugsnag.com', startTime: 1 })
-    expect(spanFactory.startSpan).not.toHaveBeenCalled()
-
-    // does not match the URLs to exclude
-    fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
-  })
-
   it('discards the span if the status is 0', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, fetchTracker, xhrTracker)
 

--- a/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -99,7 +99,7 @@ describe('network span plugin', () => {
       autoInstrumentNetworkRequests: true
     }))
 
-    fetchTracker.start({ method: 'GET', url: `${ENDPOINT}/traces`, startTime: 1 })
+    fetchTracker.start({ method: 'GET', url: ENDPOINT, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
   })
 

--- a/packages/test-utilities/lib/create-configuration.ts
+++ b/packages/test-utilities/lib/create-configuration.ts
@@ -19,7 +19,6 @@ function createConfiguration<C extends Configuration> (overrides: Partial<C> = {
       error: jest.fn()
     },
     appVersion: '',
-    networkInstrumentationIgnoreUrls: [],
     ...overrides
   } as unknown as InternalConfiguration<C>
 }


### PR DESCRIPTION
## Goal

To remove an option that will be covered by new functionality in the network span controls callback.