### PR TITLE
[PLAT-10715] Allow route name in startRouteChangeSpan callback 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- (browser) Allow route name in startRouteChangeSpan callback [#284](https://github.com/bugsnag/bugsnag-js-performance/pull/284)
+
 ### Fixed
 
 - (browser) Do not retry delivery for oversized payloads when connection fails [#280](https://github.com/bugsnag/bugsnag-js-performance/pull/280)

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -38,14 +38,9 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
     const permittedAttributes = getPermittedAttributes(configuration.sendPageAttributes)
 
     configuration.routingProvider.listenForRouteChanges((url, trigger, options) => {
-      let absoluteUrl
-
-      if (url instanceof URL) {
-        absoluteUrl = url
-      } else {
+      if (!(url instanceof URL)) {
         try {
-          const stringUrl = String(url)
-          absoluteUrl = new URL(stringUrl)
+          url = new URL(url)
         } catch (err) {
           configuration.logger.warn('Invalid span options\n  - url should be a URL')
 
@@ -71,7 +66,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
         configuration.logger
       )
 
-      const route = configuration.routingProvider.resolveRoute(absoluteUrl) || defaultRouteResolver(absoluteUrl)
+      const route = configuration.routingProvider.resolveRoute(url) || defaultRouteResolver(url)
 
       // update the span name using the validated route
       cleanOptions.name += route

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -14,8 +14,7 @@ export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Locat
 
     listenForRouteChanges (startRouteChangeSpan: StartRouteChangeCallback) {
       addEventListener('popstate', (ev) => {
-        const url = new URL(location.href)
-        const span = startRouteChangeSpan(url, 'popstate')
+        const span = startRouteChangeSpan(location.href, 'popstate')
 
         onSettle((endTime) => {
           span.end(endTime)

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -1,5 +1,4 @@
 import { type OnSettle } from './on-settle'
-import getAbsoluteUrl from './request-tracker/url-helpers'
 import { type RouteResolver, type RoutingProvider, type StartRouteChangeCallback } from './routing-provider'
 
 export const defaultRouteResolver: RouteResolver = (url: URL) => url.pathname || '/'
@@ -26,8 +25,7 @@ export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Locat
         const url = args[2]
 
         if (url) {
-          const absoluteURL = new URL(getAbsoluteUrl(url.toString(), document.baseURI))
-          const span = startRouteChangeSpan(absoluteURL, 'pushState')
+          const span = startRouteChangeSpan(url, 'pushState')
 
           onSettle((endTime) => {
             span.end(endTime)

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -213,13 +213,20 @@ describe('RouteChangePlugin', () => {
       const span = routeChangeCallback(url, 'trigger')
       expect(jestLogger.warn).toHaveBeenCalledWith('Invalid span options\n  - url should be a URL')
 
+      expect(span).toStrictEqual({
+        id: '',
+        traceId: '',
+        isValid: expect.any(Function),
+        end: expect.any(Function)
+      })
+
+      expect(span.isValid()).toBe(false)
+
       span.end()
 
       await jest.runOnlyPendingTimersAsync()
 
-      expect(delivery).not.toHaveSentSpan(expect.objectContaining({
-        name: `[RouteChange]${String(url)}`
-      }))
+      expect(delivery.requests).toHaveLength(0)
     })
 
     const invalidTriggers: any[] = [


### PR DESCRIPTION
## Goal

To simplify usage of startRouteChangeSpan callback when creating a custom route resolver

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->