### PR TITLE
An empty string should not be considered a valid endpoint

### DIFF
--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -52,7 +52,7 @@ export const schema: CoreSchema = {
   endpoint: {
     defaultValue: 'https://otlp.bugsnag.com/v1/traces',
     message: 'should be a string',
-    validate: isString
+    validate: isStringWithLength
   },
   apiKey: {
     defaultValue: '',


### PR DESCRIPTION
## Goal

Updates the endpoint config validation to reject empty strings - discovered when creating the RN test fixture