### PR TITLE
[PLAT-10809] Add bugsnag.app.in_foreground span attribute

### DIFF
--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -1,17 +1,18 @@
 import { InMemoryPersistence, createClient } from '@bugsnag/core-performance'
 import createFetchDeliveryFactory from '@bugsnag/delivery-fetch-performance'
+import { AppRegistry, AppState } from 'react-native'
+import { AppStartPlugin } from './auto-instrumentation/app-start-plugin'
 import createClock from './clock'
 import createSchema from './config'
 import idGenerator from './id-generator'
-import resourceAttributesSource from './resource-attributes-source'
-import spanAttributesSource from './span-attributes-source'
-import { AppStartPlugin } from './auto-instrumentation/app-start-plugin'
-import { AppRegistry } from 'react-native'
 import { platformExtensions } from './platform-extensions'
+import resourceAttributesSource from './resource-attributes-source'
+import { createSpanAttributesSource } from './span-attributes-source'
 
 const clock = createClock(performance)
 const appStartTime = clock.now()
 const deliveryFactory = createFetchDeliveryFactory(fetch, clock)
+const spanAttributesSource = createSpanAttributesSource(AppState)
 
 const BugsnagPerformance = createClient({
   backgroundingListener: { onStateChange: () => {} },

--- a/packages/platforms/react-native/lib/span-attributes-source.ts
+++ b/packages/platforms/react-native/lib/span-attributes-source.ts
@@ -1,9 +1,16 @@
 import { type SpanAttributesSource } from '@bugsnag/core-performance'
 import { type ReactNativeConfiguration } from './config'
+import { type AppStateStatic } from 'react-native'
 
-export const spanAttributesSource: SpanAttributesSource<ReactNativeConfiguration> = {
-  configure (configuration) {},
-  requestAttributes (span) {}
+export function createSpanAttributesSource (appState: AppStateStatic) {
+  const spanAttributesSource: SpanAttributesSource<ReactNativeConfiguration> = {
+    configure (configuration) {
+
+    },
+    requestAttributes (span) {
+      span.setAttribute('bugsnag.app.in_foreground', appState.currentState === 'active')
+    }
+  }
+
+  return spanAttributesSource
 }
-
-export default spanAttributesSource

--- a/packages/platforms/react-native/tests/span-attributes-source.test.ts
+++ b/packages/platforms/react-native/tests/span-attributes-source.test.ts
@@ -1,0 +1,41 @@
+import { InMemoryDelivery, VALID_API_KEY, createTestClient } from '@bugsnag/js-performance-test-utilities'
+import { createSpanAttributesSource } from '../lib/span-attributes-source'
+import { type AppStateStatus } from 'react-native/Libraries/AppState/AppState'
+
+jest.useFakeTimers()
+
+describe('spanAttributesSource', () => {
+  describe('.requestAttributes()', () => {
+    it('sets the bugsnag.app.in_foreground attribute', async () => {
+      const mockAppState = { currentState: 'active' as AppStateStatus, isAvailable: true, addEventListener: jest.fn() }
+      const spanAttributesSource = createSpanAttributesSource(mockAppState)
+      const delivery = new InMemoryDelivery()
+      const testClient = createTestClient({ spanAttributesSource, deliveryFactory: () => delivery })
+
+      testClient.start({ apiKey: VALID_API_KEY, appName: 'test' })
+      testClient.startSpan('foreground span').end()
+
+      await jest.runOnlyPendingTimersAsync()
+
+      expect(delivery).toHaveSentSpan(expect.objectContaining({
+        name: 'foreground span',
+        attributes: expect.arrayContaining([
+          { key: 'bugsnag.app.in_foreground', value: { boolValue: true } }
+        ])
+      }))
+
+      mockAppState.currentState = 'background'
+
+      testClient.startSpan('background span').end()
+
+      await jest.runOnlyPendingTimersAsync()
+
+      expect(delivery).toHaveSentSpan(expect.objectContaining({
+        name: 'background span',
+        attributes: expect.arrayContaining([
+          { key: 'bugsnag.app.in_foreground', value: { boolValue: false } }
+        ])
+      }))
+    })
+  })
+})

--- a/test/react-native/features/app-start-spans.feature
+++ b/test/react-native/features/app-start-spans.feature
@@ -17,6 +17,7 @@ Scenario: App starts are automatically instrumented
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "app_start"
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.app_start.type" equals "ReactNativeInit"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.app.in_foreground" is true
 
   And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
   And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/BackgroundSpanScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/BackgroundSpanScenario.js
@@ -1,0 +1,23 @@
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+import React from 'react'
+import { AppState, Text, View } from 'react-native'
+
+export const config = {
+  maximumBatchSize: 1,
+  autoInstrumentAppStarts: false,
+  appVersion: '1.2.3'
+}
+
+AppState.addEventListener('change', (state) => {
+    if (state === 'background') {
+        BugsnagPerformance.startSpan('BackgroundSpan').end()
+    }
+})
+
+export const App = () => {
+  return (
+    <View>
+        <Text>BackgroundSpanScenario</Text>
+    </View>
+  )
+}

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -1,5 +1,6 @@
 export * as AppStartScenario from './AppStartScenario'
+export * as BackgroundSpanScenario from './BackgroundSpanScenario'
 export * as ManualSpanScenario from './ManualSpanScenario'
+export * as NavigationSpanScenario from './NavigationSpanScenario'
 export * as NestedSpansScenario from './NestedSpansScenario'
 export * as WrapperComponentProviderScenario from './WrapperComponentProviderScenario'
-export * as NavigationSpanScenario from './NavigationSpanScenario'

--- a/test/react-native/features/manual-spans.feature
+++ b/test/react-native/features/manual-spans.feature
@@ -16,6 +16,7 @@ Scenario: Manual Spans can be logged
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.app.in_foreground" is true
 
   And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
   And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"

--- a/test/react-native/features/manual-spans.feature
+++ b/test/react-native/features/manual-spans.feature
@@ -1,32 +1,64 @@
 Feature: Manual spans
 
-Scenario: Manual Spans can be logged
-  When I run 'ManualSpanScenario'
-  And I wait to receive a sampling request
-  And I wait for 1 span
+  Scenario: Manual Spans can be logged
+    When I run 'ManualSpanScenario'
+    And I wait to receive a sampling request
+    And I wait for 1 span
 
-  # Check the initial probability request
-  Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
+    # Check the initial probability request
+    Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-  And the trace "Bugsnag-Span-Sampling" header equals "1:1"
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ManualSpanScenario"
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
-  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.app.in_foreground" is true
+    And the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "ManualSpanScenario"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.app.in_foreground" is true
 
-  And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
-  And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
-  And the trace payload field "resourceSpans.0.resource" string attribute "device.id" matches the regex "^c[a-z0-9]{20,32}$"
-  And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.reactnative.performance"
-  And the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.2.3"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
+    And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
+    And the trace payload field "resourceSpans.0.resource" string attribute "device.id" matches the regex "^c[a-z0-9]{20,32}$"
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.2.3"
 
-  And the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals the stored value "os.type"
-  And the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals the stored value "os.name"
+    And the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals the stored value "os.type"
+    And the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals the stored value "os.name"
 
-  And the trace payload field "resourceSpans.0.resource" string attribute "os.version" exists
-  And the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
-  And the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
+    And the trace payload field "resourceSpans.0.resource" string attribute "os.version" exists
+    And the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
+    And the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
+
+  Scenario: Spans can be logged from the background
+    When I run 'BackgroundSpanScenario'
+    And I wait to receive a sampling request
+    And I send the app to the background
+    And I wait for 1 span
+
+    # Check the initial probability request
+    Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
+
+    And the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "BackgroundSpan"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.app.in_foreground" is false
+
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
+    And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"
+    And the trace payload field "resourceSpans.0.resource" string attribute "device.id" matches the regex "^c[a-z0-9]{20,32}$"
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.2.3"
+
+    And the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals the stored value "os.type"
+    And the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals the stored value "os.name"
+
+    And the trace payload field "resourceSpans.0.resource" string attribute "os.version" exists
+    And the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
+    And the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists

--- a/test/react-native/features/navigation-spans.feature
+++ b/test/react-native/features/navigation-spans.feature
@@ -17,6 +17,7 @@ Scenario: Manual Navigation Spans can be logged
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "navigation"
   And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.route" equals "NavigationSpanScenario"
+  And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" bool attribute "bugsnag.app.in_foreground" is true
 
   And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
   And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"


### PR DESCRIPTION
## Goal

Add a new `bugsnag.app.in_foreground` span attribute

## Design

Use `ReactNative.AppState.currentState` to get the status of a span when it is created. 

## Changeset

- Refactor `spanAttributeSource` to enable providing `appState` as a parameter to simplify testing
- Add new attribute to `requestAttributes` method

## Testing

- Add unit test for `true|false` attribute values
- Update all end-to-end tests to expect the new attribute