### PR TITLE
Fix typo in 'isPersistedProbability' function name

### DIFF
--- a/packages/core/lib/persistence.ts
+++ b/packages/core/lib/persistence.ts
@@ -1,4 +1,4 @@
-import { isDeviceId, isPersistedProbabilty } from './validation'
+import { isDeviceId, isPersistedProbability } from './validation'
 
 export interface PersistedProbability {
   value: number
@@ -39,7 +39,7 @@ export function toPersistedPayload<K extends PersistenceKey> (
     case 'bugsnag-sampling-probability': {
       const json = JSON.parse(raw)
 
-      return isPersistedProbabilty(json)
+      return isPersistedProbability(json)
         ? json as PersistencePayloadMap[K]
         : undefined
     }

--- a/packages/core/lib/validation.ts
+++ b/packages/core/lib/validation.ts
@@ -28,7 +28,7 @@ export const isStringArray = (value: unknown): value is string[] => Array.isArra
 
 export const isStringOrRegExpArray = (value: unknown): value is Array<string | RegExp> => Array.isArray(value) && value.every(item => isStringWithLength(item) || item instanceof RegExp)
 
-export function isPersistedProbabilty (value: unknown): value is PersistedProbability {
+export function isPersistedProbability (value: unknown): value is PersistedProbability {
   return isObject(value) &&
     isNumber(value.value) &&
     isNumber(value.time)

--- a/packages/core/tests/validation.test.ts
+++ b/packages/core/tests/validation.test.ts
@@ -127,18 +127,18 @@ describe('validation', () => {
     })
   })
 
-  describe('isPersistedProbabilty', () => {
+  describe('isPersistedProbability', () => {
     it('passes with valid PersistedProbabilty type', () => {
       const probability = {
         value: 1234,
         time: 5678
       }
 
-      expect(validation.isPersistedProbabilty(probability)).toBe(true)
+      expect(validation.isPersistedProbability(probability)).toBe(true)
     })
 
     it.each(nonObjects)('fails validation with $type', (value) => {
-      expect(validation.isPersistedProbabilty(value)).toBe(false)
+      expect(validation.isPersistedProbability(value)).toBe(false)
     })
 
     it.each([
@@ -148,7 +148,7 @@ describe('validation', () => {
       { value: 1234 },
       { time: 1234 }
     ])('fails validation with %s', (value) => {
-      expect(validation.isPersistedProbabilty(value)).toBe(false)
+      expect(validation.isPersistedProbability(value)).toBe(false)
     })
   })
 


### PR DESCRIPTION
`isPersistedProbabilty` &rarr; `isPersistedProbability`