### PR TITLE
[PLAT-10602] Implement configuration.sendPageAttributes in route-change-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
-- (browser) Add `sendPageAttributes` configuration option [#266](https://github.com/bugsnag/bugsnag-js-performance/pull/266)
+- (browser) Add `sendPageAttributes` configuration option [#266](https://github.com/bugsnag/bugsnag-js-performance/pull/266) [#270](https://github.com/bugsnag/bugsnag-js-performance/pull/270)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - (browser) Added new `networkRequestCallback` config option [#262](https://github.com/bugsnag/bugsnag-js-performance/pull/262)
-- (browser) Add `sendPageAttributes` configuration option [#266](https://github.com/bugsnag/bugsnag-js-performance/pull/266) [#270](https://github.com/bugsnag/bugsnag-js-performance/pull/270)
+- (browser) Add `sendPageAttributes` configuration option [#266](https://github.com/bugsnag/bugsnag-js-performance/pull/266) [#270](https://github.com/bugsnag/bugsnag-js-performance/pull/270) [#271](https://github.com/bugsnag/bugsnag-js-performance/pull/271)
 
 ### Fixed
 

--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -7,6 +7,7 @@ import {
 import { type BrowserConfiguration } from '../config'
 import { type OnSettle } from '../on-settle'
 import { type PerformanceWithTiming } from '../on-settle/load-event-end-settler'
+import { getPermittedAttributes } from '../send-page-attributes'
 import { type WebVitals } from '../web-vitals'
 import { instrumentPageLoadPhaseSpans } from './page-load-phase-spans'
 
@@ -53,6 +54,7 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
     }
 
     const span = this.spanFactory.startSpan('[FullPageLoad]', { startTime: 0, parentContext: null })
+    const permittedAttributes = getPermittedAttributes(configuration.sendPageAttributes)
     const url = new URL(this.location.href)
 
     this.onSettle((endTime: number) => {
@@ -65,10 +67,10 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
 
       // Browser attributes
       span.setAttribute('bugsnag.span.category', 'full_page_load')
-      span.setAttribute('bugsnag.browser.page.referrer', this.document.referrer)
-      span.setAttribute('bugsnag.browser.page.title', this.document.title)
-      span.setAttribute('bugsnag.browser.page.url', url.toString())
       span.setAttribute('bugsnag.browser.page.route', route)
+      if (permittedAttributes.referrer) span.setAttribute('bugsnag.browser.page.referrer', this.document.referrer)
+      if (permittedAttributes.title) span.setAttribute('bugsnag.browser.page.title', this.document.title)
+      if (permittedAttributes.url) span.setAttribute('bugsnag.browser.page.url', url.toString())
 
       this.webVitals.attachTo(span)
       this.spanFactory.endSpan(span, endTime)

--- a/packages/platforms/browser/tests/auto-instrumentation/page-load-span-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/page-load-span-plugin.test.ts
@@ -438,6 +438,47 @@ describe('FullPageLoadPlugin', () => {
     }))
   })
 
+  it('blocks span attributes based on sendPageAttributes config', async () => {
+    const performance = new PerformanceFake()
+    const manager = new PerformanceObserverManager()
+    const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+    const delivery = new InMemoryDelivery()
+    const onSettle: OnSettle = (onSettleCallback) => { Promise.resolve().then(() => { onSettleCallback(1234) }) }
+    const webVitals = new WebVitals(performance, clock, manager.createPerformanceObserverFakeClass())
+    const testClient = createTestClient({
+      clock,
+      deliveryFactory: () => delivery,
+      schema: createSchema(window.location.hostname, new MockRoutingProvider()),
+      plugins: (spanFactory) => [
+        new FullPageLoadPlugin(
+          document,
+          window.location,
+          spanFactory,
+          webVitals,
+          onSettle,
+          new ControllableBackgroundingListener(),
+          performance
+        )
+      ]
+    })
+
+    testClient.start({ apiKey: VALID_API_KEY, sendPageAttributes: { url: false, referrer: false, title: false } })
+
+    await jest.runOnlyPendingTimersAsync()
+
+    expect(delivery).toHaveSentSpan(expect.objectContaining({ name: '[FullPageLoad]/initial-route' }))
+
+    const spans = delivery.requests[0].resourceSpans[0].scopeSpans[0].spans
+    const span = spans[spans.length - 1]
+
+    expect(span).toHaveAttribute('bugsnag.span.category', 'full_page_load')
+    expect(span).toHaveAttribute('bugsnag.browser.page.route', '/initial-route')
+
+    // excluded by spendPageAttributes
+    expect(span).not.toHaveAttribute('bugsnag.browser.page.referrer')
+    expect(span).not.toHaveAttribute('bugsnag.browser.page.url')
+    expect(span).not.toHaveAttribute('bugsnag.browser.page.title')
+  })
   describe('WebVitals', () => {
     describe('lcp', () => {
       it('uses the latest lcp entry (multiple entries)', async () => {

--- a/packages/platforms/browser/tests/auto-instrumentation/page-load-span-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/page-load-span-plugin.test.ts
@@ -445,7 +445,7 @@ describe('FullPageLoadPlugin', () => {
     const delivery = new InMemoryDelivery()
     const onSettle: OnSettle = (onSettleCallback) => { Promise.resolve().then(() => { onSettleCallback(1234) }) }
     const webVitals = new WebVitals(performance, clock, manager.createPerformanceObserverFakeClass())
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new MockRoutingProvider()),

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -19,6 +19,10 @@ const jestLogger = {
   info: jest.fn()
 }
 
+const mockOnSettle: OnSettle = (onSettleCallback) => {
+  Promise.resolve().then(() => { onSettleCallback(32) })
+}
+
 afterEach(() => {
   history.replaceState({}, 'unused', 'https://bugsnag.com/route-change-plugin')
   jest.clearAllTimers()
@@ -31,10 +35,7 @@ describe('RouteChangePlugin', () => {
     { type: 'string (absolute URL)', url: 'https://bugsnag.com/second-route' },
     { type: 'string (relative URL)', url: '/second-route' }
   ])('creates a route change span on pushState with $type', async ({ url }) => {
-    const onSettle: OnSettle = (onSettleCallback) => {
-      Promise.resolve().then(() => { onSettleCallback(32) })
-    }
-    const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+    const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
 
@@ -73,8 +74,7 @@ describe('RouteChangePlugin', () => {
   })
 
   it('creates a route change span on popstate', async () => {
-    const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
-    const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+    const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
 
@@ -134,8 +134,7 @@ describe('RouteChangePlugin', () => {
     { type: 'undefined', url: undefined },
     { type: 'null', url: null }
   ])('does not create a route change span on pushState with $type', async ({ url }) => {
-    const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
-    const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+    const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
 
@@ -157,8 +156,7 @@ describe('RouteChangePlugin', () => {
   })
 
   it('does not create route change spans with autoInstrumentFullPageLoads set to false', async () => {
-    const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
-    const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+    const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
     const clock = new IncrementingClock()
     const delivery = new InMemoryDelivery()
     const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
@@ -194,8 +192,7 @@ describe('RouteChangePlugin', () => {
     ]
 
     it.each(invalidRoutes)('handles invalid urls ($type)', async ({ url }) => {
-      const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
-      const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+      const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
       const routingProvider = new DefaultRoutingProvider()
       let routeChangeCallback: StartRouteChangeCallback = jest.fn()
       routingProvider.listenForRouteChanges = (startRouteChangeSpan) => {
@@ -239,8 +236,7 @@ describe('RouteChangePlugin', () => {
     ]
 
     it.each(invalidTriggers)('handles invalid triggers ($type)', async ({ trigger }) => {
-      const onSettle: OnSettle = (onSettleCallback) => { onSettleCallback(32) }
-      const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+      const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
       const routingProvider = new DefaultRoutingProvider()
       let routeChangeCallback: StartRouteChangeCallback = jest.fn()
       routingProvider.listenForRouteChanges = (startRouteChangeSpan) => {
@@ -272,5 +268,40 @@ describe('RouteChangePlugin', () => {
       const routeChangeSpan = delivery.requests[0].resourceSpans[0].scopeSpans[0].spans[0]
       expect(routeChangeSpan).toHaveAttribute('bugsnag.browser.page.route_change.trigger', String(trigger))
     })
+  })
+
+  it('sendPageAttributes', async () => {
+    const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
+    const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+    const delivery = new InMemoryDelivery()
+
+    const testClient = createTestClient({
+      clock,
+      deliveryFactory: () => delivery,
+      schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
+      plugins: (spanFactory) => [new RouteChangePlugin(spanFactory, window.location, document)]
+    })
+
+    testClient.start({ apiKey: VALID_API_KEY, sendPageAttributes: { url: false, title: false } })
+
+    history.pushState({}, '', 'https://bugsnag.com/second-route')
+
+    await jest.runOnlyPendingTimersAsync()
+
+    expect(delivery).toHaveSentSpan(expect.objectContaining({
+      name: '[RouteChange]/second-route',
+      startTimeUnixNano: '1000000',
+      endTimeUnixNano: '32000000'
+    }))
+
+    const span = delivery.requests[0].resourceSpans[0].scopeSpans[0].spans[0]
+    expect(span).toHaveAttribute('bugsnag.span.category', 'route_change')
+    expect(span).toHaveAttribute('bugsnag.browser.page.route', '/second-route')
+    expect(span).toHaveAttribute('bugsnag.browser.page.previous_route', '/route-change-plugin')
+    expect(span).toHaveAttribute('bugsnag.browser.page.route_change.trigger', 'pushState')
+
+    // excluded by sendPageAttributes
+    expect(span).not.toHaveAttribute('bugsnag.browser.page.url')
+    expect(span).not.toHaveAttribute('bugsnag.browser.page.title')
   })
 })

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -270,12 +270,12 @@ describe('RouteChangePlugin', () => {
     })
   })
 
-  it('sendPageAttributes', async () => {
+  it('excludes attributes specified in sendPageAttributes', async () => {
     const DefaultRoutingProvider = createDefaultRoutingProvider(mockOnSettle, window.location)
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const delivery = new InMemoryDelivery()
 
-    const testClient = createTestClient({
+    const testClient = createTestClient<BrowserSchema, BrowserConfiguration>({
       clock,
       deliveryFactory: () => delivery,
       schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),


### PR DESCRIPTION
## Goal

Prevent adding span attributes in full page loads based on values set in `sendPageAttributes` configuration

## Testing

Added a new unit test to ensure span attributes are not added when matching properties are set to `false`