### PR TITLE
[PLAT-10639] Use pathname when resolved route is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - (browser) Calculate time origin on create as well as visibility change [#268](https://github.com/bugsnag/bugsnag-js-performance/pull/268)
 - (browser) Only track network requests over http(s) [#275](https://github.com/bugsnag/bugsnag-js-performance/pull/275)
-- (browser) Return full url from default route resolver when route is empty [#276](https://github.com/bugsnag/bugsnag-js-performance/pull/276)
+- (browser) Use pathname when resolved route is empty or undefined [#276](https://github.com/bugsnag/bugsnag-js-performance/pull/276)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - (browser) Calculate time origin on create as well as visibility change [#268](https://github.com/bugsnag/bugsnag-js-performance/pull/268)
 - (browser) Only track network requests over http(s) [#275](https://github.com/bugsnag/bugsnag-js-performance/pull/275)
-- (browser) Use pathname when resolved route is empty or undefined [#276](https://github.com/bugsnag/bugsnag-js-performance/pull/276)
+- (browser) Fall back to default route resolver when custom resolver returns empty string or undefined [#276](https://github.com/bugsnag/bugsnag-js-performance/pull/276)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - (browser) Calculate time origin on create as well as visibility change [#268](https://github.com/bugsnag/bugsnag-js-performance/pull/268)
 - (browser) Only track network requests over http(s) [#275](https://github.com/bugsnag/bugsnag-js-performance/pull/275)
+- (browser) Return full url from default route resolver when route is empty [#276](https://github.com/bugsnag/bugsnag-js-performance/pull/276)
 
 ### Removed
 

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -2,6 +2,7 @@ import { coreSpanOptionSchema, isString, validateSpanOptions, type InternalConfi
 import { type BrowserConfiguration } from '../config'
 import { type RouteChangeSpanOptions } from '../routing-provider'
 import { getPermittedAttributes } from '../send-page-attributes'
+import { defaultRouteResolver } from '../default-routing-provider'
 
 // exclude isFirstClass from the route change option schema
 const { startTime, parentContext, makeCurrentContext } = coreSpanOptionSchema
@@ -32,7 +33,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
     if (!configuration.autoInstrumentRouteChanges) return
 
     const previousUrl = new URL(this.location.href)
-    let previousRoute = configuration.routingProvider.resolveRoute(previousUrl) || previousUrl.pathname
+    let previousRoute = configuration.routingProvider.resolveRoute(previousUrl) || defaultRouteResolver(previousUrl)
 
     const permittedAttributes = getPermittedAttributes(configuration.sendPageAttributes)
 
@@ -70,7 +71,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
         configuration.logger
       )
 
-      const route = configuration.routingProvider.resolveRoute(absoluteUrl) || absoluteUrl.pathname
+      const route = configuration.routingProvider.resolveRoute(absoluteUrl) || defaultRouteResolver(absoluteUrl)
 
       // update the span name using the validated route
       cleanOptions.name += route

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -31,7 +31,9 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
   configure (configuration: InternalConfiguration<BrowserConfiguration>) {
     if (!configuration.autoInstrumentRouteChanges) return
 
-    let previousRoute = configuration.routingProvider.resolveRoute(new URL(this.location.href))
+    const previousUrl = new URL(this.location.href)
+    let previousRoute = configuration.routingProvider.resolveRoute(previousUrl) || previousUrl.pathname
+
     const permittedAttributes = getPermittedAttributes(configuration.sendPageAttributes)
 
     configuration.routingProvider.listenForRouteChanges((url, trigger, options) => {
@@ -68,7 +70,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
         configuration.logger
       )
 
-      const route = configuration.routingProvider.resolveRoute(absoluteUrl)
+      const route = configuration.routingProvider.resolveRoute(absoluteUrl) || absoluteUrl.pathname
 
       // update the span name using the validated route
       cleanOptions.name += route

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -2,7 +2,7 @@ import { type OnSettle } from './on-settle'
 import getAbsoluteUrl from './request-tracker/url-helpers'
 import { type RouteResolver, type RoutingProvider, type StartRouteChangeCallback } from './routing-provider'
 
-export const defaultRouteResolver: RouteResolver = (url: URL) => url.pathname || url.toString()
+export const defaultRouteResolver: RouteResolver = (url: URL) => url.pathname || '/'
 
 export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Location) => {
   return class DefaultRoutingProvider implements RoutingProvider {

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -2,7 +2,7 @@ import { type OnSettle } from './on-settle'
 import getAbsoluteUrl from './request-tracker/url-helpers'
 import { type RouteResolver, type RoutingProvider, type StartRouteChangeCallback } from './routing-provider'
 
-const defaultRouteResolver: RouteResolver = (url: URL) => url.pathname
+const defaultRouteResolver: RouteResolver = (url: URL) => [null, undefined, ''].includes(url.pathname) ? url.toString() : url.pathname
 
 export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Location) => {
   return class DefaultRoutingProvider implements RoutingProvider {

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -2,7 +2,7 @@ import { type OnSettle } from './on-settle'
 import getAbsoluteUrl from './request-tracker/url-helpers'
 import { type RouteResolver, type RoutingProvider, type StartRouteChangeCallback } from './routing-provider'
 
-const defaultRouteResolver: RouteResolver = (url: URL) => [null, undefined, ''].includes(url.pathname) ? url.toString() : url.pathname
+export const defaultRouteResolver: RouteResolver = (url: URL) => url.pathname || url.toString()
 
 export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Location) => {
   return class DefaultRoutingProvider implements RoutingProvider {

--- a/packages/platforms/browser/tests/default-routing-provider.test.ts
+++ b/packages/platforms/browser/tests/default-routing-provider.test.ts
@@ -4,6 +4,8 @@
 
 import { createDefaultRoutingProvider, defaultRouteResolver } from '../lib/default-routing-provider'
 
+jest.useFakeTimers()
+
 describe('defaultRouteResolver', () => {
   const array = [
     {
@@ -58,6 +60,8 @@ describe('DefaultRoutingProvider', () => {
       routingProvider.listenForRouteChanges(startRouteChangeSpan)
 
       history.back()
+
+      jest.runAllTimers()
 
       expect(startRouteChangeSpan).toHaveBeenCalled()
     })

--- a/packages/platforms/browser/tests/default-routing-provider.test.ts
+++ b/packages/platforms/browser/tests/default-routing-provider.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createDefaultRoutingProvider, defaultRouteResolver } from '../lib/default-routing-provider'
+
+describe('defaultRouteResolver', () => {
+  const array = [
+    {
+      type: 'empty string',
+      path: '',
+      expected: '/'
+    },
+    {
+      type: 'simple path',
+      path: '/new-route',
+      expected: '/new-route'
+    },
+    {
+      type: 'path with query string',
+      path: '/new-route?apiKey=1234',
+      expected: '/new-route'
+    }
+  ]
+
+  it.each(array)('correctly resolves a given route ($type)', ({ path, expected }) => {
+    const url = new URL(path, document.baseURI)
+    const route = defaultRouteResolver(url)
+    expect(route).toBe(expected)
+  })
+})
+
+describe('DefaultRoutingProvider', () => {
+  describe('listenForRouteChanges', () => {
+    it('invokes the provided callback on pushState', () => {
+      const onSettle = jest.fn(() => 1234)
+      const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+
+      const routingProvider = new DefaultRoutingProvider()
+      const startRouteChangeSpan = jest.fn()
+
+      routingProvider.listenForRouteChanges(startRouteChangeSpan)
+
+      history.pushState({}, '', '/first-route')
+
+      expect(startRouteChangeSpan).toHaveBeenCalled()
+    })
+
+    it('invokes the provided callback on popstate', () => {
+      const onSettle = jest.fn(() => 1234)
+      const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+
+      const routingProvider = new DefaultRoutingProvider()
+      const startRouteChangeSpan = jest.fn()
+
+      history.pushState({}, '', '/second-route')
+
+      routingProvider.listenForRouteChanges(startRouteChangeSpan)
+
+      history.back()
+
+      expect(startRouteChangeSpan).toHaveBeenCalled()
+    })
+  })
+
+  describe('resolveRoute', () => {
+    it('uses the provided routeResolver function', () => {
+      const onSettle = jest.fn(() => 1234)
+      const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+      const routeResolver = jest.fn(() => 'new route')
+
+      const routingProvider = new DefaultRoutingProvider(routeResolver)
+
+      const url = new URL(window.location.href)
+      const route = routingProvider.resolveRoute(url)
+
+      expect(route).toBe('new route')
+      expect(routeResolver).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Goal

To prevent empty attributes in route change spans

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->