### PR TITLE
Add wrapperComponentProvider config option (React Native)

### DIFF
--- a/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
+++ b/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
@@ -40,15 +40,24 @@ export class AppStartPlugin implements Plugin<ReactNativeConfiguration> {
     appStartSpan.setAttribute('bugsnag.span.category', 'app_start')
     appStartSpan.setAttribute('bugsnag.app_start.type', 'ReactNativeInit')
 
-    const Wrapper = ({children}: WrapperProps) => {
+    const AppStartWrapper = ({children}: WrapperProps) => {
       useEffect(() => {
         this.spanFactory.endSpan(appStartSpan, this.clock.now())
       }, [])
       return (<>{children}</>)
     }
 
-    const instrumentedComponentProvider: WrapperComponentProvider = () => ({ children }) => {
-      return (<Wrapper>{children}</Wrapper>)
+    const instrumentedComponentProvider: WrapperComponentProvider = (appParams) => ({ children }) => {
+      if (configuration.wrapperComponentProvider) {
+        const WrapperComponent = configuration.wrapperComponentProvider(appParams)
+        return (
+          <AppStartWrapper>
+            <WrapperComponent>{children}</WrapperComponent>
+          </AppStartWrapper>
+        )
+      }
+
+      return (<AppStartWrapper>{children}</AppStartWrapper>)
     }
 
     this.appRegistry.setWrapperComponentProvider(instrumentedComponentProvider)

--- a/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
+++ b/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
@@ -12,6 +12,9 @@ type WrapperProps = {
   children: ReactNode
 }
 
+export const isWrapperComponentProvider = (value: unknown): value is WrapperComponentProvider | null => 
+  value === null || typeof value === 'function'
+
 export class AppStartPlugin implements Plugin<ReactNativeConfiguration> {
   private readonly appStartTime: number
   private readonly spanFactory: SpanFactory<ReactNativeConfiguration>

--- a/packages/platforms/react-native/lib/config.ts
+++ b/packages/platforms/react-native/lib/config.ts
@@ -6,12 +6,15 @@ import {
   type Configuration,
   type CoreSchema
 } from '@bugsnag/core-performance'
+import { type WrapperComponentProvider } from 'react-native'
+import { isWrapperComponentProvider } from './auto-instrumentation/app-start-plugin'
 
 export interface ReactNativeSchema extends CoreSchema {
   appName: ConfigOption<string>
   codeBundleId: ConfigOption<string>
   generateAnonymousId: ConfigOption<boolean>
   autoInstrumentAppStarts: ConfigOption<boolean>
+  wrapperComponentProvider: ConfigOption<WrapperComponentProvider | null>
 }
 
 export interface ReactNativeConfiguration extends Configuration {
@@ -19,6 +22,7 @@ export interface ReactNativeConfiguration extends Configuration {
   codeBundleId?: string
   generateAnonymousId?: boolean
   autoInstrumentAppStarts?: boolean
+  wrapperComponentProvider?: WrapperComponentProvider | null
 }
 
 function createSchema (): ReactNativeSchema {
@@ -43,6 +47,11 @@ function createSchema (): ReactNativeSchema {
       defaultValue: true,
       message: 'should be true|false',
       validate: isBoolean
+    },
+    wrapperComponentProvider: {
+      defaultValue: null,
+      message: 'should be a function',
+      validate: isWrapperComponentProvider
     }
   }
 }

--- a/packages/platforms/react-native/tests/config.test.ts
+++ b/packages/platforms/react-native/tests/config.test.ts
@@ -84,4 +84,38 @@ describe('ReactNativeSchema', () => {
       })
     })
   })
+
+  describe('wrapperComponentProvider', () => {
+    it('defaults to null', () => {
+      expect(schema.wrapperComponentProvider.defaultValue).toBe(null)
+    })
+
+    const functionOrNullValidation = [
+      { expected: true, value: () => 123 },
+      { expected: true, value: null },
+      { expected: false, value: undefined },
+      { expected: false, value: true },
+      { expected: false, value: false },
+      { expected: false, value: 123 },
+      { expected: false, value: BigInt(9007199254740991) },
+      { expected: false, value: '' },
+      { expected: false, value: /a/ },
+      { expected: false, value: {} },
+      { expected: false, value: { a: 1, b: 2 } },
+      { expected: false, value: [] },
+      { expected: false, value: [[]] },
+      { expected: false, value: [['a']] },
+      { expected: false, value: ['a', /b/, 1] },
+      { expected: false, value: Symbol('test') },
+      { expected: false, value: 'string' }
+    ]
+
+    describe('.validate()', () => {
+      it.each(functionOrNullValidation)('returns $expected for the value $value', ({ expected, value }) => {
+        const schema = createSchema()
+        const validate = schema.wrapperComponentProvider.validate
+        expect(validate(value)).toBe(expected)
+      })
+    })
+  })
 })

--- a/test/react-native/features/app-start-spans.feature
+++ b/test/react-native/features/app-start-spans.feature
@@ -29,3 +29,36 @@ Scenario: App starts are automatically instrumented
   And the trace payload field "resourceSpans.0.resource" string attribute "os.version" exists
   And the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
   And the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
+
+Scenario: A wrapper component provider can be provided as a config option
+  When I run 'WrapperComponentProviderScenario'
+  Given the element "wrapper-component" is present within 60 seconds 
+  And the element "app-component" is present within 60 seconds 
+
+  And I wait to receive a sampling request
+  And I wait for 1 span
+
+  # Check the initial probability request
+  Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
+  
+  And the trace "Bugsnag-Span-Sampling" header equals "1:1"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[AppStart/ReactNativeInit]"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "app_start"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.app_start.type" equals "ReactNativeInit"
+
+  And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
+  And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
+  And the trace payload field "resourceSpans.0.resource" string attribute "device.id" matches the regex "^c[a-z0-9]{20,32}$"
+  And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.reactnative.performance"
+
+  And the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals the stored value "os.type"
+  And the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals the stored value "os.name"
+
+  And the trace payload field "resourceSpans.0.resource" string attribute "os.version" exists
+  And the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
+  And the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/WrapperComponentProviderScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/WrapperComponentProviderScenario.js
@@ -1,0 +1,30 @@
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+
+const wrapperComponentProvider = () =>  ({ children }) => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text accessibilityLabel='wrapper-component'>WrapperComponentProviderScenario</Text>
+        {children}
+      </View>
+    </SafeAreaView>
+  )
+}
+
+export const config = {
+  maximumBatchSize: 1,
+  wrapperComponentProvider
+}
+
+export const App = () => {
+  return (<Text accessibilityLabel='app-component'>Wrapped App Component</Text>)
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -1,2 +1,3 @@
 export * as ManualSpanScenario from './ManualSpanScenario'
 export * as AppStartScenario from './AppStartScenario'
+export * as WrapperComponentProviderScenario from './WrapperComponentProviderScenario'


### PR DESCRIPTION
## Goal

React native's `AppRegistry` only permits one `WrapperComponentProvider` per app and there isn't a way to retrieve an existing one.

This PR adds a new configuration option named `wrapperComponentProvider` which allows users to provide their own `WrapperComponentProvider` if they are already using one. 

If provided, the app start wrapper component will be used to wrap the user-provided wrapper component, so that the app start instrumentation wrapper is still at the root.

## Testing

This is difficult to unit test effectively - relies instead on a new e2e test scenario that asserts both that the the app start is instrumented and the supplied wrapper component is rendered as expected 