### PR TITLE
Ensure full page load spans always have a route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - (browser) Do not retry delivery for oversized payloads when connection fails [#280](https://github.com/bugsnag/bugsnag-js-performance/pull/280)
+- (browser) Fallback to the default route resolver for full page load spans if the configured `routingProvider` does not return a route [#300](https://github.com/bugsnag/bugsnag-js-performance/pull/300)
 
 ## v1.0.0 (2023-07-27)
 

--- a/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/full-page-load-plugin.ts
@@ -10,6 +10,7 @@ import { type PerformanceWithTiming } from '../on-settle/load-event-end-settler'
 import { getPermittedAttributes } from '../send-page-attributes'
 import { type WebVitals } from '../web-vitals'
 import { instrumentPageLoadPhaseSpans } from './page-load-phase-spans'
+import { defaultRouteResolver } from '../default-routing-provider'
 
 export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
   private readonly spanFactory: SpanFactory<BrowserConfiguration>
@@ -60,7 +61,10 @@ export class FullPageLoadPlugin implements Plugin<BrowserConfiguration> {
     this.onSettle((endTime: number) => {
       if (this.wasBackgrounded) return
 
-      const route = configuration.routingProvider.resolveRoute(url)
+      // ensure there's always a route on this span by falling back to the
+      // default route resolver - the pipeline will ignore page load spans that
+      // don't have a route
+      const route = configuration.routingProvider.resolveRoute(url) || defaultRouteResolver(url)
       span.name += route
 
       instrumentPageLoadPhaseSpans(this.spanFactory, this.performance, route, span)


### PR DESCRIPTION
## Goal

For route change spans we fallback to the default route resolver when a configured `routingProvider` does not return a route. However we don't do the same thing for full page load spans

This PR unifies this logic so that full page load spans will also always have a route