### PR TITLE
Use `Clock` to set the `Bugsnag-Sent-At` header

### DIFF
--- a/packages/core/lib/clock.ts
+++ b/packages/core/lib/clock.ts
@@ -10,6 +10,10 @@ export interface Clock {
   // or any other number, so long as it is consistent to the platform
   now: () => number
 
+  // returns a Date object representing the current time using the same time
+  // source as 'now'
+  date: () => Date
+
   // a function to convert a Date object into the format returned by 'now'
   convert: (date: Date) => number
 

--- a/packages/core/tests/time.test.ts
+++ b/packages/core/tests/time.test.ts
@@ -9,16 +9,16 @@ describe('timeToNumber', () => {
   })
 
   it('accepts a real number', () => {
-    const clock = { now: jest.fn(() => 1), convert: jest.fn(), toUnixTimestampNanoseconds: jest.fn() }
+    const clock = new IncrementingClock()
     const number = timeToNumber(clock, 1234)
-    expect(clock.now).not.toHaveBeenCalled()
+
     expect(number).toBe(1234)
   })
 
   it.each([NaN, Infinity, -Infinity])('ignores %s and uses clock.now()', (time) => {
-    const clock = { now: jest.fn(() => 1), convert: jest.fn(), toUnixTimestampNanoseconds: jest.fn() }
+    const clock = new IncrementingClock()
     const number = timeToNumber(clock, time)
-    expect(clock.now).toHaveBeenCalled()
+
     expect(number).toBe(1)
   })
 })

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -36,7 +36,7 @@ const BugsnagPerformance = createClient({
   clock,
   resourceAttributesSource,
   spanAttributesSource,
-  deliveryFactory: createBrowserDeliveryFactory(window.fetch, backgroundingListener),
+  deliveryFactory: createBrowserDeliveryFactory(window.fetch, backgroundingListener, clock),
   idGenerator,
   schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
   plugins: (spanFactory, spanContextStorage) => [

--- a/packages/platforms/browser/lib/clock.ts
+++ b/packages/platforms/browser/lib/clock.ts
@@ -35,6 +35,7 @@ function createClock (performance: PerformanceWithOptionalTimeOrigin, background
 
   return {
     now: () => performance.now(),
+    date: () => new Date(calculatedTimeOrigin + performance.now()),
     convert: (date) => date.getTime() - calculatedTimeOrigin,
     // convert milliseconds since timeOrigin to full timestamp
     toUnixTimestampNanoseconds: (time: number) => millisecondsToNanoseconds(calculatedTimeOrigin + time).toString()

--- a/packages/platforms/browser/lib/delivery.ts
+++ b/packages/platforms/browser/lib/delivery.ts
@@ -1,5 +1,6 @@
 import {
   type BackgroundingListener,
+  type Clock,
   type Delivery,
   type DeliveryFactory,
   type TracePayload,
@@ -24,7 +25,11 @@ function samplingProbabilityFromHeaders (headers: Headers): number | undefined {
   return asNumber
 }
 
-function createBrowserDeliveryFactory (fetch: Fetch, backgroundingListener: BackgroundingListener): DeliveryFactory {
+function createBrowserDeliveryFactory (
+  fetch: Fetch,
+  backgroundingListener: BackgroundingListener,
+  clock: Clock
+): DeliveryFactory {
   // we set fetch's 'keepalive' flag if the app is backgrounded/terminated so
   // that we can flush the last batch - without 'keepalive' the browser can
   // cancel (or never start sending) this request
@@ -38,7 +43,7 @@ function createBrowserDeliveryFactory (fetch: Fetch, backgroundingListener: Back
   return function browserDeliveryFactory (endpoint: string): Delivery {
     return {
       async send (payload: TracePayload) {
-        payload.headers['Bugsnag-Sent-At'] = (new Date()).toISOString()
+        payload.headers['Bugsnag-Sent-At'] = clock.date().toISOString()
 
         try {
           const response = await fetch(endpoint, {

--- a/packages/platforms/browser/tests/clock.test.ts
+++ b/packages/platforms/browser/tests/clock.test.ts
@@ -33,6 +33,36 @@ describe('Browser Clock', () => {
     })
   })
 
+  describe('clock.date()', () => {
+    it('returns a Date', async () => {
+      const timeOrigin = new Date('2023-01-02T00:00:00.000Z')
+      jest.setSystemTime(timeOrigin)
+
+      const clock = createClock(new PerformanceFake(), new ControllableBackgroundingListener())
+
+      await jest.advanceTimersByTimeAsync(100)
+
+      expect(clock.date()).toEqual(new Date(timeOrigin.getTime() + 100))
+    })
+
+    it('returns a greater date on every invocation (100 runs)', async () => {
+      const timeOrigin = new Date('2023-01-02T00:00:00.000Z')
+      jest.setSystemTime(timeOrigin)
+
+      let lastDate = timeOrigin
+      const clock = createClock(new PerformanceFake(), new ControllableBackgroundingListener())
+
+      for (let i = 0; i < 100; i++) {
+        await jest.advanceTimersByTimeAsync(10)
+
+        const newDate = clock.date()
+
+        expect(newDate).toEqual(new Date(lastDate.getTime() + 10))
+        lastDate = newDate
+      }
+    })
+  })
+
   describe('clock.convert()', () => {
     it('converts a Date into a number', () => {
       const clock = createClock(new PerformanceFake(), new ControllableBackgroundingListener())

--- a/packages/platforms/browser/tests/delivery.test.ts
+++ b/packages/platforms/browser/tests/delivery.test.ts
@@ -3,7 +3,10 @@
  */
 
 import { type TracePayload } from '@bugsnag/core-performance'
-import { ControllableBackgroundingListener } from '@bugsnag/js-performance-test-utilities'
+import {
+  ControllableBackgroundingListener,
+  IncrementingClock
+} from '@bugsnag/js-performance-test-utilities'
 import createBrowserDeliveryFactory from '../lib/delivery'
 
 // the format of the Bugsnag-Sent-At header: YYYY-MM-DDTHH:mm:ss.sssZ
@@ -13,6 +16,7 @@ describe('Browser Delivery', () => {
   it('delivers a span', () => {
     const fetch = jest.fn(() => Promise.resolve({} as unknown as Response))
     const backgroundingListener = new ControllableBackgroundingListener()
+    const clock = new IncrementingClock('2023-01-02T00:00:00.000Z')
 
     const deliveryPayload: TracePayload = {
       body: {
@@ -39,7 +43,7 @@ describe('Browser Delivery', () => {
       }
     }
 
-    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener, clock)
     const delivery = deliveryFactory('/test')
     delivery.send(deliveryPayload)
 
@@ -51,7 +55,7 @@ describe('Browser Delivery', () => {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1:1',
         'Content-Type': 'application/json',
-        'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
+        'Bugsnag-Sent-At': new Date(clock.timeOrigin + 1).toISOString()
       }
     })
   })
@@ -85,7 +89,7 @@ describe('Browser Delivery', () => {
       }
     }
 
-    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener, new IncrementingClock())
     const delivery = deliveryFactory('/test')
 
     backgroundingListener.sendToBackground()
@@ -134,7 +138,7 @@ describe('Browser Delivery', () => {
       }
     }
 
-    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener, new IncrementingClock())
     const delivery = deliveryFactory('/test')
 
     backgroundingListener.sendToBackground()
@@ -176,7 +180,7 @@ describe('Browser Delivery', () => {
     const fetch = jest.fn(() => Promise.resolve({ status: 200, headers } as unknown as Response))
     const backgroundingListener = new ControllableBackgroundingListener()
 
-    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener, new IncrementingClock())
     const delivery = deliveryFactory('/test')
     const deliveryPayload: TracePayload = {
       body: { resourceSpans: [] },
@@ -214,7 +218,7 @@ describe('Browser Delivery', () => {
     const fetch = jest.fn(() => Promise.resolve({ status: 200, headers } as unknown as Response))
     const backgroundingListener = new ControllableBackgroundingListener()
 
-    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener)
+    const deliveryFactory = createBrowserDeliveryFactory(fetch, backgroundingListener, new IncrementingClock())
     const delivery = deliveryFactory('/test')
     const payload: TracePayload = {
       body: { resourceSpans: [] },

--- a/packages/test-utilities/lib/incrementing-clock.ts
+++ b/packages/test-utilities/lib/incrementing-clock.ts
@@ -6,8 +6,8 @@ interface ClockOptions {
 }
 
 class IncrementingClock implements Clock {
+  public readonly timeOrigin: number
   private currentTime: number
-  private readonly timeOrigin: number
 
   constructor (options: string | ClockOptions = {}) {
     if (typeof options === 'string') {

--- a/packages/test-utilities/lib/incrementing-clock.ts
+++ b/packages/test-utilities/lib/incrementing-clock.ts
@@ -22,6 +22,10 @@ class IncrementingClock implements Clock {
     return ++this.currentTime
   }
 
+  date () {
+    return new Date(this.timeOrigin + this.now())
+  }
+
   convert (date: Date) {
     return date.getTime() - this.timeOrigin
   }


### PR DESCRIPTION
## Goal

Use `Clock` to set the `Bugsnag-Sent-At` header. This requires a new `Clock#date` function that returns a `Date` object