### PR TITLE
Add `USE_CDN_BUILD` to args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.browser-feature-builder
       args:
         MAZE_RUNNER_VERSION: latest-v8-cli-legacy
+        USE_CDN_BUILD:
     environment:
       <<: *common-environment
       BROWSER_STACK_BROWSERS_USERNAME:


### PR DESCRIPTION
The "[Build Legacy Maze Runner image (CDN)](https://buildkite.com/bugsnag/bugsnag-js-performance/builds/2179#018a7438-41ee-497a-89f0-592a2e795166)" step doesn't actually run against the CDN build because the `USE_CDN_BUILD` arg isn't listed in `docker-compose.yaml`

This PR fixes that: https://buildkite.com/bugsnag/bugsnag-js-performance/builds/2179#018a7438-41ee-497a-89f0-592a2e795166/213-461