### PR TITLE
Prevent React Native clock from sticking

### DIFF
--- a/packages/platforms/react-native/lib/clock.ts
+++ b/packages/platforms/react-native/lib/clock.ts
@@ -5,28 +5,15 @@ interface Performance {
 }
 
 const createClock = (performance: Performance): Clock => {
-  // Prevent clock from running backwards
-  // React Native 0.68 introduced a bug where `performance.now` was no longer monotonic https://github.com/facebook/react-native/issues/33977
-  // NOTE: If our new "now" is less than the previous "now" - we will use the previous value.
-  let previousClock = performance.now()
-  const currentPerfTime = () => {
-    const newClock = performance.now()
-    if (newClock > previousClock) {
-      previousClock = newClock
-      return newClock
-    }
-    return previousClock
-  }
-
   // Measurable "monotonic" time
   // In React Native, `performance.now` often returns some very high values, but does not expose the `timeOrigin` it uses to calculate what "now" is.
   // by storing the value of `performance.now` when the app starts, we can remove that value from any further `.now` calculations, and add it to the current "wall time" to get a useful timestamp.
-  const startPerfTime = currentPerfTime()
+  const startPerfTime = performance.now()
   const startWallTime = Date.now()
 
   return {
-    now: currentPerfTime,
-    date: () => new Date(currentPerfTime() - startPerfTime + startWallTime),
+    now: performance.now,
+    date: () => new Date(performance.now() - startPerfTime + startWallTime),
     convert: (date: Date) => date.getTime() - startWallTime + startPerfTime,
     // convert milliseconds since timeOrigin to full timestamp
     toUnixTimestampNanoseconds: (time: number) =>


### PR DESCRIPTION
## Goal

Remove the logic that prevents the clock from moving backwards in react native, if the clock were to drift back by a significant amount (say, from changing timezone) - every span in the future would keep using exactly the same timestamp.