### PR TITLE
Prefer 'satisfies never' to '_exhaustiveCheck'

### DIFF
--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -95,10 +95,8 @@ export class BatchProcessor<C extends Configuration> implements Processor {
           this.configuration.logger.info('delivery failed, adding to retry queue')
           this.retryQueue.add(payload, batchTime)
           break
-        default: {
-          const _exhaustiveCheck: never = response.state
-          return _exhaustiveCheck
-        }
+        default:
+          response.state satisfies never
       }
     } catch (err) {
       this.configuration.logger.warn('delivery failed')

--- a/packages/core/lib/retry-queue.ts
+++ b/packages/core/lib/retry-queue.ts
@@ -57,10 +57,8 @@ export class InMemoryQueue implements RetryQueue {
             case 'failure-retryable':
               this.add(payload, time)
               break
-            default: {
-              const _exhaustiveCheck: never = state
-              return _exhaustiveCheck
-            }
+            default:
+              state satisfies never
           }
         } catch (err) {}
       }

--- a/packages/platforms/browser/lib/persistence.ts
+++ b/packages/platforms/browser/lib/persistence.ts
@@ -36,10 +36,9 @@ function toString<K extends PersistenceKey> (key: K, value: PersistencePayloadMa
     case 'bugsnag-anonymous-id':
       return value as string
 
-    default: {
-      const _exhaustiveCheck: never = key
-      return _exhaustiveCheck
-    }
+    default:
+      key satisfies never
+      return key
   }
 }
 


### PR DESCRIPTION
## Goal

Prefer 'satisfies never' to the '_exhaustiveCheck' we've been using in most places. This leads to less code in the compiled JavaScript