### PR TITLE
[PLAT-10602] Add `sendPageAttributes` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
+- (browser) Add `sendPageAttributes` configuration option [#266](https://github.com/bugsnag/bugsnag-js-performance/pull/266)
 
 ### Fixed
 

--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -1,9 +1,13 @@
-import { type InternalConfiguration, type Configuration } from './config'
+import { type Configuration, type InternalConfiguration } from './config'
+import { type SpanInternal } from './span'
 import { isNumber } from './validation'
 
 export type SpanAttribute = string | number | boolean
 
-export type SpanAttributesSource = () => Map<string, SpanAttribute>
+export interface SpanAttributesSource <C extends Configuration> {
+  configure: (configuration: InternalConfiguration<C>) => void
+  requestAttributes: (span: SpanInternal) => void
+}
 
 export class SpanAttributes {
   private readonly attributes: Map<string, SpanAttribute>

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -272,6 +272,7 @@ describe('Span', () => {
           }))
         })
       })
+
       describe('parentContext', () => {
         const parentContextOptions: any[] = [
           { type: 'true', parentContext: true },

--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -11,7 +11,7 @@ import { type WebVitals } from '../web-vitals'
 import { instrumentPageLoadPhaseSpans } from './page-load-phase-spans'
 
 export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
-  private readonly spanFactory: SpanFactory
+  private readonly spanFactory: SpanFactory<BrowserConfiguration>
   private readonly document: Document
   private readonly location: Location
   private readonly onSettle: OnSettle
@@ -25,7 +25,7 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
   constructor (
     document: Document,
     location: Location,
-    spanFactory: SpanFactory,
+    spanFactory: SpanFactory<BrowserConfiguration>,
     webVitals: WebVitals,
     onSettle: OnSettle,
     backgroundingListener: BackgroundingListener,

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -14,7 +14,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   private logger: Logger = { debug: console.debug, warn: console.warn, info: console.info, error: console.error }
 
   constructor (
-    private spanFactory: SpanFactory,
+    private spanFactory: SpanFactory<BrowserConfiguration>,
     private fetchTracker: RequestTracker,
     private xhrTracker: RequestTracker
   ) {}

--- a/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
@@ -1,17 +1,17 @@
 import type { SpanContext, SpanFactory } from '@bugsnag/core-performance'
+import { type BrowserConfiguration } from '../config'
 import { type PerformanceWithTiming } from '../on-settle/load-event-end-settler'
 
-type PageLoadPhase
-  = 'Unload'
-  | 'Redirect'
-  | 'LoadFromCache'
-  | 'DNSLookup'
-  | 'TCPHandshake'
-  | 'TLS'
-  | 'HTTPRequest'
-  | 'HTTPResponse'
-  | 'DomContentLoadedEvent'
-  | 'LoadEvent'
+type PageLoadPhase = 'Unload'
+| 'Redirect'
+| 'LoadFromCache'
+| 'DNSLookup'
+| 'TCPHandshake'
+| 'TLS'
+| 'HTTPRequest'
+| 'HTTPResponse'
+| 'DomContentLoadedEvent'
+| 'LoadEvent'
 
 function shouldOmitSpan (startTime?: number, endTime?: number): boolean {
   return (startTime === undefined || endTime === undefined) ||
@@ -19,7 +19,7 @@ function shouldOmitSpan (startTime?: number, endTime?: number): boolean {
 }
 
 export const instrumentPageLoadPhaseSpans = (
-  spanFactory: SpanFactory,
+  spanFactory: SpanFactory<BrowserConfiguration>,
   performance: PerformanceWithTiming,
   route: string,
   parentContext: SpanContext

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -35,7 +35,7 @@ function resourceLoadSupported (PerformanceObserverClass: typeof PerformanceObse
 
 export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
   constructor (
-    private readonly spanFactory: SpanFactory,
+    private readonly spanFactory: SpanFactory<BrowserConfiguration>,
     private readonly spanContextStorage: SpanContextStorage,
     private readonly PerformanceObserverClass: typeof PerformanceObserver
   ) {}

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -22,7 +22,7 @@ interface InternalRouteChangeSpanOptions extends RouteChangeSpanOptions {
 
 export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
   constructor (
-    private readonly spanFactory: SpanFactory,
+    private readonly spanFactory: SpanFactory<BrowserConfiguration>,
     private readonly location: Location,
     private readonly document: Document
   ) {}

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -11,7 +11,7 @@ import makeBrowserPersistence from './persistence'
 import createFetchRequestTracker from './request-tracker/request-tracker-fetch'
 import createXmlHttpRequestTracker from './request-tracker/request-tracker-xhr'
 import createResourceAttributesSource from './resource-attributes-source'
-import spanAttributesSource from './span-attributes-source'
+import createSpanAttributesSource from './span-attributes-source'
 import { WebVitals } from './web-vitals'
 
 const backgroundingListener = createBrowserBackgroundingListener(document)

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -15,6 +15,7 @@ import spanAttributesSource from './span-attributes-source'
 import { WebVitals } from './web-vitals'
 
 const backgroundingListener = createBrowserBackgroundingListener(document)
+const spanAttributesSource = createSpanAttributesSource(document)
 const clock = createClock(performance, backgroundingListener)
 const persistence = makeBrowserPersistence(window)
 const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -6,18 +6,17 @@ import { createSchema } from './config'
 import { createDefaultRoutingProvider } from './default-routing-provider'
 import createBrowserDeliveryFactory from './delivery'
 import idGenerator from './id-generator'
-import makeBrowserPersistence from './persistence'
 import createOnSettle from './on-settle'
+import makeBrowserPersistence from './persistence'
 import createFetchRequestTracker from './request-tracker/request-tracker-fetch'
 import createXmlHttpRequestTracker from './request-tracker/request-tracker-xhr'
 import createResourceAttributesSource from './resource-attributes-source'
-import createSpanAttributesSource from './span-attributes-source'
+import spanAttributesSource from './span-attributes-source'
 import { WebVitals } from './web-vitals'
 
 const backgroundingListener = createBrowserBackgroundingListener(document)
 const clock = createClock(performance, backgroundingListener)
 const persistence = makeBrowserPersistence(window)
-const spanAttributesSource = createSpanAttributesSource(document.title, window.location.href)
 const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
 const fetchRequestTracker = createFetchRequestTracker(window, clock)
 const xhrRequestTracker = createXmlHttpRequestTracker(window, clock)

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -8,6 +8,7 @@ import {
 } from '@bugsnag/core-performance'
 import { defaultNetworkRequestCallback, isNetworkRequestCallback, type NetworkRequestCallback } from './network-request-callback'
 import { isRoutingProvider, type RoutingProvider } from './routing-provider'
+import { defaultSendPageAttributes, isSendPageAttributes, type SendPageAttributes } from './send-page-attributes'
 
 export interface BrowserSchema extends CoreSchema {
   autoInstrumentFullPageLoads: ConfigOption<boolean>
@@ -17,6 +18,7 @@ export interface BrowserSchema extends CoreSchema {
   routingProvider: ConfigOption<RoutingProvider>
   settleIgnoreUrls: ConfigOption<Array<string | RegExp>>
   networkRequestCallback: ConfigOption<NetworkRequestCallback>
+  sendPageAttributes: ConfigOption<SendPageAttributes>
 }
 
 export interface BrowserConfiguration extends Configuration {
@@ -27,6 +29,7 @@ export interface BrowserConfiguration extends Configuration {
   routingProvider?: RoutingProvider
   settleIgnoreUrls?: Array<string | RegExp>
   networkRequestCallback?: NetworkRequestCallback
+  sendPageAttributes?: SendPageAttributes
 }
 
 export function createSchema (hostname: string, defaultRoutingProvider: RoutingProvider): BrowserSchema {
@@ -70,6 +73,11 @@ export function createSchema (hostname: string, defaultRoutingProvider: RoutingP
       defaultValue: defaultNetworkRequestCallback,
       message: 'should be a function',
       validate: isNetworkRequestCallback
+    },
+    sendPageAttributes: {
+      defaultValue: defaultSendPageAttributes,
+      message: 'should be an object',
+      validate: isSendPageAttributes
     }
   }
 }

--- a/packages/platforms/browser/lib/send-page-attributes.ts
+++ b/packages/platforms/browser/lib/send-page-attributes.ts
@@ -12,7 +12,7 @@ export const defaultSendPageAttributes = {
   url: true
 }
 
-export function compileAttributes (sendPageAttributes: SendPageAttributes) {
+export function getPermittedAttributes (sendPageAttributes: SendPageAttributes) {
   return {
     ...defaultSendPageAttributes,
     ...sendPageAttributes

--- a/packages/platforms/browser/lib/send-page-attributes.ts
+++ b/packages/platforms/browser/lib/send-page-attributes.ts
@@ -1,0 +1,24 @@
+import { isObject } from '@bugsnag/core-performance'
+
+export interface SendPageAttributes {
+  referrer?: boolean
+  title?: boolean
+  url?: boolean
+}
+
+export const defaultSendPageAttributes = {
+  referrer: true,
+  title: true,
+  url: true
+}
+
+export function compileAttributes (sendPageAttributes: SendPageAttributes) {
+  return {
+    ...defaultSendPageAttributes,
+    ...sendPageAttributes
+  }
+}
+
+export function isSendPageAttributes (obj: unknown): obj is SendPageAttributes {
+  return isObject(obj) && Object.values(obj).every(value => typeof value === 'boolean') && Object.keys(obj).every(key => Object.keys(defaultSendPageAttributes).includes(key))
+}

--- a/packages/platforms/browser/lib/send-page-attributes.ts
+++ b/packages/platforms/browser/lib/send-page-attributes.ts
@@ -20,5 +20,8 @@ export function getPermittedAttributes (sendPageAttributes: SendPageAttributes) 
 }
 
 export function isSendPageAttributes (obj: unknown): obj is SendPageAttributes {
-  return isObject(obj) && Object.values(obj).every(value => typeof value === 'boolean') && Object.keys(obj).every(key => Object.keys(defaultSendPageAttributes).includes(key))
+  const allowedTypes = ['undefined', 'boolean']
+  const keys = Object.keys(defaultSendPageAttributes)
+
+  return isObject(obj) && keys.every(key => allowedTypes.includes(typeof obj[key]))
 }

--- a/packages/platforms/browser/lib/span-attributes-source.ts
+++ b/packages/platforms/browser/lib/span-attributes-source.ts
@@ -1,10 +1,33 @@
-import type { SpanAttribute, SpanAttributesSource } from '@bugsnag/core-performance'
+import type { InternalConfiguration, SpanAttributesSource, SpanInternal } from '@bugsnag/core-performance'
+import { type BrowserConfiguration } from './config'
 
-const spanAttributesSource: SpanAttributesSource = () => {
-  const spanAttributes = new Map<string, SpanAttribute>()
-  spanAttributes.set('bugsnag.span.category', 'custom')
+export const createSpanAttributesSource = (document: Document): SpanAttributesSource<BrowserConfiguration> => {
+  const defaultAttributes = {
+    url: {
+      name: 'bugsnag.browser.page.url',
+      getValue: () => document.location.href,
+      permitted: false
+    },
+    title: {
+      name: 'bugsnag.browser.page.title',
+      getValue: () => document.title,
+      permitted: false
+    }
+  }
 
-  return spanAttributes
+  return {
+    configure (configuration: InternalConfiguration<BrowserConfiguration>) {
+      defaultAttributes.title.permitted = configuration.sendPageAttributes.title || false
+      defaultAttributes.url.permitted = configuration.sendPageAttributes.url || false
+    },
+    requestAttributes (span: SpanInternal) {
+      for (const attribute of Object.values(defaultAttributes)) {
+        if (attribute.permitted) {
+          span.setAttribute(attribute.name, attribute.getValue())
+        }
+      }
+    }
+  }
 }
 
-export default spanAttributesSource
+export default createSpanAttributesSource

--- a/packages/platforms/browser/lib/span-attributes-source.ts
+++ b/packages/platforms/browser/lib/span-attributes-source.ts
@@ -1,14 +1,10 @@
 import type { SpanAttribute, SpanAttributesSource } from '@bugsnag/core-performance'
 
-const createSpanAttributesSource = (title: string, url: string): SpanAttributesSource => {
-  return () => {
-    const spanAttributes = new Map<string, SpanAttribute>()
-    spanAttributes.set('bugsnag.span.category', 'custom')
-    spanAttributes.set('bugsnag.browser.page.url', url)
-    spanAttributes.set('bugsnag.browser.page.title', title)
+const spanAttributesSource: SpanAttributesSource = () => {
+  const spanAttributes = new Map<string, SpanAttribute>()
+  spanAttributes.set('bugsnag.span.category', 'custom')
 
-    return spanAttributes
-  }
+  return spanAttributes
 }
 
-export default createSpanAttributesSource
+export default spanAttributesSource

--- a/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -1,8 +1,8 @@
-import { NetworkRequestPlugin } from '../../lib/auto-instrumentation/network-request-plugin'
-import { MockSpanFactory, createConfiguration, createTestClient } from '@bugsnag/js-performance-test-utilities'
-import { RequestTracker, type RequestStartCallback } from '../../lib/request-tracker/request-tracker'
-import { type BrowserConfiguration } from '../../lib/config'
 import { spanContextEquals } from '@bugsnag/core-performance'
+import { MockSpanFactory, createConfiguration, createTestClient } from '@bugsnag/js-performance-test-utilities'
+import { NetworkRequestPlugin } from '../../lib/auto-instrumentation/network-request-plugin'
+import { type BrowserSchema, type BrowserConfiguration } from '../../lib/config'
+import { RequestTracker, type RequestStartCallback } from '../../lib/request-tracker/request-tracker'
 
 const ENDPOINT = 'http://traces.endpoint'
 const TEST_URL = 'http://test-url.com/'
@@ -16,7 +16,7 @@ class MockRequestTracker extends RequestTracker {
 describe('network span plugin', () => {
   let xhrTracker: MockRequestTracker
   let fetchTracker: MockRequestTracker
-  let spanFactory: MockSpanFactory
+  let spanFactory: MockSpanFactory<BrowserConfiguration>
 
   beforeEach(() => {
     xhrTracker = new MockRequestTracker()
@@ -134,7 +134,7 @@ describe('network span plugin', () => {
   })
 
   it('does not push network spans to the context stack', () => {
-    const client = createTestClient({ plugins: (spanFactory) => [new NetworkRequestPlugin(spanFactory, fetchTracker, xhrTracker)] })
+    const client = createTestClient<BrowserSchema, BrowserConfiguration>({ plugins: (spanFactory) => [new NetworkRequestPlugin(spanFactory, fetchTracker, xhrTracker)] })
     const rootSpan = client.startSpan('root span')
 
     fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })

--- a/packages/platforms/browser/tests/auto-instrumentation/page-load-span-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/page-load-span-plugin.test.ts
@@ -3,6 +3,7 @@
  * @jest-environment-options { "referrer": "https://bugsnag.com", "url": "https://bugsnag.com/initial-route" }
  */
 
+import { spanContextEquals } from '@bugsnag/core-performance'
 import {
   ControllableBackgroundingListener,
   InMemoryDelivery,
@@ -11,21 +12,20 @@ import {
   VALID_API_KEY,
   createTestClient
 } from '@bugsnag/js-performance-test-utilities'
+import { FullPageLoadPlugin } from '../../lib/auto-instrumentation/full-page-load-plugin'
+import { createSchema, type BrowserConfiguration, type BrowserSchema } from '../../lib/config'
+import { type OnSettle } from '../../lib/on-settle'
+import { WebVitals } from '../../lib/web-vitals'
 import {
   PerformanceFake,
   PerformanceObserverManager,
-  createPerformanceNavigationTimingFake,
-  createPerformancePaintTimingFake,
-  createPerformanceEventTimingFake,
+  createLargestContentfulPaintFake,
   createLayoutShiftFake,
-  createLargestContentfulPaintFake
+  createPerformanceEventTimingFake,
+  createPerformanceNavigationTimingFake,
+  createPerformancePaintTimingFake
 } from '../utilities'
-import { FullPageLoadPlugin } from '../../lib/auto-instrumentation/full-page-load-plugin'
-import { createSchema } from '../../lib/config'
-import { type OnSettle } from '../../lib/on-settle'
-import { WebVitals } from '../../lib/web-vitals'
 import MockRoutingProvider from '../utilities/mock-routing-provider'
-import { spanContextEquals } from '@bugsnag/core-performance'
 
 jest.useFakeTimers()
 
@@ -44,7 +44,7 @@ describe('FullPageLoadPlugin', () => {
       Promise.resolve().then(() => { onSettleCallback(1234) })
     }
     const webVitals = new WebVitals(performance, clock, manager.createPerformanceObserverFakeClass())
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
@@ -115,7 +115,7 @@ describe('FullPageLoadPlugin', () => {
     const performance = new PerformanceFake()
     const Observer = manager.createPerformanceObserverFakeClass()
     const webVitals = new WebVitals(new PerformanceFake(), clock, Observer)
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
       plugins: (spanFactory) => [
@@ -148,7 +148,7 @@ describe('FullPageLoadPlugin', () => {
     const backgroundingListener = new ControllableBackgroundingListener()
     const performance = new PerformanceFake()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
       backgroundingListener,
@@ -184,7 +184,7 @@ describe('FullPageLoadPlugin', () => {
     const backgroundingListener = new ControllableBackgroundingListener()
     const performance = new PerformanceFake()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
       backgroundingListener,
@@ -223,7 +223,7 @@ describe('FullPageLoadPlugin', () => {
     const webVitals = new WebVitals(new PerformanceFake(), clock, Observer)
     const backgroundingListener = new ControllableBackgroundingListener()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
       backgroundingListener,
@@ -261,7 +261,7 @@ describe('FullPageLoadPlugin', () => {
     const backgroundingListener = new ControllableBackgroundingListener()
     const performance = new PerformanceFake()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
       backgroundingListener,
@@ -300,7 +300,7 @@ describe('FullPageLoadPlugin', () => {
     const backgroundingListener = new ControllableBackgroundingListener()
     const performance = new PerformanceFake()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
       backgroundingListener,
@@ -336,7 +336,7 @@ describe('FullPageLoadPlugin', () => {
     const manager = new PerformanceObserverManager()
     const Observer = manager.createPerformanceObserverFakeClass()
     const webVitals = new WebVitals(performance, clock, Observer)
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       idGenerator: new IncrementingIdGenerator(),
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
@@ -393,7 +393,7 @@ describe('FullPageLoadPlugin', () => {
     const manager = new PerformanceObserverManager()
     const Observer = manager.createPerformanceObserverFakeClass()
     const webVitals = new WebVitals(performance, clock, Observer)
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       idGenerator: new IncrementingIdGenerator(),
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       deliveryFactory: () => delivery,
@@ -448,7 +448,7 @@ describe('FullPageLoadPlugin', () => {
         const delivery = new InMemoryDelivery()
         const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(1234) }
         const webVitals = new WebVitals(performance, clock, manager.createPerformanceObserverFakeClass())
-        const testClient = createTestClient({
+        const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
           clock,
           deliveryFactory: () => delivery,
           schema: createSchema(window.location.hostname, new MockRoutingProvider()),
@@ -495,7 +495,7 @@ describe('FullPageLoadPlugin', () => {
         const delivery = new InMemoryDelivery()
         const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(1234) }
         const webVitals = new WebVitals(performance, clock, manager.createPerformanceObserverFakeClass())
-        const testClient = createTestClient({
+        const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
           clock,
           deliveryFactory: () => delivery,
           schema: createSchema(window.location.hostname, new MockRoutingProvider()),
@@ -548,7 +548,7 @@ describe('FullPageLoadPlugin', () => {
         const delivery = new InMemoryDelivery()
         const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(1234) }
         const webVitals = new WebVitals(performance, clock, manager.createPerformanceObserverFakeClass())
-        const testClient = createTestClient({
+        const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
           clock,
           deliveryFactory: () => delivery,
           schema: createSchema(window.location.hostname, new MockRoutingProvider()),
@@ -590,7 +590,7 @@ describe('FullPageLoadPlugin', () => {
       const delivery = new InMemoryDelivery()
       const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(1234) }
       const webVitals = new WebVitals(performance, clock, undefined)
-      const testClient = createTestClient({
+      const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
         clock,
         deliveryFactory: () => delivery,
         schema: createSchema(window.location.hostname, new MockRoutingProvider()),

--- a/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/resource-load-plugin.test.ts
@@ -4,6 +4,7 @@
 
 import { InMemoryDelivery, IncrementingIdGenerator, VALID_API_KEY, createTestClient } from '@bugsnag/js-performance-test-utilities'
 import { ResourceLoadPlugin } from '../../lib/auto-instrumentation/resource-load-plugin'
+import { type BrowserConfiguration, type BrowserSchema } from '../../lib/config'
 import { PerformanceObserverManager } from '../utilities'
 import { createPerformanceResourceNavigationTimingFake } from '../utilities/performance-entry'
 
@@ -16,7 +17,7 @@ describe('ResourceLoadPlugin', () => {
     const Observer = manager.createPerformanceObserverFakeClass()
     const idGenerator = new IncrementingIdGenerator()
 
-    const client = createTestClient({
+    const client = createTestClient<BrowserSchema, BrowserConfiguration>({
       idGenerator,
       deliveryFactory: () => delivery,
       plugins: (spanFactory, spanContextStorage) => [
@@ -65,7 +66,7 @@ describe('ResourceLoadPlugin', () => {
     const Observer = manager.createPerformanceObserverFakeClass()
     const idGenerator = new IncrementingIdGenerator()
 
-    const client = createTestClient({
+    const client = createTestClient<BrowserSchema, BrowserConfiguration>({
       idGenerator,
       deliveryFactory: () => delivery,
       plugins: (spanFactory, spanContextStorage) => [
@@ -105,7 +106,7 @@ describe('ResourceLoadPlugin', () => {
     const Observer = manager.createPerformanceObserverFakeClass()
     const idGenerator = new IncrementingIdGenerator()
 
-    const client = createTestClient({
+    const client = createTestClient<BrowserSchema, BrowserConfiguration>({
       idGenerator,
       deliveryFactory: () => delivery,
       plugins: (spanFactory, spanContextStorage) => [
@@ -144,7 +145,7 @@ describe('ResourceLoadPlugin', () => {
     const Observer = manager.createPerformanceObserverFakeClass()
     const idGenerator = new IncrementingIdGenerator()
 
-    const client = createTestClient({
+    const client = createTestClient<BrowserSchema, BrowserConfiguration>({
       idGenerator,
       deliveryFactory: () => delivery,
       plugins: (spanFactory, spanContextStorage) => [

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -5,7 +5,7 @@
 
 import { InMemoryDelivery, IncrementingClock, VALID_API_KEY, createTestClient } from '@bugsnag/js-performance-test-utilities'
 import { RouteChangePlugin } from '../../lib/auto-instrumentation/route-change-plugin'
-import { createSchema } from '../../lib/config'
+import { createSchema, type BrowserConfiguration, type BrowserSchema } from '../../lib/config'
 import { createDefaultRoutingProvider } from '../../lib/default-routing-provider'
 import { type OnSettle } from '../../lib/on-settle'
 import { type StartRouteChangeCallback } from '../../lib/routing-provider'
@@ -38,7 +38,7 @@ describe('RouteChangePlugin', () => {
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
@@ -78,7 +78,7 @@ describe('RouteChangePlugin', () => {
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
@@ -139,7 +139,7 @@ describe('RouteChangePlugin', () => {
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
@@ -161,7 +161,7 @@ describe('RouteChangePlugin', () => {
     const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
     const clock = new IncrementingClock()
     const delivery = new InMemoryDelivery()
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
@@ -203,7 +203,7 @@ describe('RouteChangePlugin', () => {
       }
 
       const delivery = new InMemoryDelivery()
-      const testClient = createTestClient({
+      const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
         deliveryFactory: () => delivery,
         schema: createSchema(window.location.hostname, routingProvider),
         plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location, document)]
@@ -248,7 +248,7 @@ describe('RouteChangePlugin', () => {
       }
 
       const delivery = new InMemoryDelivery()
-      const testClient = createTestClient({
+      const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
         deliveryFactory: () => delivery,
         schema: createSchema(window.location.hostname, routingProvider),
         plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location, document)]

--- a/packages/platforms/browser/tests/on-settle/index.test.ts
+++ b/packages/platforms/browser/tests/on-settle/index.test.ts
@@ -7,7 +7,7 @@ import {
   VALID_API_KEY,
   createTestClient
 } from '@bugsnag/js-performance-test-utilities'
-import { createSchema } from '../../lib/config'
+import { type BrowserConfiguration, type BrowserSchema, createSchema } from '../../lib/config'
 import createOnSettle from '../../lib/on-settle'
 import {
   RequestTracker,
@@ -300,7 +300,7 @@ describe('onSettle', () => {
       performance
     )
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       plugins: (spanFactory) => [onSettle]
     })
@@ -341,7 +341,7 @@ describe('onSettle', () => {
       performance
     )
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       plugins: (spanFactory) => [onSettle]
     })
@@ -375,7 +375,7 @@ describe('onSettle', () => {
       performance
     )
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),
       plugins: (spanFactory) => [onSettle]
     })

--- a/packages/platforms/browser/tests/routing-provider.test.ts
+++ b/packages/platforms/browser/tests/routing-provider.test.ts
@@ -5,7 +5,7 @@
 
 import { InMemoryDelivery, IncrementingClock, VALID_API_KEY, createTestClient } from '@bugsnag/js-performance-test-utilities'
 import { RouteChangePlugin } from '../lib/auto-instrumentation/route-change-plugin'
-import { createSchema } from '../lib/config'
+import { type BrowserConfiguration, type BrowserSchema, createSchema } from '../lib/config'
 import { createDefaultRoutingProvider } from '../lib/default-routing-provider'
 import { isRoutingProvider } from '../lib/routing-provider'
 
@@ -19,7 +19,7 @@ describe('DefaultRoutingProvider', () => {
     const delivery = new InMemoryDelivery()
     const routeResolverFn = jest.fn((url: URL | string) => '/resolved-route')
     const routingProvier = new DefaultRoutingProvider(routeResolverFn)
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, routingProvier),
@@ -41,7 +41,7 @@ describe('DefaultRoutingProvider', () => {
       const clock = new IncrementingClock('1970-01-01T00:00:00Z')
       const delivery = new InMemoryDelivery()
       const routingProvier = new DefaultRoutingProvider()
-      const testClient = createTestClient({
+      const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
         clock,
         deliveryFactory: () => delivery,
         schema: createSchema(window.location.hostname, routingProvier),

--- a/packages/platforms/browser/tests/send-page-attributes.test.ts
+++ b/packages/platforms/browser/tests/send-page-attributes.test.ts
@@ -1,4 +1,4 @@
-import { compileAttributes, defaultSendPageAttributes, isSendPageAttributes } from '../lib/send-page-attributes'
+import { getPermittedAttributes, defaultSendPageAttributes, isSendPageAttributes } from '../lib/send-page-attributes'
 
 describe('isSendPageAttributes', () => {
   const valid = [
@@ -46,15 +46,15 @@ describe('isSendPageAttributes', () => {
   })
 })
 
-describe('compileAttributes', () => {
+describe('getPermittedAttributes', () => {
   it('retains provided values', () => {
     const providedAttributes = { url: false, referrer: false, title: false }
-    const compiledAttributes = compileAttributes(providedAttributes)
+    const compiledAttributes = getPermittedAttributes(providedAttributes)
     expect(compiledAttributes).toStrictEqual(providedAttributes)
   })
 
   it('completes missing values', () => {
-    const compiledAttributes = compileAttributes({ url: true })
+    const compiledAttributes = getPermittedAttributes({ url: true })
     expect(compiledAttributes).toStrictEqual(defaultSendPageAttributes)
   })
 })

--- a/packages/platforms/browser/tests/send-page-attributes.test.ts
+++ b/packages/platforms/browser/tests/send-page-attributes.test.ts
@@ -1,0 +1,60 @@
+import { compileAttributes, defaultSendPageAttributes, isSendPageAttributes } from '../lib/send-page-attributes'
+
+describe('isSendPageAttributes', () => {
+  const valid = [
+    defaultSendPageAttributes,
+    {
+      url: false,
+      referrer: false,
+      title: false
+    },
+    { url: true },
+    { referrer: false },
+    { title: true },
+    {}
+  ]
+
+  it.each(valid)('returns true for a valid list of attributes', (value) => {
+    expect(isSendPageAttributes(value)).toBe(true)
+  })
+
+  const invalid = [
+    {
+      url: 'string',
+      referrer: false,
+      title: false
+    },
+    {
+      url: true,
+      referrer: false,
+      title: false,
+      unknown: true
+    },
+    () => [],
+    [],
+    true,
+    false,
+    null,
+    undefined,
+    'string',
+    1234,
+    Symbol('title')
+  ]
+
+  it.each(invalid)('returns false for an invalid list of attributes', (value) => {
+    expect(isSendPageAttributes(value)).toBe(false)
+  })
+})
+
+describe('compileAttributes', () => {
+  it('retains provided values', () => {
+    const providedAttributes = { url: false, referrer: false, title: false }
+    const compiledAttributes = compileAttributes(providedAttributes)
+    expect(compiledAttributes).toStrictEqual(providedAttributes)
+  })
+
+  it('completes missing values', () => {
+    const compiledAttributes = compileAttributes({ url: true })
+    expect(compiledAttributes).toStrictEqual(defaultSendPageAttributes)
+  })
+})

--- a/packages/platforms/browser/tests/send-page-attributes.test.ts
+++ b/packages/platforms/browser/tests/send-page-attributes.test.ts
@@ -11,6 +11,12 @@ describe('isSendPageAttributes', () => {
     { url: true },
     { referrer: false },
     { title: true },
+    {
+      url: true,
+      referrer: false,
+      title: false,
+      unknown: true
+    },
     {}
   ]
 
@@ -23,12 +29,6 @@ describe('isSendPageAttributes', () => {
       url: 'string',
       referrer: false,
       title: false
-    },
-    {
-      url: true,
-      referrer: false,
-      title: false,
-      unknown: true
     },
     () => [],
     [],

--- a/packages/platforms/browser/tests/span-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/span-attributes-source.test.ts
@@ -1,21 +1,35 @@
-/**
- * @jest-environment jsdom
- */
+import { SpanAttributes, SpanInternal } from '@bugsnag/core-performance'
+import { createConfiguration } from '@bugsnag/js-performance-test-utilities'
+import { type BrowserConfiguration } from '../lib'
+import createSpanAttributesSource from '../lib/span-attributes-source'
 
-import spanAttributesSource from '../lib/span-attributes-source'
+const mockDocument = {
+  title: 'span attributes source',
+  location: {
+    href: 'https://bugsnag.com/span-attributes-source'
+  }
+}
+
+const spanAttributesSource = createSpanAttributesSource(mockDocument as Document)
 
 describe('spanAttributesSource', () => {
-  it('allows get/set for new attributes', () => {
-    const spanAttributes = spanAttributesSource()
-    expect(spanAttributes.get('bugsnag.test.attribute')).toBeUndefined()
-    spanAttributes.set('bugsnag.test.attribute', 'value')
-    expect(spanAttributes.get('bugsnag.test.attribute')).toBe('value')
-  })
+  it('adds permitted attributes to a span', () => {
+    const browserConfiguration = createConfiguration<BrowserConfiguration>({ sendPageAttributes: { url: true, title: true } })
+    const spanAttributes = new SpanAttributes(new Map())
+    const span = new SpanInternal('id', 'traceId', 'test span', 1234, spanAttributes)
 
-  it('includes common span attributes', () => {
-    const spanAttributes = spanAttributesSource()
-    expect(Array.from(spanAttributes.entries())).toEqual([
-      ['bugsnag.span.category', 'custom']
-    ])
+    spanAttributesSource.requestAttributes(span)
+
+    // @ts-expect-error attributes not accessible on span
+    const attributes: Map<string, any> = span.attributes.attributes
+
+    expect(attributes.get('bugsnag.browser.page.title')).toBeUndefined()
+    expect(attributes.get('bugsnag.browser.page.url')).toBeUndefined()
+
+    spanAttributesSource.configure(browserConfiguration)
+    spanAttributesSource.requestAttributes(span)
+
+    expect(attributes.get('bugsnag.browser.page.title')).toBe('span attributes source')
+    expect(attributes.get('bugsnag.browser.page.url')).toBe('https://bugsnag.com/span-attributes-source')
   })
 })

--- a/packages/platforms/browser/tests/span-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/span-attributes-source.test.ts
@@ -2,19 +2,20 @@
  * @jest-environment jsdom
  */
 
-import createSpanAttributesSource from '../lib/span-attributes-source'
+import spanAttributesSource from '../lib/span-attributes-source'
 
 describe('spanAttributesSource', () => {
+  it('allows get/set for new attributes', () => {
+    const spanAttributes = spanAttributesSource()
+    expect(spanAttributes.get('bugsnag.test.attribute')).toBeUndefined()
+    spanAttributes.set('bugsnag.test.attribute', 'value')
+    expect(spanAttributes.get('bugsnag.test.attribute')).toBe('value')
+  })
+
   it('includes common span attributes', () => {
-    const spanAttributesSource = createSpanAttributesSource(
-      'the page title',
-      'https://www.bugsnag.com'
-    )
     const spanAttributes = spanAttributesSource()
     expect(Array.from(spanAttributes.entries())).toEqual([
-      ['bugsnag.span.category', 'custom'],
-      ['bugsnag.browser.page.url', 'https://www.bugsnag.com'],
-      ['bugsnag.browser.page.title', 'the page title']
+      ['bugsnag.span.category', 'custom']
     ])
   })
 })

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -1,16 +1,17 @@
 import {
-  type SpanInternal,
-  type SpanEnded,
-  type SpanOptions,
+  DefaultSpanContextStorage,
   Sampler,
   SpanFactory,
-  DefaultSpanContextStorage
+  type Configuration,
+  type SpanEnded,
+  type SpanInternal,
+  type SpanOptions
 } from '@bugsnag/core-performance'
-import StableIdGenerator from './stable-id-generator'
-import spanAttributesSource from './span-attributes-source'
-import IncrementingClock from './incrementing-clock'
-import InMemoryProcessor from './in-memory-processor'
 import ControllableBackgroundingListener from './controllable-backgrounding-listener'
+import InMemoryProcessor from './in-memory-processor'
+import IncrementingClock from './incrementing-clock'
+import spanAttributesSource from './span-attributes-source'
+import StableIdGenerator from './stable-id-generator'
 
 const jestLogger = {
   debug: jest.fn(),
@@ -19,7 +20,7 @@ const jestLogger = {
   warn: jest.fn()
 }
 
-class MockSpanFactory extends SpanFactory {
+class MockSpanFactory <C extends Configuration> extends SpanFactory<C> {
   public createdSpans: SpanEnded[]
 
   constructor () {

--- a/packages/test-utilities/lib/span-attributes-source.ts
+++ b/packages/test-utilities/lib/span-attributes-source.ts
@@ -1,9 +1,12 @@
-import { type SpanAttribute } from '@bugsnag/core-performance'
+import { type Configuration, type SpanAttributesSource } from '@bugsnag/core-performance'
 
-function spanAttributesSource (): Map<string, SpanAttribute> {
-  const spanAttributes = new Map()
+const spanAttributesSource: SpanAttributesSource<Configuration> = {
+  configure () {
 
-  return spanAttributes
+  },
+  requestAttributes () {
+
+  }
 }
 
 export default spanAttributesSource

--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -23,28 +23,28 @@ Feature: Page Load spans
         And a span named "[PageLoadPhase/HTTPRequest]/page-load-spans/" contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | HTTPRequest           |
 
         And a span named "[PageLoadPhase/HTTPResponse]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"
         And a span named "[PageLoadPhase/HTTPResponse]/page-load-spans/" contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | HTTPResponse          |
 
         And a span named "[PageLoadPhase/DomContentLoadedEvent]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"
         And a span named "[PageLoadPhase/DomContentLoadedEvent]/page-load-spans/" contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | DomContentLoadedEvent |
 
         And a span named "[PageLoadPhase/LoadEvent]/page-load-spans/" has a parent named "[FullPageLoad]/page-load-spans/"
         And a span named "[PageLoadPhase/LoadEvent]/page-load-spans/" contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | LoadEvent             |
 
         # The following spans may or may not be present in the trace. In most cases this is
@@ -56,7 +56,7 @@ Feature: Page Load spans
         And if a span named "[PageLoadPhase/Redirect]/page-load-spans/" exists, it contains the attributes:
             | attribute                                 | type         | value                 |
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | Redirect              |
 
         # Unload may have 0 start and end times
@@ -64,7 +64,7 @@ Feature: Page Load spans
         And if a span named "[PageLoadPhase/Unload]/page-load-spans/" exists, it contains the attributes:
             | attribute                                 | type         | value                 |
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | Unload                |
 
         # LoadFromCache may have 0 start and end times 
@@ -72,7 +72,7 @@ Feature: Page Load spans
         And if a span named "[PageLoadPhase/LoadFromCache]/page-load-spans/" exists, it contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | LoadFromCache         |
 
         # DNSLookup may have 0 start and end times
@@ -80,7 +80,7 @@ Feature: Page Load spans
         And if a span named "[PageLoadPhase/DNSLookup]/page-load-spans/" exists, it contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | DNSLookup             |
 
         # TCPHandshake may have 0 start and end times 
@@ -88,7 +88,7 @@ Feature: Page Load spans
         And if a span named "[PageLoadPhase/TCPHandshake]/page-load-spans/" exists, it contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | TCPHandshake          |
 
         # TLS may have 0 start and end times
@@ -96,7 +96,7 @@ Feature: Page Load spans
         And if a span named "[PageLoadPhase/TLS]/page-load-spans/" exists, it contains the attributes:
             | attribute                                 | type         | value                 | 
             | bugsnag.span.category                     | stringValue  | page_load_phase       |
-            | bugsnag.browser.page.title                | stringValue  | Page load spans       |
+            | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | TLS                   |
 
 


### PR DESCRIPTION
## Goal

Add a new configuration option to manually exclude `url`, `title` and `referrer` attributes from automatically instrumented spans

## Testing

Unit tests for validation functions