### PR TITLE
Reduce code coverage failure threshold

### DIFF
--- a/.github/leave-pr-stats-comment.js
+++ b/.github/leave-pr-stats-comment.js
@@ -53,7 +53,7 @@ module.exports = async function (github, context, require, needs) {
 
   ### Code coverage
 
-  ${coverageDiff.diff(JSON.parse(sizes.before.coverage), JSON.parse(sizes.after.coverage)).results}
+  ${coverageDiff.diff(JSON.parse(sizes.before.coverage), JSON.parse(sizes.after.coverage), { coverageThreshold: 90 }).results}
 
   <p align="right">
     Generated against ${context.payload.pull_request.head.sha}


### PR DESCRIPTION
## Goal

Reduces the 'fail' threshold for the code coverage reporting tool from 100% to 90%. 

The decrease threshold is still 0 so any percentage decrease in a file's coverage will be reported as a 'fail'