### PR TITLE
[PLAT-10654] Generate and persist device ID

### DIFF
--- a/cuid.d.ts
+++ b/cuid.d.ts
@@ -1,5 +1,5 @@
 declare module '@bugsnag/cuid' {
-  declare function cuid (): string
+  function cuid (): string
 
   export default cuid
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18941,6 +18941,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/core-performance": "^1.0.0",
+        "@bugsnag/cuid": "^3.0.2",
         "@bugsnag/delivery-fetch-performance": "^1.0.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5091,6 +5091,18 @@
         "typescript": "^3 || ^4"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.19.2.tgz",
+      "integrity": "sha512-7jTQKbT3BdhFHQMnfElsLeeyVqNICv72lPKbeNHnNgLP9eH3+Yk1GFMWWb7A8qRMYianSmwmx1cYofNe9H9hLQ==",
+      "peer": true,
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || 0.60 - 0.72 || 1000.0.0"
+      }
+    },
     "node_modules/@react-native-community/cli": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-11.3.5.tgz",
@@ -13660,6 +13672,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "peer": true,
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -18948,6 +18981,7 @@
         "babel-preset-react-native": "^4.0.1"
       },
       "peerDependencies": {
+        "@react-native-async-storage/async-storage": "*",
         "react-native": "*"
       }
     },

--- a/packages/core/lib/persistence.ts
+++ b/packages/core/lib/persistence.ts
@@ -1,3 +1,5 @@
+import { isDeviceId, isPersistedProbabilty } from './validation'
+
 export interface PersistedProbability {
   value: number
   time: number
@@ -27,4 +29,26 @@ export class InMemoryPersistence implements Persistence {
   async save<K extends PersistenceKey> (key: K, value: PersistencePayloadMap[K]): Promise<void> {
     this.persistedItems.set(key, value)
   }
+}
+
+export function toPersistedPayload<K extends PersistenceKey> (
+  key: K,
+  raw: string
+): PersistencePayloadMap[K] | undefined {
+  switch (key) {
+    case 'bugsnag-sampling-probability': {
+      const json = JSON.parse(raw)
+
+      return isPersistedProbabilty(json)
+        ? json as PersistencePayloadMap[K]
+        : undefined
+    }
+
+    case 'bugsnag-anonymous-id':
+      return isDeviceId(raw)
+        ? raw as PersistencePayloadMap[K]
+        : undefined
+  }
+
+  key satisfies never
 }

--- a/packages/core/lib/validation.ts
+++ b/packages/core/lib/validation.ts
@@ -43,3 +43,10 @@ export const isSpanContext = (value: unknown): value is SpanContext =>
 export function isTime (value: unknown): value is Time {
   return isNumber(value) || value instanceof Date
 }
+
+// NOTE: this should be kept in sync with the notifier
+// https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-browser-device/device.js
+export function isDeviceId (raw: string): boolean {
+  // make sure the persisted value looks like a valid cuid
+  return /^c[a-z0-9]{20,32}$/.test(raw)
+}

--- a/packages/platforms/browser/lib/persistence.ts
+++ b/packages/platforms/browser/lib/persistence.ts
@@ -1,9 +1,9 @@
 import {
+  InMemoryPersistence,
+  toPersistedPayload,
   type Persistence,
   type PersistenceKey,
-  type PersistencePayloadMap,
-  isPersistedProbabilty,
-  InMemoryPersistence
+  type PersistencePayloadMap
 } from '@bugsnag/core-performance'
 
 interface LocalStorage {
@@ -26,38 +26,6 @@ function makeBrowserPersistence (window: WindowWithLocalStorage): Persistence {
 
   // store items in memory if localStorage isn't available
   return new InMemoryPersistence()
-}
-
-// NOTE: this should be kept in sync with the notifier
-// https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-browser-device/device.js
-function isDeviceId (raw: string): boolean {
-  // make sure the persisted value looks like a valid cuid
-  return /^c[a-z0-9]{20,32}$/.test(raw)
-}
-
-function toPersistedPayload<K extends PersistenceKey> (
-  key: K,
-  raw: string
-): PersistencePayloadMap[K] | undefined {
-  switch (key) {
-    case 'bugsnag-sampling-probability': {
-      const json = JSON.parse(raw)
-
-      return isPersistedProbabilty(json)
-        ? json as PersistencePayloadMap[K]
-        : undefined
-    }
-
-    case 'bugsnag-anonymous-id':
-      return isDeviceId(raw)
-        ? raw as PersistencePayloadMap[K]
-        : undefined
-
-    default: {
-      const _exhaustiveCheck: never = key
-      return _exhaustiveCheck
-    }
-  }
 }
 
 function toString<K extends PersistenceKey> (key: K, value: PersistencePayloadMap[K]): string {

--- a/packages/platforms/browser/tsconfig.json
+++ b/packages/platforms/browser/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../../tsconfig.json",
   "include": ["lib/*"],
   "compilerOptions": {
-    "types": ["./navigator-user-agent-data", "./cuid"]
+    "types": ["./navigator-user-agent-data", "../../../cuid"]
   }
 }

--- a/packages/platforms/react-native/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/packages/platforms/react-native/__mocks__/@react-native-async-storage/async-storage.ts
@@ -1,0 +1,1 @@
+export { default } from '@react-native-async-storage/async-storage/jest/async-storage-mock'

--- a/packages/platforms/react-native/lib/config.ts
+++ b/packages/platforms/react-native/lib/config.ts
@@ -1,4 +1,5 @@
 import {
+  isBoolean,
   isStringWithLength,
   schema,
   type ConfigOption,
@@ -9,11 +10,13 @@ import {
 export interface ReactNativeSchema extends CoreSchema {
   appName: ConfigOption<string>
   codeBundleId: ConfigOption<string>
+  generateAnonymousId: ConfigOption<boolean>
 }
 
 export interface ReactNativeConfiguration extends Configuration {
   appName: string
   codeBundleId?: string
+  generateAnonymousId: boolean
 }
 
 function createSchema (): ReactNativeSchema {
@@ -28,6 +31,11 @@ function createSchema (): ReactNativeSchema {
       defaultValue: '',
       message: 'should be a string',
       validate: isStringWithLength
+    },
+    generateAnonymousId: {
+      defaultValue: true,
+      message: 'should be true|false',
+      validate: isBoolean
     }
   }
 }

--- a/packages/platforms/react-native/lib/config.ts
+++ b/packages/platforms/react-native/lib/config.ts
@@ -16,7 +16,7 @@ export interface ReactNativeSchema extends CoreSchema {
 export interface ReactNativeConfiguration extends Configuration {
   appName: string
   codeBundleId?: string
-  generateAnonymousId: boolean
+  generateAnonymousId?: boolean
 }
 
 function createSchema (): ReactNativeSchema {

--- a/packages/platforms/react-native/lib/persistence.ts
+++ b/packages/platforms/react-native/lib/persistence.ts
@@ -5,17 +5,12 @@ import {
   toPersistedPayload,
   InMemoryPersistence
 } from '@bugsnag/core-performance'
-import type { AsyncStorageStatic } from '@react-native-async-storage/async-storage'
+import AsyncStorage, { type AsyncStorageStatic } from '@react-native-async-storage/async-storage'
 
 export function getReactNativePersistence (): Persistence {
   // use @react-native-async-storage/async-storage if it's installed
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const AsyncStorage = require('@react-native-async-storage/async-storage')
-
-    if (AsyncStorage) {
-      return new ReactNativePersistence(AsyncStorage)
-    }
+    if (AsyncStorage) return new ReactNativePersistence(AsyncStorage)
   } catch {}
 
   // store items in memory if @react-native-async-storage/async-storage isn't available

--- a/packages/platforms/react-native/lib/persistence.ts
+++ b/packages/platforms/react-native/lib/persistence.ts
@@ -8,8 +8,7 @@ import {
 import type { AsyncStorageStatic } from '@react-native-async-storage/async-storage'
 
 export function getReactNativePersistence (): Persistence {
-  // accessing localStorage can throw on some browsers, so we have to catch
-  // these errors and provide a fallback
+  // use @react-native-async-storage/async-storage if it's installed
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const AsyncStorage = require('@react-native-async-storage/async-storage')
@@ -19,7 +18,7 @@ export function getReactNativePersistence (): Persistence {
     }
   } catch {}
 
-  // store items in memory if localStorage isn't available
+  // store items in memory if @react-native-async-storage/async-storage isn't available
   return new InMemoryPersistence()
 }
 

--- a/packages/platforms/react-native/lib/persistence.ts
+++ b/packages/platforms/react-native/lib/persistence.ts
@@ -1,16 +1,23 @@
 import {
   InMemoryPersistence,
+  isObject,
   toPersistedPayload,
   type Persistence,
   type PersistenceKey,
   type PersistencePayloadMap
 } from '@bugsnag/core-performance'
-import AsyncStorage, { type AsyncStorageStatic } from '@react-native-async-storage/async-storage'
+import { type AsyncStorageStatic } from '@react-native-async-storage/async-storage'
+
+const isAsyncStorage = (value: unknown): value is AsyncStorageStatic => isObject(value) && typeof value.getItem === 'function' && typeof value.setItem === 'function'
 
 export function getReactNativePersistence (): Persistence {
   // use @react-native-async-storage/async-storage if it's installed
   try {
-    if (AsyncStorage) return new ReactNativePersistence(AsyncStorage)
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const asyncStorage = require('@react-native-async-storage/async-storage').default
+    if (isAsyncStorage(asyncStorage)) {
+      return new ReactNativePersistence(asyncStorage)
+    }
   } catch {}
 
   // store items in memory if @react-native-async-storage/async-storage isn't available

--- a/packages/platforms/react-native/lib/persistence.ts
+++ b/packages/platforms/react-native/lib/persistence.ts
@@ -39,7 +39,8 @@ class ReactNativePersistence implements Persistence {
 
   async save<K extends PersistenceKey> (key: K, value: PersistencePayloadMap[K]): Promise<void> {
     try {
-      this.storage.setItem(key, JSON.stringify(value))
+      const stringValue = typeof value === 'string' ? value : JSON.stringify(value)
+      this.storage.setItem(key, stringValue)
     } catch {}
   }
 }

--- a/packages/platforms/react-native/lib/persistence.ts
+++ b/packages/platforms/react-native/lib/persistence.ts
@@ -1,0 +1,44 @@
+import {
+  type Persistence,
+  type PersistenceKey,
+  type PersistencePayloadMap,
+  toPersistedPayload,
+  InMemoryPersistence
+} from '@bugsnag/core-performance'
+import type { AsyncStorageStatic } from '@react-native-async-storage/async-storage'
+
+export function getReactNativePersistence (): Persistence {
+  // accessing localStorage can throw on some browsers, so we have to catch
+  // these errors and provide a fallback
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const AsyncStorage = require('@react-native-async-storage/async-storage')
+
+    if (AsyncStorage) {
+      return new ReactNativePersistence(AsyncStorage)
+    }
+  } catch {}
+
+  // store items in memory if localStorage isn't available
+  return new InMemoryPersistence()
+}
+
+class ReactNativePersistence implements Persistence {
+  constructor (private readonly storage: AsyncStorageStatic) {}
+
+  async load<K extends PersistenceKey> (key: K): Promise<PersistencePayloadMap[K] | undefined> {
+    try {
+      const raw = await this.storage.getItem(key)
+
+      if (raw) {
+        return toPersistedPayload(key, raw)
+      }
+    } catch {}
+  }
+
+  async save<K extends PersistenceKey> (key: K, value: PersistencePayloadMap[K]): Promise<void> {
+    try {
+      this.storage.setItem(key, JSON.stringify(value))
+    } catch {}
+  }
+}

--- a/packages/platforms/react-native/lib/persistence.ts
+++ b/packages/platforms/react-native/lib/persistence.ts
@@ -1,28 +1,19 @@
 import {
+  toPersistedPayload,
   type Persistence,
   type PersistenceKey,
-  type PersistencePayloadMap,
-  toPersistedPayload,
-  InMemoryPersistence
+  type PersistencePayloadMap
 } from '@bugsnag/core-performance'
-import AsyncStorage, { type AsyncStorageStatic } from '@react-native-async-storage/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
 export function getReactNativePersistence (): Persistence {
-  // use @react-native-async-storage/async-storage if it's installed
-  try {
-    if (AsyncStorage) return new ReactNativePersistence(AsyncStorage)
-  } catch {}
-
-  // store items in memory if @react-native-async-storage/async-storage isn't available
-  return new InMemoryPersistence()
+  return new ReactNativePersistence()
 }
 
 class ReactNativePersistence implements Persistence {
-  constructor (private readonly storage: AsyncStorageStatic) {}
-
   async load<K extends PersistenceKey> (key: K): Promise<PersistencePayloadMap[K] | undefined> {
     try {
-      const raw = await this.storage.getItem(key)
+      const raw = await AsyncStorage.getItem(key)
 
       if (raw) {
         return toPersistedPayload(key, raw)
@@ -32,7 +23,7 @@ class ReactNativePersistence implements Persistence {
 
   async save<K extends PersistenceKey> (key: K, value: PersistencePayloadMap[K]): Promise<void> {
     try {
-      this.storage.setItem(key, JSON.stringify(value))
+      AsyncStorage.setItem(key, JSON.stringify(value))
     } catch {}
   }
 }

--- a/packages/platforms/react-native/lib/resource-attributes-source.ts
+++ b/packages/platforms/react-native/lib/resource-attributes-source.ts
@@ -1,8 +1,15 @@
 import { ResourceAttributes, type InternalConfiguration } from '@bugsnag/core-performance'
 import { type ReactNativeConfiguration } from './config'
 import { Platform } from 'react-native'
+import { getReactNativePersistence } from './persistence'
+import cuid from '@bugsnag/cuid'
+
+const persistence = getReactNativePersistence()
 
 function resourceAttributesSource (config: InternalConfiguration<ReactNativeConfiguration>) {
+  let getDeviceId: Promise<string> | undefined
+  let deviceId: string | undefined
+
   const attributes = new ResourceAttributes(
     config.releaseStage,
     config.appVersion,
@@ -14,7 +21,6 @@ function resourceAttributesSource (config: InternalConfiguration<ReactNativeConf
   attributes.set('os.name', Platform.OS)
   attributes.set('os.version', Platform.Version.toString())
   attributes.set('service.name', config.appName)
-  attributes.set('device.id', 'unknown')
 
   if (config.codeBundleId) {
     attributes.set('bugsnag.app.code_bundle_id', config.codeBundleId)
@@ -25,6 +31,42 @@ function resourceAttributesSource (config: InternalConfiguration<ReactNativeConf
 
   // @ts-expect-error Platform.constants.Model exists on android devices
   attributes.set('device.model.identifier', Platform.select({ android: Platform.constants.Model, ios: 'unknown', default: 'unknown' }))
+
+  if (config.generateAnonymousId) {
+    // ensure we only load/generate the anonymous ID once no matter how many
+    // times we're called, otherwise we could generate different IDs on
+    // different calls as cuids are partly time based
+    if (!getDeviceId) {
+      getDeviceId = persistence.load('bugsnag-anonymous-id')
+        .then(maybeAnonymousId => {
+          // use the persisted value or generate a new ID
+          const anonymousId = maybeAnonymousId || cuid()
+
+          // if there was no persisted value, save the newly generated ID
+          if (!maybeAnonymousId) {
+            persistence.save('bugsnag-anonymous-id', anonymousId)
+          }
+
+          // store the device ID so we can set it synchronously in future
+          deviceId = anonymousId
+
+          return deviceId
+        })
+    }
+
+    if (deviceId) {
+      // set device ID synchronously if it's already available
+      attributes.set('device.id', deviceId)
+    } else {
+      // otherwise add it when the promise resolves
+      return getDeviceId
+        .then(deviceId => {
+          attributes.set('device.id', deviceId)
+
+          return attributes
+        })
+    }
+  }
 
   return Promise.resolve(attributes)
 }

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@bugsnag/core-performance": "^1.0.0",
-    "@bugsnag/delivery-fetch-performance": "^1.0.0"
+    "@bugsnag/delivery-fetch-performance": "^1.0.0",
+    "@bugsnag/cuid": "^3.0.2"
   },
   "devDependencies": {
     "babel-preset-react-native": "^4.0.1"

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -23,7 +23,8 @@
     "babel-preset-react-native": "^4.0.1"
   },
   "peerDependencies": {
-    "react-native": "*"
+    "react-native": "*",
+    "@react-native-async-storage/async-storage": "*"
   },
   "scripts": {
     "build": "rollup --config",

--- a/packages/platforms/react-native/rollup.config.mjs
+++ b/packages/platforms/react-native/rollup.config.mjs
@@ -2,5 +2,5 @@ import fs from 'fs'
 import createRollupConfig from '../../../.rollup/index.mjs'
 
 export default createRollupConfig({
-  external: ['@bugsnag/delivery-fetch-performance', 'react-native', '@bugsnag/cuid'],
+  external: ['@bugsnag/delivery-fetch-performance', 'react-native', '@bugsnag/cuid', '@react-native-async-storage/async-storage'],
 })

--- a/packages/platforms/react-native/rollup.config.mjs
+++ b/packages/platforms/react-native/rollup.config.mjs
@@ -2,5 +2,5 @@ import fs from 'fs'
 import createRollupConfig from '../../../.rollup/index.mjs'
 
 export default createRollupConfig({
-  external: ['@bugsnag/delivery-fetch-performance'],
+  external: ['@bugsnag/delivery-fetch-performance', 'react-native', '@bugsnag/cuid'],
 })

--- a/packages/platforms/react-native/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/react-native/tests/resource-attributes-source.test.ts
@@ -6,56 +6,24 @@ describe('resourceAttributesSource', () => {
   it('includes all expected attributes (iOS)', async () => {
     const configuraiton = createConfiguration<ReactNativeConfiguration>({ releaseStage: 'test', appVersion: '1.0.0', appName: 'Test App', codeBundleId: '12345678' })
     const resourceAttributes = await resourceAttributesSource(configuraiton)
+    const jsonAttributes = resourceAttributes.toJson()
 
-    expect(resourceAttributes.toJson()).toEqual(expect.arrayContaining([
-      {
-        key: 'bugsnag.app.code_bundle_id',
-        value: { stringValue: '12345678' }
-      },
-      {
-        key: 'deployment.environment',
-        value: { stringValue: 'test' }
-      },
-      {
-        key: 'device.id',
-        value: { stringValue: 'unknown' }
-      },
-      {
-        key: 'device.manufacturer',
-        value: { stringValue: 'Apple' }
-      },
-      {
-        key: 'device.model.identifier',
-        value: { stringValue: 'unknown' }
-      },
-      {
-        key: 'os.type',
-        value: { stringValue: 'darwin' }
-      },
-      {
-        key: 'os.name',
-        value: { stringValue: 'ios' }
-      },
-      {
-        key: 'os.version',
-        value: { stringValue: '1.2.3' }
-      },
-      {
-        key: 'service.name',
-        value: { stringValue: 'Test App' }
-      },
-      {
-        key: 'service.version',
-        value: { stringValue: '1.0.0' }
-      },
-      {
-        key: 'telemetry.sdk.name',
-        value: { stringValue: 'bugsnag.performance.reactnative' }
-      },
-      {
-        key: 'telemetry.sdk.version',
-        value: { stringValue: '__VERSION__' }
-      }
-    ]))
+    function getAttribute (key: string) {
+      const matchingAttribute = jsonAttributes.find(attribute => attribute?.key === key)
+      return matchingAttribute?.value
+    }
+
+    expect(getAttribute('bugsnag.app.code_bundle_id')).toStrictEqual({ stringValue: '12345678' })
+    expect(getAttribute('deployment.environment')).toStrictEqual({ stringValue: 'test' })
+    expect(getAttribute('device.id')).toStrictEqual({ stringValue: expect.stringMatching(/^c[a-z0-9]{20,32}$/) })
+    expect(getAttribute('device.manufacturer')).toStrictEqual({ stringValue: 'Apple' })
+    expect(getAttribute('device.model.identifier')).toStrictEqual({ stringValue: 'unknown' })
+    expect(getAttribute('os.type')).toStrictEqual({ stringValue: 'darwin' })
+    expect(getAttribute('os.name')).toStrictEqual({ stringValue: 'ios' })
+    expect(getAttribute('os.version')).toStrictEqual({ stringValue: '1.2.3' })
+    expect(getAttribute('service.name')).toStrictEqual({ stringValue: 'Test App' })
+    expect(getAttribute('service.version')).toStrictEqual({ stringValue: '1.0.0' })
+    expect(getAttribute('telemetry.sdk.name')).toStrictEqual({ stringValue: 'bugsnag.performance.reactnative' })
+    expect(getAttribute('telemetry.sdk.version')).toStrictEqual({ stringValue: '__VERSION__' })
   })
 })

--- a/packages/platforms/react-native/tsconfig.json
+++ b/packages/platforms/react-native/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "../../../tsconfig.json",
   "include": [
     "lib/*"
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["../../../cuid"]
+  }
 }

--- a/test/react-native/features/fixtures/performance-scenarios/scenarios/ManualSpanScenario.js
+++ b/test/react-native/features/fixtures/performance-scenarios/scenarios/ManualSpanScenario.js
@@ -5,7 +5,7 @@ import BugsnagPerformance from '@bugsnag/react-native-performance'
 export const ManualSpanScenario = (endpoint, apiKey) => {
   const App = () => {
     useEffect(() => {
-      BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, appName: 'com.bugsnag.reactnative.performance' })
+      BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, appName: 'com.bugsnag.reactnative.performance', appVersion: '1.2.3' })
       BugsnagPerformance.startSpan('ManualSpanScenario').end()
     }, [])
 

--- a/test/react-native/features/manual-spans.feature
+++ b/test/react-native/features/manual-spans.feature
@@ -19,8 +19,9 @@ Scenario: Manual Spans can be logged
 
   And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
   And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
-  And the trace payload field "resourceSpans.0.resource" string attribute "device.id" equals "unknown"
+  And the trace payload field "resourceSpans.0.resource" string attribute "device.id" matches the regex "^c[a-z0-9]{20,32}$"
   And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.reactnative.performance"
+  And the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.2.3"
 
   And the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals the stored value "os.type"
   And the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals the stored value "os.name"


### PR DESCRIPTION
## Goal

Generate and persist device IDs using `@bugsnag/cuid` and `async-storage`

## Changeset

- Move `cuid` ts declaration to root and share between required ts configs
- Move persisted payload validation to core package to share between browser and react native
- Add config option to react-native
- Add persistence to react-native using `async-storage` falling back to in-memory persistence when not available

## Testing

Test `device.id` attribute matches the expected regex in resource attribute source unit tests