### PR TITLE
[PLAT-10617] Only track network requests over http(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - (browser) Calculate time origin on create as well as visibility change [#268](https://github.com/bugsnag/bugsnag-js-performance/pull/268)
+- (browser) Only track network requests over http(s) [#275](https://github.com/bugsnag/bugsnag-js-performance/pull/275)
 
 ### Removed
 

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -8,6 +8,8 @@ import {
   type RequestTracker
 } from '../request-tracker/request-tracker'
 
+const permittedPrefixes = ['http://', 'https://', '/', './', '../']
+
 export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   private configEndpoint: string = ''
   private networkRequestCallback: NetworkRequestCallback = defaultNetworkRequestCallback
@@ -60,7 +62,6 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   }
 
   private shouldTrackRequest (startContext: RequestStartContext): boolean {
-    const permittedPrefixes = ['http://', 'https://', '/', './', '../']
     return startContext.url !== this.configEndpoint && permittedPrefixes.some((prefix) => startContext.url.startsWith(prefix))
   }
 }

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -60,6 +60,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
   }
 
   private shouldTrackRequest (startContext: RequestStartContext): boolean {
-    return startContext.url !== this.configEndpoint
+    const permittedPrefixes = ['http://', 'https://', '/', './', '../']
+    return startContext.url !== this.configEndpoint && permittedPrefixes.some((prefix) => startContext.url.startsWith(prefix))
   }
 }


### PR DESCRIPTION
## Goal

Prevent errors in the pipeline from sending spans caused by network requests over additional protocols to http and https.

## Design

Prevent spans being created with urls starting with anything other than http and https, or using a relative path.

## Testing

Added unit tests for positive and negative scenarios