### PR TITLE
Add file abstraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18259,6 +18259,15 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/react-native-file-access": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-file-access/-/react-native-file-access-3.0.4.tgz",
+      "integrity": "sha512-sDmGeIIiSlLSrdtvEtADQ1uMoF+Zoegvu/Wr0z0Ej9lU8tHX0C1q+fJnCEBJSUjQ31rSzlabjWgQDKbpOEBdWg==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/@jest/types": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
@@ -21128,7 +21137,8 @@
       "dependencies": {
         "@bugsnag/core-performance": "^1.0.0",
         "@bugsnag/cuid": "^3.0.2",
-        "@bugsnag/delivery-fetch-performance": "^1.0.0"
+        "@bugsnag/delivery-fetch-performance": "^1.0.0",
+        "react-native-file-access": "^3.0.4"
       },
       "devDependencies": {
         "@react-native-async-storage/async-storage": "1.19.2",

--- a/packages/platforms/react-native/__mocks__/react-native-file-access.ts
+++ b/packages/platforms/react-native/__mocks__/react-native-file-access.ts
@@ -171,6 +171,16 @@ class FileSystemMock {
   public ls = jest.fn(async (_path: string) => ['file1', 'file2']);
 
   /**
+   * Make a directory.
+   *
+   * This is a noop as the mock file system does not differentiate between files
+   * and directories
+   *
+   * NOTE: this method was added by bugsnag
+   */
+  public mkdir = jest.fn(async () => {})
+
+  /**
    * Move a file.
    */
   public mv = jest.fn(async (source: string, target: string) => {

--- a/packages/platforms/react-native/__mocks__/react-native-file-access.ts
+++ b/packages/platforms/react-native/__mocks__/react-native-file-access.ts
@@ -1,0 +1,222 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 alpha0010
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * https://github.com/alpha0010/react-native-file-access/blob/7179426e701fa6e54bda6c2a753cfe31a4a08293/LICENSE
+ */
+
+// Copied from v3.0.4:
+// https://github.com/alpha0010/react-native-file-access/blob/7179426e701fa6e54bda6c2a753cfe31a4a08293/jest/react-native-file-access.ts
+
+/* eslint-disable */
+/* global jest */
+
+import { Platform } from 'react-native';
+import type {
+  ExternalDir,
+  FetchResult,
+  FileStat,
+  FsStat,
+  HashAlgorithm,
+  Util as UtilFunctions,
+} from 'react-native-file-access';
+
+export const Util: typeof UtilFunctions =
+  require('react-native-file-access/lib/commonjs/util').Util;
+
+export const Dirs = {
+  CacheDir: '/mock/CacheDir',
+  DatabaseDir: '/mock/DatabaseDir',
+  DocumentDir: '/mock/DocumentDir',
+  LibraryDir: '/mock/LibraryDir',
+  MainBundleDir: '/mock/MainBundleDir',
+};
+
+class FileSystemMock {
+  /**
+   * Data store for mock filesystem.
+   */
+  public filesystem = new Map<string, string>();
+
+  /**
+   * Append content to a file.
+   */
+  public appendFile = jest.fn(async (path: string, data: string) => {
+    this.filesystem.set(path, (this.filesystem.get(path) ?? '') + data);
+  });
+
+  /**
+   * Append a file to another file.
+   *
+   * Returns number of bytes written.
+   */
+  public concatFiles = jest.fn(async (source: string, target: string) => {
+    const data = this.getFileOrThrow(source);
+    this.filesystem.set(target, (this.filesystem.get(target) ?? '') + data);
+    return data.length;
+  });
+
+  /**
+   * Copy a file.
+   */
+  public cp = jest.fn(async (source: string, target: string) => {
+    this.filesystem.set(target, this.getFileOrThrow(source));
+  });
+
+  /**
+   * Copy a file to external storage
+   */
+  public cpExternal = jest.fn(
+    async (source: string, targetName: string, dir: ExternalDir) => {
+      this.filesystem.set(`/${dir}/${targetName}`, this.getFileOrThrow(source));
+    }
+  );
+
+  /**
+   * Copy a bundled asset file.
+   */
+  public cpAsset = jest.fn(async (asset: string, target: string) => {
+    this.filesystem.set(target, `[Mock asset data for '${asset}']`);
+  });
+
+  /**
+   * Check device available space.
+   */
+  public df = jest.fn<Promise<FsStat>, []>(async () => ({
+    internal_free: 100,
+    internal_total: 200,
+  }));
+
+  /**
+   * Check if a path exists.
+   */
+  public exists = jest.fn(async (path: string) => this.filesystem.has(path));
+
+  /**
+   * Save a network request to a file.
+   */
+  public fetch = jest.fn(
+    async (
+      resource: string,
+      init: {
+        body?: string;
+        headers?: { [key: string]: string };
+        method?: string;
+        path?: string;
+      }
+    ): Promise<FetchResult> => {
+      if (init.path != null) {
+        this.filesystem.set(init.path, `[Mock fetch data for '${resource}']`);
+      }
+      return {
+        headers: {},
+        ok: true,
+        redirected: false,
+        status: 200,
+        statusText: 'OK',
+        url: resource,
+      };
+    }
+  );
+
+  /**
+   * Return the local storage directory for app groups.
+   *
+   * This is an Apple only feature.
+   */
+  public getAppGroupDir = jest.fn((groupName: string) => {
+    if (Platform.OS !== 'ios' && Platform.OS !== 'macos') {
+      throw new Error('AppGroups are available on Apple devices only');
+    }
+    return `${Dirs.DocumentDir}/shared/AppGroup/${groupName}`;
+  });
+
+  /**
+   * Hash the file content.
+   */
+  public hash = jest.fn(async (path: string, algorithm: HashAlgorithm) => {
+    if (!this.filesystem.has(path)) {
+      throw new Error(`File ${path} not found`);
+    }
+    return `[${algorithm} hash of '${path}']`;
+  });
+
+  /**
+   * Check if a path is a directory.
+   */
+  public isDir = jest.fn(async (path: string) => !this.filesystem.has(path));
+
+  /**
+   * List files in a directory.
+   */
+  public ls = jest.fn(async (_path: string) => ['file1', 'file2']);
+
+  /**
+   * Move a file.
+   */
+  public mv = jest.fn(async (source: string, target: string) => {
+    this.filesystem.set(target, this.getFileOrThrow(source));
+    this.filesystem.delete(source);
+  });
+
+  /**
+   * Read the content of a file.
+   */
+  public readFile = jest.fn(async (path: string) => this.getFileOrThrow(path));
+
+  /**
+   * Read file metadata.
+   */
+  public stat = jest.fn(
+    async (path: string): Promise<FileStat> => ({
+      filename: path.substring(path.lastIndexOf('/')),
+      lastModified: 1,
+      path: path,
+      size: this.getFileOrThrow(path).length,
+      type: 'file',
+    })
+  );
+
+  /**
+   * Delete a file.
+   */
+  public unlink = jest.fn(async (path: string) => {
+    this.filesystem.delete(path);
+  });
+
+  /**
+   * Write content to a file.
+   */
+  public writeFile = jest.fn(async (path: string, data: string) => {
+    this.filesystem.set(path, data);
+  });
+
+  private getFileOrThrow(path: string): string {
+    const data = this.filesystem.get(path);
+    if (data == null) {
+      throw new Error(`File ${path} not found`);
+    }
+    return data;
+  }
+}
+
+export const FileSystem = new FileSystemMock();

--- a/packages/platforms/react-native/lib/persistence/file.ts
+++ b/packages/platforms/react-native/lib/persistence/file.ts
@@ -1,0 +1,41 @@
+import { isObject } from '@bugsnag/core-performance'
+import { Util, type FileSystem } from 'react-native-file-access'
+
+/**
+ * A wrapper around 'react-native-file-access' that allows reading and writing
+ * to a specific file without having to specify the path every time it's used
+ */
+export default class File {
+  private readonly path: string
+  private readonly directory: string
+  private readonly fileSystem: typeof FileSystem
+
+  constructor (path: string, fileSystem: typeof FileSystem) {
+    this.path = path
+    this.directory = Util.dirname(path)
+    this.fileSystem = fileSystem
+  }
+
+  async read (): Promise<string> {
+    return await this.fileSystem.readFile(this.path)
+  }
+
+  async write (data: string): Promise<void> {
+    await this.ensureDirectoryExists()
+
+    await this.fileSystem.writeFile(this.path, data, 'utf8')
+  }
+
+  async ensureDirectoryExists (): Promise<void> {
+    try {
+      await this.fileSystem.mkdir(this.directory)
+    } catch (err) {
+      // on Android mkdir will fail if the directory already exists, which isn't
+      // an error case we care about
+      // on iOS it will succeed unless there's a genuine error
+      if (isObject(err) && err.code !== 'EEXIST') {
+        throw err
+      }
+    }
+  }
+}

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -16,16 +16,17 @@
   },
   "dependencies": {
     "@bugsnag/core-performance": "^1.0.0",
+    "@bugsnag/cuid": "^3.0.2",
     "@bugsnag/delivery-fetch-performance": "^1.0.0",
-    "@bugsnag/cuid": "^3.0.2"
+    "react-native-file-access": "^3.0.4"
   },
   "devDependencies": {
-    "babel-preset-react-native": "^4.0.1",
-    "@react-native-async-storage/async-storage": "1.19.2"
+    "@react-native-async-storage/async-storage": "1.19.2",
+    "babel-preset-react-native": "^4.0.1"
   },
   "peerDependencies": {
-    "react-native": "*",
-    "@react-native-async-storage/async-storage": "*"
+    "@react-native-async-storage/async-storage": "*",
+    "react-native": "*"
   },
   "scripts": {
     "build": "rollup --config",

--- a/packages/platforms/react-native/tests/persistence/file.test.ts
+++ b/packages/platforms/react-native/tests/persistence/file.test.ts
@@ -1,0 +1,69 @@
+import File from '../../lib/persistence/file'
+import { FileSystem } from 'react-native-file-access'
+
+describe('File', () => {
+  beforeEach(() => {
+    // reset the FileSystem mock between tests, otherwise they will interfere
+    // with each other
+    // @ts-expect-error this exists on 'FileSystemMock' (see '__mocks__')
+    FileSystem.filesystem = new Map<string, string>()
+  })
+
+  it('can write to the given file path', async () => {
+    const file = new File('/a/file/path', FileSystem)
+
+    await file.write('some stuff')
+
+    expect(await FileSystem.readFile('/a/file/path')).toStrictEqual('some stuff')
+  })
+
+  it('can read from the given file path', async () => {
+    const file = new File('/another/file/path', FileSystem)
+
+    await file.write('beep beep')
+
+    expect(await file.read()).toStrictEqual('beep beep')
+  })
+
+  it('throws when reading from the file when it does not exist', async () => {
+    expect.assertions(1)
+    const file = new File('/a/third/file/path', FileSystem)
+
+    await expect(file.read()).rejects.toThrow()
+  })
+
+  it('overwrites previously written data on each write', async () => {
+    const file = new File('/this/one/is/different/too', FileSystem)
+
+    await file.write('beep')
+    expect(await file.read()).toStrictEqual('beep')
+
+    await file.write('boop')
+    expect(await file.read()).toStrictEqual('boop')
+  })
+
+  it('rethrows errors when creating the directory', async () => {
+    expect.assertions(1)
+    const file = new File('/a/b/c.txt', FileSystem)
+
+    jest.mocked(FileSystem.mkdir).mockImplementation(() => {
+      throw new Error('no')
+    })
+
+    await expect(file.write('abc')).rejects.toThrow(new Error('no'))
+  })
+
+  it('handles error when directory already exists', async () => {
+    const file = new File('/x/y/z.abc', FileSystem)
+
+    jest.mocked(FileSystem.mkdir).mockImplementation(() => {
+      const error = new Error('already exists!')
+      ;(error as any).code = 'EEXIST'
+
+      throw error
+    })
+
+    await file.write('beep')
+    expect(await file.read()).toStrictEqual('beep')
+  })
+})


### PR DESCRIPTION
## Goal

Adds an abstraction for reading & writing files using [the `react-native-file-access` library](https://github.com/alpha0010/react-native-file-access)

This is step 1 to supporting the `Persistence` interface in the React Native SDK backed by a JSON file