### PR TITLE
[PLAT-10601] Add networkRequestCallback config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
+
 ### Fixed
 
 - (browser) Calculate time origin on create as well as visibility change [#268](https://github.com/bugsnag/bugsnag-js-performance/pull/268)
 
 ## v0.3.0 (2023-07-17)
-
-### Added
-
-- (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## v0.3.0 (2023-07-17)
 
+### Added
+
+- (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
+
 ### Fixed
 
 - (core) Use platform clock to set the `Bugsnag-Sent-At` header [#265](https://github.com/bugsnag/bugsnag-js-performance/pull/265)

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -16,7 +16,6 @@ export interface BrowserSchema extends CoreSchema {
   generateAnonymousId: ConfigOption<boolean>
   routingProvider: ConfigOption<RoutingProvider>
   settleIgnoreUrls: ConfigOption<Array<string | RegExp>>
-  networkInstrumentationIgnoreUrls: ConfigOption<Array<string | RegExp>>
   networkRequestCallback: ConfigOption<NetworkRequestCallback>
 }
 
@@ -27,7 +26,6 @@ export interface BrowserConfiguration extends Configuration {
   generateAnonymousId?: boolean
   routingProvider?: RoutingProvider
   settleIgnoreUrls?: Array<string | RegExp>
-  networkInstrumentationIgnoreUrls?: Array<string | RegExp>
   networkRequestCallback?: NetworkRequestCallback
 }
 
@@ -64,11 +62,6 @@ export function createSchema (hostname: string, defaultRoutingProvider: RoutingP
       validate: isRoutingProvider
     },
     settleIgnoreUrls: {
-      defaultValue: [],
-      message: 'should be an array of string|RegExp',
-      validate: isStringOrRegExpArray
-    },
-    networkInstrumentationIgnoreUrls: {
       defaultValue: [],
       message: 'should be an array of string|RegExp',
       validate: isStringOrRegExpArray

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -1,11 +1,12 @@
 import {
-  isStringOrRegExpArray,
   isBoolean,
+  isStringOrRegExpArray,
   schema,
   type ConfigOption,
   type Configuration,
   type CoreSchema
 } from '@bugsnag/core-performance'
+import { defaultNetworkRequestCallback, isNetworkRequestCallback, type NetworkRequestCallback } from './network-request-callback'
 import { isRoutingProvider, type RoutingProvider } from './routing-provider'
 
 export interface BrowserSchema extends CoreSchema {
@@ -15,6 +16,8 @@ export interface BrowserSchema extends CoreSchema {
   generateAnonymousId: ConfigOption<boolean>
   routingProvider: ConfigOption<RoutingProvider>
   settleIgnoreUrls: ConfigOption<Array<string | RegExp>>
+  networkInstrumentationIgnoreUrls: ConfigOption<Array<string | RegExp>>
+  networkRequestCallback: ConfigOption<NetworkRequestCallback>
 }
 
 export interface BrowserConfiguration extends Configuration {
@@ -24,6 +27,8 @@ export interface BrowserConfiguration extends Configuration {
   generateAnonymousId?: boolean
   routingProvider?: RoutingProvider
   settleIgnoreUrls?: Array<string | RegExp>
+  networkInstrumentationIgnoreUrls?: Array<string | RegExp>
+  networkRequestCallback?: NetworkRequestCallback
 }
 
 export function createSchema (hostname: string, defaultRoutingProvider: RoutingProvider): BrowserSchema {
@@ -62,6 +67,16 @@ export function createSchema (hostname: string, defaultRoutingProvider: RoutingP
       defaultValue: [],
       message: 'should be an array of string|RegExp',
       validate: isStringOrRegExpArray
+    },
+    networkInstrumentationIgnoreUrls: {
+      defaultValue: [],
+      message: 'should be an array of string|RegExp',
+      validate: isStringOrRegExpArray
+    },
+    networkRequestCallback: {
+      defaultValue: defaultNetworkRequestCallback,
+      message: 'should be a function',
+      validate: isNetworkRequestCallback
     }
   }
 }

--- a/packages/platforms/browser/lib/network-request-callback.ts
+++ b/packages/platforms/browser/lib/network-request-callback.ts
@@ -1,0 +1,14 @@
+export interface NetworkRequestInfo {
+  url: string
+  readonly type: string
+}
+
+export type NetworkRequestCallback = (networkRequestInfo: NetworkRequestInfo) => NetworkRequestInfo | null
+
+export function defaultNetworkRequestCallback (networkRequestInfo: NetworkRequestInfo) {
+  return networkRequestInfo
+}
+
+export function isNetworkRequestCallback (value: unknown): value is NetworkRequestCallback {
+  return typeof value === 'function'
+}

--- a/packages/platforms/browser/tests/network-request-callback.test.ts
+++ b/packages/platforms/browser/tests/network-request-callback.test.ts
@@ -1,0 +1,41 @@
+import { defaultNetworkRequestCallback, isNetworkRequestCallback } from '../lib/network-request-callback'
+
+describe('defaultNetworkRequestCallback', () => {
+  it('returns an unmodified networkRequestInfo object', () => {
+    const networkRequestInfo = {
+      url: 'https://bugsnag.com/unit-test',
+      type: 'fetch'
+    }
+
+    const response = defaultNetworkRequestCallback(networkRequestInfo)
+
+    expect(response.url).toBe('https://bugsnag.com/unit-test')
+    expect(response.type).toBe('fetch')
+    expect(response).toBe(networkRequestInfo)
+  })
+})
+
+describe('isNetworkRequestCallback', () => {
+  it('returns true for the defaultNetworkRequestCallback', () => {
+    const isValid = isNetworkRequestCallback(defaultNetworkRequestCallback)
+    expect(isValid).toBe(true)
+  })
+
+  const invalidCallbacks = [
+    { type: 'array', callback: [] },
+    // eslint-disable-next-line compat/compat
+    { type: 'bigint', callback: BigInt(9007199254740991) },
+    { type: 'boolean', callback: true },
+    { type: 'number', callback: 1234 },
+    { type: 'null', callback: null },
+    { type: 'object', callback: { foo: 'bar' } },
+    { type: 'string', callback: 'string' },
+    { type: 'symbol', callback: Symbol('unique symbol') },
+    { type: 'undefined', callback: undefined }
+  ]
+
+  it.each(invalidCallbacks)('returns false for invalid callback ($type)', ({ callback }) => {
+    const isValid = isNetworkRequestCallback(callback)
+    expect(isValid).toBe(false)
+  })
+})


### PR DESCRIPTION
## Goal

Add a new configuration option to modify the url of network spans return null (can be used by the network span and resource load span plugins to prevent span creation)

## Testing

Added unit tests for `defaultNetworkRequestCallback` and `isNetworkRequestCallback` validation function