### PR TITLE
upload react-router-performance to CDN on release

### DIFF
--- a/bin/cdn-upload
+++ b/bin/cdn-upload
@@ -24,7 +24,11 @@ const files = [
   'bugsnag-performance.js',
   'bugsnag-performance.js.map',
   'bugsnag-performance.min.js',
-  'bugsnag-performance.min.js.map'
+  'bugsnag-performance.min.js.map',
+  'bugsnag-react-router-performance.js',
+  'bugsnag-react-router-performance.js.map',
+  'bugsnag-react-router-performance.min.js',
+  'bugsnag-react-router-performance.min.js.map'
 ].map(file => path.resolve(__dirname, '../build/', file))
 
 const s3 = new S3Client({ region })

--- a/packages/react-router/rollup.config.cdn.mjs
+++ b/packages/react-router/rollup.config.cdn.mjs
@@ -7,7 +7,7 @@ import nodeResolve from '@rollup/plugin-node-resolve'
 
 // the built files for the CDN go in the top-level 'build' directory so they
 // can't accidentally be uploaded to NPM somehow
-const buildDirectory = '../../../build'
+const buildDirectory = '../../build'
 
 if (!fs.existsSync(buildDirectory)) {
   fs.mkdirSync(buildDirectory)


### PR DESCRIPTION
## Goal

We agreed to make the `@bugsnag/react-router-performance` CDN bundle available on the CDN

## Design

Same approach as for `@bugsnag/browser-performance`

## Changeset

Include react-router-performance bundles in the upload script

## Testing

Will need testing upon release