### PR TITLE
[PLAT-10605] Add end to end tests

### DIFF
--- a/test/browser/features/fixtures/packages/network-span-control/index.html
+++ b/test/browser/features/fixtures/packages/network-span-control/index.html
@@ -9,14 +9,12 @@
         <h1>network-span-control</h1>
 
         <button id="fetch-modified-url">fetch-modified-url</button>
-        <button id="fetch-no-url">fetch-no-url</button>
-        <button id="fetch-no-title">fetch-no-title</button>
         <button id="fetch-prevented">fetch-prevented</button>
         
         <button id="xhr-modified-url">xhr-modified-url</button>
-        <button id="xhr-no-url">xhr-no-url</button>
-        <button id="xhr-no-title">xhr-no-title</button>
         <button id="xhr-prevented">xhr-prevented</button>
+        
+        <button id="page-load-no-attributes">page-load-no-attributes</button>
 
         <script src="./dist/bundle.js" type="module"></script>
     </body>

--- a/test/browser/features/fixtures/packages/network-span-control/index.html
+++ b/test/browser/features/fixtures/packages/network-span-control/index.html
@@ -4,18 +4,14 @@
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
         <title>Network span control</title>
+        <script src="./dist/bundle.js" type="module"></script>
     </head>
     <body>
         <h1>network-span-control</h1>
-
         <button id="fetch-modified-url">fetch-modified-url</button>
         <button id="fetch-prevented">fetch-prevented</button>
-        
         <button id="xhr-modified-url">xhr-modified-url</button>
         <button id="xhr-prevented">xhr-prevented</button>
-        
         <button id="page-load-no-attributes">page-load-no-attributes</button>
-
-        <script src="./dist/bundle.js" type="module"></script>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/network-span-control/index.html
+++ b/test/browser/features/fixtures/packages/network-span-control/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
+        <title>Network span control</title>
+    </head>
+    <body>
+        <h1>network-span-control</h1>
+
+        <button id="fetch-modified-url">fetch-modified-url</button>
+        <button id="fetch-no-url">fetch-no-url</button>
+        <button id="fetch-no-title">fetch-no-title</button>
+        <button id="fetch-prevented">fetch-prevented</button>
+        
+        <button id="xhr-modified-url">xhr-modified-url</button>
+        <button id="xhr-no-url">xhr-no-url</button>
+        <button id="xhr-no-title">xhr-no-title</button>
+        <button id="xhr-prevented">xhr-prevented</button>
+
+        <script src="./dist/bundle.js" type="module"></script>
+    </body>
+</html>

--- a/test/browser/features/fixtures/packages/network-span-control/package.json
+++ b/test/browser/features/fixtures/packages/network-span-control/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "network-span-control",
+    "private": true,
+    "scripts": {
+        "build": "rollup --config ../rollup.config.mjs",
+        "clean": "rm -rf dist"
+    }
+}

--- a/test/browser/features/fixtures/packages/network-span-control/src/index.js
+++ b/test/browser/features/fixtures/packages/network-span-control/src/index.js
@@ -47,15 +47,6 @@ document.getElementById('xhr-prevented').addEventListener('click', () => {
   xhr.send()
 })
 
-document.getElementById('page-load-full-attributes').addEventListener('click', () => {
-  BugsnagPerformance.start({
-    ...commonConfig,
-    autoInstrumentFullPageLoads: true,
-    batchInactivityTimeoutMs: 5000,
-    maximumBatchSize: 13 
-  })
-})
-
 document.getElementById('page-load-no-attributes').addEventListener('click', () => {
   BugsnagPerformance.start({
     ...commonConfig,

--- a/test/browser/features/fixtures/packages/network-span-control/src/index.js
+++ b/test/browser/features/fixtures/packages/network-span-control/src/index.js
@@ -15,7 +15,7 @@ const commonConfig = {
 
 const modifiedUrlConfig = { 
   ...commonConfig,
-  networkRequestCallback: (networkRequestInfo) => ({ ...networkRequestInfo, url: 'not-your-ordinary-url' })
+  networkRequestCallback: (networkRequestInfo) => ({ ...networkRequestInfo, url: networkRequestInfo.url + '&not-your-ordinary-url=true' })
 }
 
 document.getElementById('fetch-modified-url').addEventListener('click', () => {

--- a/test/browser/features/fixtures/packages/network-span-control/src/index.js
+++ b/test/browser/features/fixtures/packages/network-span-control/src/index.js
@@ -46,3 +46,23 @@ document.getElementById('xhr-prevented').addEventListener('click', () => {
   xhr.open('GET', reflectEndpoint)
   xhr.send()
 })
+
+document.getElementById('page-load-full-attributes').addEventListener('click', () => {
+  BugsnagPerformance.start({
+    ...commonConfig,
+    autoInstrumentFullPageLoads: true,
+    batchInactivityTimeoutMs: 5000,
+    maximumBatchSize: 13 
+  })
+})
+
+document.getElementById('page-load-no-attributes').addEventListener('click', () => {
+  BugsnagPerformance.start({
+    ...commonConfig,
+    sendPageAttributes: { url: false, referrer: false, title: false },
+    autoInstrumentFullPageLoads: true,
+    batchInactivityTimeoutMs: 5000,
+    maximumBatchSize: 13
+  })
+})
+

--- a/test/browser/features/fixtures/packages/network-span-control/src/index.js
+++ b/test/browser/features/fixtures/packages/network-span-control/src/index.js
@@ -1,0 +1,48 @@
+import BugsnagPerformance from '@bugsnag/browser-performance'
+
+const parameters = new URLSearchParams(window.location.search)
+const apiKey = parameters.get('api_key')
+const endpoint = parameters.get('endpoint')
+const reflectEndpoint = '/reflect?status=200&delay_ms=0'
+
+const commonConfig = {
+  apiKey,
+  endpoint,
+  autoInstrumentFullPageLoads: false,
+  autoInstrumentNetworkRequests: true,
+  maximumBatchSize: 1,
+}
+
+const modifiedUrlConfig = { 
+  ...commonConfig,
+  networkRequestCallback: (networkRequestInfo) => ({ ...networkRequestInfo, url: 'not-your-ordinary-url' })
+}
+
+document.getElementById('fetch-modified-url').addEventListener('click', () => {
+  BugsnagPerformance.start(modifiedUrlConfig)
+  fetch(reflectEndpoint)
+})
+
+document.getElementById('xhr-modified-url').addEventListener('click', () => {
+  BugsnagPerformance.start(modifiedUrlConfig)
+  const xhr = new XMLHttpRequest()
+  xhr.open('GET', reflectEndpoint)
+  xhr.send()
+})
+
+const deliveryPreventedConfig = { 
+  ...commonConfig,
+  networkRequestCallback: () => null
+}
+
+document.getElementById('fetch-prevented').addEventListener('click', () => {
+  BugsnagPerformance.start(deliveryPreventedConfig)
+  fetch(reflectEndpoint)
+})
+
+document.getElementById('xhr-prevented').addEventListener('click', () => {
+  BugsnagPerformance.start(deliveryPreventedConfig)
+  const xhr = new XMLHttpRequest()
+  xhr.open('GET', reflectEndpoint)
+  xhr.send()
+})

--- a/test/browser/features/network-spans.feature
+++ b/test/browser/features/network-spans.feature
@@ -31,7 +31,7 @@ Feature: Network spans
         When I click the element "failed-requests"
         Then I should have received no spans
 
-    Scenario: Attributes can be modified by networkRequestCallback
+    Scenario: Attributes can be modified by networkRequestCallback using fetch
         Given I navigate to the test URL "/network-span-control"
         When I click the element "fetch-modified-url"
         And I wait to receive 1 traces
@@ -41,6 +41,7 @@ Feature: Network spans
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
 
+    Scenario: Attributes can be modified by networkRequestCallback using xhr
         Given I navigate to the test URL "/network-span-control"
         When I click the element "xhr-modified-url"
         And I wait to receive 1 traces
@@ -50,11 +51,12 @@ Feature: Network spans
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
 
-    Scenario: Delivery of spans can be prevented by networkRequestCallback
+    Scenario: Delivery of spans can be prevented by networkRequestCallback using fetch
         Given I navigate to the test URL "/network-span-control"
         When I click the element "fetch-prevented"
         Then I should have received no spans
 
+    Scenario: Delivery of spans can be prevented by networkRequestCallback using xhr
         Given I navigate to the test URL "/network-span-control"
         When I click the element "xhr-prevented"
         Then I should have received no spans

--- a/test/browser/features/network-spans.feature
+++ b/test/browser/features/network-spans.feature
@@ -38,7 +38,7 @@ Feature: Network spans
         
         Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
-        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "not-your-ordinary-url"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
 
         Given I navigate to the test URL "/network-span-control"
@@ -47,7 +47,7 @@ Feature: Network spans
         
         Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
-        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "not-your-ordinary-url"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
 
     Scenario: Delivery of spans can be prevented by networkRequestCallback

--- a/test/browser/features/network-spans.feature
+++ b/test/browser/features/network-spans.feature
@@ -30,3 +30,31 @@ Feature: Network spans
         Given I navigate to the test URL "/network-spans"
         When I click the element "failed-requests"
         Then I should have received no spans
+
+    Scenario: Attributes can be modified by networkRequestCallback
+        Given I navigate to the test URL "/network-span-control"
+        When I click the element "fetch-modified-url"
+        And I wait to receive 1 traces
+        
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "not-your-ordinary-url"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
+
+        Given I navigate to the test URL "/network-span-control"
+        When I click the element "xhr-modified-url"
+        And I wait to receive 1 traces
+        
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "not-your-ordinary-url"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
+
+    Scenario: Delivery of spans can be prevented by networkRequestCallback
+        Given I navigate to the test URL "/network-span-control"
+        When I click the element "fetch-prevented"
+        Then I should have received no spans
+
+        Given I navigate to the test URL "/network-span-control"
+        When I click the element "xhr-prevented"
+        Then I should have received no spans

--- a/test/browser/features/page-load-spans.feature
+++ b/test/browser/features/page-load-spans.feature
@@ -99,4 +99,11 @@ Feature: Page Load spans
             | bugsnag.browser.page.title                | stringValue  | New title       |
             | bugsnag.phase                             | stringValue  | TLS                   |
 
+    Scenario: Page load spans can have attributes dropped by sendPageAttributes config
+        Given I navigate to the test URL "/network-span-control"
+        When I click the element "page-load-no-attributes"
+        And I wait to receive 1 traces
 
+        Then a span named "[FullPageLoad]/network-span-control/" does not contain the attribute "bugsnag.browser.page.title"
+        And a span named "[FullPageLoad]/network-span-control/" does not contain the attribute "bugsnag.browser.page.url"
+        And a span named "[FullPageLoad]/network-span-control/" does not contain the attribute "bugsnag.browser.page.referrer"

--- a/test/browser/features/steps/browser-steps.rb
+++ b/test/browser/features/steps/browser-steps.rb
@@ -195,6 +195,18 @@ Then('if a span named {string} exists, it has a parent named {string}') do |chil
   end
 end
 
+Then('a span named {string} does not contain the attribute {string}') do |span_name, expected_attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  named_spans = spans.find_all { |span| span['name'].eql?(span_name) }
+  raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if named_spans.empty?
+
+  named_spans.each do |span|    
+    if span['attributes'].any? { |attribute| attribute['key'].eql?(expected_attribute) }
+      raise Test::Unit::AssertionFailedError.new "Attribute #{expected_attribute} was present on span #{span_name}"
+    end
+  end
+end
+
 module Maze
   module Driver
     class Browser


### PR DESCRIPTION
## Goal

Test network span control changes across supported browsers

## Testing

Add end to end tests for modifying urls and preventing delivery of spans using networkRequestCallback config option
Add end to end tests for removing span attributes using sendPageAttribute config option