### PR TITLE
[PLAT-10646] Oversized payload handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Added
-
-- (browser) Add `Bugsnag-Uncompressed-Content-Length` header to trace payloads [#280](https://github.com/bugsnag/bugsnag-js-performance/pull/280)
-
 ### Fixed
 
 - (browser) Do not retry delivery for oversized payloads when connection fails [#280](https://github.com/bugsnag/bugsnag-js-performance/pull/280)

--- a/packages/core/lib/delivery.ts
+++ b/packages/core/lib/delivery.ts
@@ -57,7 +57,6 @@ export interface TracePayload {
     // therefore it's 'undefined' when passed to delivery, which adds a value
     // immediately before initiating the request
     'Bugsnag-Sent-At'?: string
-    'Bugsnag-Uncompressed-Content-Length'?: string
   }
 }
 

--- a/packages/platforms/browser/lib/delivery.ts
+++ b/packages/platforms/browser/lib/delivery.ts
@@ -46,7 +46,6 @@ function createBrowserDeliveryFactory (
         const body = JSON.stringify(payload.body)
 
         payload.headers['Bugsnag-Sent-At'] = clock.date().toISOString()
-        payload.headers['Bugsnag-Uncompressed-Content-Length'] = body.length.toString()
 
         try {
           const response = await fetch(endpoint, {

--- a/packages/platforms/browser/tests/delivery.test.ts
+++ b/packages/platforms/browser/tests/delivery.test.ts
@@ -55,7 +55,6 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1:1',
-        'Bugsnag-Uncompressed-Content-Length': '342',
         'Content-Type': 'application/json',
         'Bugsnag-Sent-At': new Date(clock.timeOrigin + 1).toISOString()
       }
@@ -105,7 +104,6 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1:1',
-        'Bugsnag-Uncompressed-Content-Length': '342',
         'Content-Type': 'application/json',
         'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
       }
@@ -156,7 +154,6 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1:1',
-        'Bugsnag-Uncompressed-Content-Length': '342',
         'Content-Type': 'application/json',
         'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
       }
@@ -204,7 +201,6 @@ describe('Browser Delivery', () => {
       headers: {
         'Bugsnag-Api-Key': 'test-api-key',
         'Bugsnag-Span-Sampling': '1.0:0',
-        'Bugsnag-Uncompressed-Content-Length': '20',
         'Content-Type': 'application/json',
         'Bugsnag-Sent-At': expect.stringMatching(SENT_AT_FORMAT)
       }


### PR DESCRIPTION
## Goal

Do not retry oversized payloads when connection terminates, add content length header for future usage by the pipeline

## Changeset

- Remove all payloads that fail due to a terminated connection if they are oversized
- Add Bugsnag-Uncompressed-Content-Length to communicate size to server for improved handling in future
- Use the uncompressed size when calculating the 1mb limit

## Testing

Unit test to check an oversized payload is not retried when there is a connection error