### PR TITLE
[PLAT-10604] Implement networkRequestCallback in Network Span Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
 
-## v0.3.0 (2023-07-17)
-
 ### Fixed
 
 - (browser) Calculate time origin on create as well as visibility change [#268](https://github.com/bugsnag/bugsnag-js-performance/pull/268)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
 
+## v0.3.0 (2023-07-17)
+
 ### Fixed
 
 - (browser) Calculate time origin on create as well as visibility change [#268](https://github.com/bugsnag/bugsnag-js-performance/pull/268)

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -35,7 +35,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
 
     const networkRequestInfo = this.networkRequestCallback({ url: startContext.url, type: startContext.type })
 
-    if (networkRequestInfo === null) return
+    if (!networkRequestInfo) return
 
     if (typeof networkRequestInfo.url !== 'string') {
       this.logger.warn(`expected url to be a string following network request callback, got ${typeof networkRequestInfo.url}`)

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -30,7 +30,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   private trackRequest = (startContext: RequestStartContext): RequestEndCallback | undefined => {
     if (!this.shouldTrackRequest(startContext)) return
 
-    const networkRequestInfo = this.networkRequestCallback({ url: startContext.url, type: startContext.method })
+    const networkRequestInfo = this.networkRequestCallback({ url: startContext.url, type: startContext.type })
 
     if (!networkRequestInfo) return
 

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -45,7 +45,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
     if (typeof networkRequestInfo.url === 'string') {
       span.setAttribute('http.url', networkRequestInfo.url)
     } else {
-      this.logger.warn(`expected url to be a string, got ${typeof networkRequestInfo.url}, http.url attribute discarded.`)
+      this.logger.warn(`expected url to be a string following network request callback, got ${typeof networkRequestInfo.url}, http.url attribute discarded.`)
     }
 
     span.setAttribute('bugsnag.span.category', 'network')

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -35,21 +35,21 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
 
     const networkRequestInfo = this.networkRequestCallback({ url: startContext.url, type: startContext.type })
 
-    if (!networkRequestInfo) return
+    if (networkRequestInfo === null) return
+
+    if (typeof networkRequestInfo.url !== 'string') {
+      this.logger.warn(`expected url to be a string following network request callback, got ${typeof networkRequestInfo.url}`)
+      return
+    }
 
     const span = this.spanFactory.startSpan(
       `[HTTP]/${startContext.method.toUpperCase()}`,
       { startTime: startContext.startTime, makeCurrentContext: false }
     )
 
-    if (typeof networkRequestInfo.url === 'string') {
-      span.setAttribute('http.url', networkRequestInfo.url)
-    } else {
-      this.logger.warn(`expected url to be a string following network request callback, got ${typeof networkRequestInfo.url}, http.url attribute discarded.`)
-    }
-
     span.setAttribute('bugsnag.span.category', 'network')
     span.setAttribute('http.method', startContext.method)
+    span.setAttribute('http.url', networkRequestInfo.url)
 
     return (endContext: RequestEndContext) => {
       if (endContext.state === 'success') {

--- a/packages/platforms/browser/lib/network-request-callback.ts
+++ b/packages/platforms/browser/lib/network-request-callback.ts
@@ -1,6 +1,6 @@
 export interface NetworkRequestInfo {
   url: string
-  readonly type: string
+  readonly type: 'fetch' | 'xmlhttprequest'
 }
 
 export type NetworkRequestCallback = (networkRequestInfo: NetworkRequestInfo) => NetworkRequestInfo | null

--- a/packages/platforms/browser/lib/network-request-callback.ts
+++ b/packages/platforms/browser/lib/network-request-callback.ts
@@ -1,6 +1,6 @@
 export interface NetworkRequestInfo {
   url: string
-  readonly type: 'fetch' | 'xmlhttprequest'
+  readonly type: PerformanceResourceTiming['initiatorType']
 }
 
 export type NetworkRequestCallback = (networkRequestInfo: NetworkRequestInfo) => NetworkRequestInfo | null

--- a/packages/platforms/browser/lib/request-tracker/request-tracker-fetch.ts
+++ b/packages/platforms/browser/lib/request-tracker/request-tracker-fetch.ts
@@ -11,7 +11,7 @@ function createStartContext (baseUrl: string, startTime: number, input: unknown,
   const inputIsRequest = isRequest(input)
   const url = inputIsRequest ? input.url : String(input)
   const method = (!!init && (init as RequestInit).method) || (inputIsRequest && input.method) || 'GET'
-  return { url: getAbsoluteUrl(url, baseUrl), method, startTime }
+  return { url: getAbsoluteUrl(url, baseUrl), method, startTime, type: 'fetch' }
 }
 
 function isRequest (input: unknown): input is Request {

--- a/packages/platforms/browser/lib/request-tracker/request-tracker-xhr.ts
+++ b/packages/platforms/browser/lib/request-tracker/request-tracker-xhr.ts
@@ -37,6 +37,7 @@ function createXmlHttpRequestTracker (window: WindowWithXmlHttpRequest, clock: C
       if (existingHandler) this.removeEventListener('readystatechange', existingHandler)
 
       const onRequestEnd: RequestEndCallback = requestTracker.start({
+        type: 'xmlhttprequest',
         method: requestData.method,
         url: requestData.url,
         startTime: clock.now()

--- a/packages/platforms/browser/lib/request-tracker/request-tracker.ts
+++ b/packages/platforms/browser/lib/request-tracker/request-tracker.ts
@@ -2,6 +2,7 @@ export interface RequestStartContext {
   url: string
   method: string
   startTime: number
+  type: 'fetch' | 'xmlhttprequest'
 }
 
 export interface RequestEndContextSuccess {

--- a/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -46,10 +46,10 @@ describe('network span plugin', () => {
       autoInstrumentNetworkRequests: true
     }))
 
-    fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
+    fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
 
-    xhrTracker.start({ method: 'POST', url: TEST_URL, startTime: 2 })
+    xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: TEST_URL, startTime: 2 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
   })
 
@@ -61,7 +61,7 @@ describe('network span plugin', () => {
       autoInstrumentNetworkRequests: true
     }))
 
-    const endRequest = fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
+    const endRequest = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
 
@@ -99,7 +99,7 @@ describe('network span plugin', () => {
       autoInstrumentNetworkRequests: true
     }))
 
-    fetchTracker.start({ method: 'GET', url: ENDPOINT, startTime: 1 })
+    fetchTracker.start({ type: 'fetch', method: 'GET', url: `${ENDPOINT}`, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
   })
 
@@ -111,7 +111,7 @@ describe('network span plugin', () => {
       autoInstrumentNetworkRequests: true
     }))
 
-    const endRequest = xhrTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
+    const endRequest = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ endTime: 2, state: 'error' })
@@ -126,7 +126,7 @@ describe('network span plugin', () => {
       autoInstrumentNetworkRequests: true
     }))
 
-    const endRequest = fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
+    const endRequest = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ state: 'error', error: new Error('woopsy'), endTime: 2 })
@@ -137,8 +137,8 @@ describe('network span plugin', () => {
     const client = createTestClient({ plugins: (spanFactory) => [new NetworkRequestPlugin(spanFactory, fetchTracker, xhrTracker)] })
     const rootSpan = client.startSpan('root span')
 
-    fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
-    xhrTracker.start({ method: 'POST', url: TEST_URL, startTime: 2 })
+    fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
+    xhrTracker.start({ type: 'fetch', method: 'POST', url: TEST_URL, startTime: 2 })
 
     expect(spanContextEquals(rootSpan, client.currentSpanContext)).toBe(true)
   })
@@ -151,10 +151,10 @@ describe('network span plugin', () => {
       networkRequestCallback: (networkRequestInfo) => networkRequestInfo.url === 'no-delivery' ? null : networkRequestInfo
     }))
 
-    fetchTracker.start({ method: 'GET', url: 'no-delivery', startTime: 1 })
+    fetchTracker.start({ type: 'fetch', method: 'GET', url: 'no-delivery', startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
 
-    fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
+    fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
   })
 
@@ -169,7 +169,7 @@ describe('network span plugin', () => {
       })
     }))
 
-    const endRequest = fetchTracker.start({ method: 'GET', url: TEST_URL, startTime: 1 })
+    const endRequest = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ status: 200, endTime: 2, state: 'success' })

--- a/packages/platforms/browser/tests/network-request-callback.test.ts
+++ b/packages/platforms/browser/tests/network-request-callback.test.ts
@@ -5,7 +5,7 @@ describe('defaultNetworkRequestCallback', () => {
     const networkRequestInfo = {
       url: 'https://bugsnag.com/unit-test',
       type: 'fetch'
-    }
+    } as const
 
     const response = defaultNetworkRequestCallback(networkRequestInfo)
 

--- a/packages/platforms/browser/tests/on-settle/index.test.ts
+++ b/packages/platforms/browser/tests/on-settle/index.test.ts
@@ -21,6 +21,7 @@ import {
 import MockRoutingProvider from '../utilities/mock-routing-provider'
 
 const START_CONTEXT: RequestStartContext = {
+  type: 'fetch',
   url: 'https://www.bugsnag.com',
   method: 'GET',
   startTime: 1234

--- a/packages/platforms/browser/tests/on-settle/request-settler.test.ts
+++ b/packages/platforms/browser/tests/on-settle/request-settler.test.ts
@@ -12,6 +12,7 @@ import createClock from '../../lib/clock'
 import { ControllableBackgroundingListener, IncrementingClock } from '@bugsnag/js-performance-test-utilities'
 
 const START_CONTEXT: RequestStartContext = {
+  type: 'fetch',
   url: 'https://www.bugsnag.com',
   method: 'GET',
   startTime: 1234

--- a/packages/platforms/browser/tests/request-tracker/request-tracker-fetch.test.ts
+++ b/packages/platforms/browser/tests/request-tracker/request-tracker-fetch.test.ts
@@ -43,6 +43,7 @@ describe('fetch Request Tracker', () => {
     expect(response.status).toEqual(status)
 
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method,
       startTime: 1
@@ -61,6 +62,7 @@ describe('fetch Request Tracker', () => {
 
     await expect(window.fetch(TEST_URL)).rejects.toEqual(new Error('Fail'))
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method: 'GET',
       startTime: 1
@@ -82,6 +84,7 @@ describe('fetch Request Tracker', () => {
     expect(response.status).toEqual(200)
 
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method: 'GET',
       startTime: 1
@@ -102,6 +105,7 @@ describe('fetch Request Tracker', () => {
     expect(response.status).toEqual(200)
 
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method: 'GET',
       startTime: 1
@@ -122,6 +126,7 @@ describe('fetch Request Tracker', () => {
     expect(response.status).toEqual(200)
 
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method: 'POST',
       startTime: 1
@@ -142,6 +147,7 @@ describe('fetch Request Tracker', () => {
     expect(response.status).toEqual(200)
 
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method: 'POST',
       startTime: 1
@@ -162,6 +168,7 @@ describe('fetch Request Tracker', () => {
     expect(response.status).toEqual(200)
 
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: `${window.location.origin}/test`,
       method: 'GET',
       startTime: 1
@@ -180,6 +187,7 @@ describe('fetch Request Tracker', () => {
 
     await expect(window.fetch(undefined as unknown as string)).rejects.toEqual(new Error('Fail'))
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: `${window.location.origin}/undefined`,
       method: 'GET',
       startTime: 1
@@ -200,6 +208,7 @@ describe('fetch Request Tracker', () => {
 
     await expect(window.fetch(null as unknown as RequestInfo)).rejects.toEqual(new Error('Fail'))
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: `${window.location.origin}/null`,
       method: 'GET',
       startTime: 1
@@ -221,6 +230,7 @@ describe('fetch Request Tracker', () => {
     const response = await window.fetch(TEST_URL, null as unknown as RequestInit)
     expect(response.status).toEqual(200)
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method: 'GET',
       startTime: 1
@@ -241,6 +251,7 @@ describe('fetch Request Tracker', () => {
     expect(response.status).toEqual(200)
 
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'fetch',
       url: TEST_URL,
       method: 'GET',
       startTime: 1

--- a/packages/platforms/browser/tests/request-tracker/request-tracker-xhr.test.ts
+++ b/packages/platforms/browser/tests/request-tracker/request-tracker-xhr.test.ts
@@ -77,6 +77,7 @@ describe('XHR Request Tracker', () => {
     expect(window.XMLHttpRequest.prototype.addEventListener).toHaveBeenCalled()
     expect(originalSend).toHaveBeenCalled()
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'xmlhttprequest',
       url: TEST_URL,
       method,
       startTime: 1
@@ -101,6 +102,7 @@ describe('XHR Request Tracker', () => {
 
     request.send()
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'xmlhttprequest',
       url: `${window.location.origin}/test`,
       method: 'GET',
       startTime: 1
@@ -125,6 +127,7 @@ describe('XHR Request Tracker', () => {
 
     request.send()
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'xmlhttprequest',
       url: TEST_URL,
       method: 'GET',
       startTime: 1
@@ -151,6 +154,7 @@ describe('XHR Request Tracker', () => {
 
     request.send()
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'xmlhttprequest',
       url: TEST_URL,
       method: 'GET',
       startTime: 1
@@ -180,6 +184,7 @@ describe('XHR Request Tracker', () => {
 
     expect(startCallback).toHaveBeenCalledTimes(1)
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'xmlhttprequest',
       url: differentUrl,
       method: 'POST',
       startTime: 1
@@ -208,6 +213,7 @@ describe('XHR Request Tracker', () => {
 
     expect(window.XMLHttpRequest.prototype.addEventListener).toHaveBeenCalledTimes(1)
     expect(startCallback).toHaveBeenCalledWith({
+      type: 'xmlhttprequest',
       url: TEST_URL,
       method: 'GET',
       startTime: 1
@@ -229,6 +235,7 @@ describe('XHR Request Tracker', () => {
     expect(endCallback).toHaveBeenCalledTimes(2)
 
     expect(startCallback).toHaveBeenLastCalledWith({
+      type: 'xmlhttprequest',
       url: differentUrl,
       method: 'POST',
       startTime: 3

--- a/packages/platforms/browser/tests/request-tracker/request-tracker.test.ts
+++ b/packages/platforms/browser/tests/request-tracker/request-tracker.test.ts
@@ -9,7 +9,7 @@ describe('Request Tracker', () => {
     requestTracker.onStart(startCallback)
     expect(startCallback).not.toHaveBeenCalled()
 
-    const context = { url: '/', method: 'GET', startTime: 1 }
+    const context = { type: 'fetch', url: '/', method: 'GET', startTime: 1 } as const
     requestTracker.start(context)
     expect(startCallback).toHaveBeenCalledWith(context)
   })
@@ -22,7 +22,7 @@ describe('Request Tracker', () => {
     requestTracker.onStart(startCallback)
     expect(startCallback).not.toHaveBeenCalled()
 
-    const startContext = { url: '/', method: 'GET', startTime: 1 }
+    const startContext = { type: 'fetch', url: '/', method: 'GET', startTime: 1 } as const
     const onEnd = requestTracker.start(startContext)
     expect(startCallback).toHaveBeenCalledWith(startContext)
     expect(endCallback).not.toHaveBeenCalled()
@@ -43,7 +43,7 @@ describe('Request Tracker', () => {
     expect(acceptCallback).not.toHaveBeenCalled()
     expect(rejectCallback).not.toHaveBeenCalled()
 
-    const startContext = { url: '/', method: 'GET', startTime: 1 }
+    const startContext = { type: 'fetch', url: '/', method: 'GET', startTime: 1 } as const
     const onEnd = requestTracker.start(startContext)
     expect(acceptCallback).toHaveBeenCalledWith(startContext)
     expect(rejectCallback).toHaveBeenCalledWith(startContext)

--- a/packages/test-utilities/lib/create-configuration.ts
+++ b/packages/test-utilities/lib/create-configuration.ts
@@ -19,6 +19,7 @@ function createConfiguration<C extends Configuration> (overrides: Partial<C> = {
       error: jest.fn()
     },
     appVersion: '',
+    networkRequestCallback: (networkRequestInfo: unknown) => networkRequestInfo,
     ...overrides
   } as unknown as InternalConfiguration<C>
 }


### PR DESCRIPTION
## Goal

use the `networkRequestCallback` plugin in the `network-span-plugin` in order to use the modified url or prevent creation of spans.

## Testing

Unit tests to ensure modified URLs are used by `network-span-plugin`
Unit tests to ensure spans are not created when `networkRequestCallback` returns `null`