### PR TITLE
Add `RCT_NEW_ARCH_ENABLED` to the React Native docker environment

### DIFF
--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -1,195 +1,196 @@
 steps:
+  - group: "React Native Tests"
+    steps:
+      #
+      # Test fixtures
+      #
+      - label: ':android: Build RN {{matrix}} test fixture APK (Old Arch)'
+        key: "build-react-native-android-fixture-old-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: macos-12-arm
+        env:
+          RN_VERSION: "{{matrix}}"
+          BUILD_ANDROID: "true"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/oldarch/**/reactnative.apk"
+        commands:
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.71"
+          - "0.72"
 
-  #
-  # Test fixtures
-  #
-  - label: ':android: Build RN {{matrix}} test fixture APK (Old Arch)'
-    key: "build-react-native-android-fixture-old-arch"
-    timeout_in_minutes: 30
-    agents:
-      queue: macos-12-arm
-    env:
-      RN_VERSION: "{{matrix}}"
-      BUILD_ANDROID: "true"
-    artifact_paths:
-      - "test/react-native/features/fixtures/generated/oldarch/**/reactnative.apk"
-    commands:
-      - ./bin/generate-react-native-fixture
-    matrix:
-      - "0.71"
-      - "0.72"
+      - label: ':android: Build RN {{matrix}} test fixture APK (New Arch)'
+        key: "build-react-native-android-fixture-new-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: macos-12-arm
+        env:
+          RN_VERSION: "{{matrix}}"
+          RCT_NEW_ARCH_ENABLED: "true"
+          BUILD_ANDROID: "true"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/newarch/**/reactnative.apk"
+        commands:
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.71"
+          - "0.72"
 
-  - label: ':android: Build RN {{matrix}} test fixture APK (New Arch)'
-    key: "build-react-native-android-fixture-new-arch"
-    timeout_in_minutes: 30
-    agents:
-      queue: macos-12-arm
-    env:
-      RN_VERSION: "{{matrix}}"
-      RCT_NEW_ARCH_ENABLED: "true"
-      BUILD_ANDROID: "true"
-    artifact_paths:
-      - "test/react-native/features/fixtures/generated/newarch/**/reactnative.apk"
-    commands:
-      - ./bin/generate-react-native-fixture
-    matrix:
-      - "0.71"
-      - "0.72"
+      - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
+        key: "build-react-native-ios-fixture-old-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: "macos-12-arm"
+        env:
+          RN_VERSION: "{{matrix}}"
+          BUILD_IOS: "true"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/oldarch/**/output/reactnative.ipa"
+        commands:
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.71"
+          - "0.72"
 
-  - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
-    key: "build-react-native-ios-fixture-old-arch"
-    timeout_in_minutes: 30
-    agents:
-      queue: "macos-12-arm"
-    env:
-      RN_VERSION: "{{matrix}}"
-      BUILD_IOS: "true"
-      DEVELOPER_DIR: "/Applications/Xcode14.app"
-    artifact_paths:
-      - "test/react-native/features/fixtures/generated/oldarch/**/output/reactnative.ipa"
-    commands:
-      - ./bin/generate-react-native-fixture
-    matrix:
-      - "0.71"
-      - "0.72"
+      - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
+        key: "build-react-native-ios-fixture-new-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: "macos-12-arm"
+        env:
+          RN_VERSION: "{{matrix}}"
+          RCT_NEW_ARCH_ENABLED: "1"
+          BUILD_IOS: "true"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/newarch/**/output/reactnative.ipa"
+        commands:
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.71"
+          - "0.72"
 
-  - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
-    key: "build-react-native-ios-fixture-new-arch"
-    timeout_in_minutes: 30
-    agents:
-      queue: "macos-12-arm"
-    env:
-      RN_VERSION: "{{matrix}}"
-      RCT_NEW_ARCH_ENABLED: "1"
-      BUILD_IOS: "true"
-      DEVELOPER_DIR: "/Applications/Xcode14.app"
-    artifact_paths:
-      - "test/react-native/features/fixtures/generated/newarch/**/output/reactnative.ipa"
-    commands:
-      - ./bin/generate-react-native-fixture
-    matrix:
-      - "0.71"
-      - "0.72"
+        #
+        # End-to-end tests
+        #
+      - label: ":bitbar: :android: RN {{matrix}} Android 12 (Old Arch) end-to-end tests"
+        depends_on: "build-react-native-android-fixture-old-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/oldarch/{{matrix}}/reactnative.apk"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.7.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/oldarch/{{matrix}}/reactnative.apk
+              - --farm=bb
+              - --device=ANDROID_12
+              - --a11y-locator
+              - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar-app"
+        concurrency_method: eager
+        matrix:
+          - "0.71"
+          - "0.72"
 
-    #
-    # End-to-end tests
-    #
-  - label: ":bitbar: :android: RN {{matrix}} Android 12 (Old Arch) end-to-end tests"
-    depends_on: "build-react-native-android-fixture-old-arch"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download: "test/react-native/features/fixtures/generated/oldarch/{{matrix}}/reactnative.apk"
-        upload: ./test/react-native/maze_output/**/*
-      docker-compose#v4.7.0:
-        pull: react-native-maze-runner
-        run: react-native-maze-runner
-        service-ports: true
-        command:
-          - --app=/app/features/fixtures/generated/oldarch/{{matrix}}/reactnative.apk
-          - --farm=bb
-          - --device=ANDROID_12
-          - --a11y-locator
-          - --fail-fast
-          - --no-tunnel
-          - --aws-public-ip
-    retry:
-      manual:
-        permit_on_passed: true
-    concurrency: 25
-    concurrency_group: "bitbar-app"
-    concurrency_method: eager
-    matrix:
-      - "0.71"
-      - "0.72"
+      - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
+        depends_on: "build-react-native-android-fixture-new-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/newarch/{{matrix}}/reactnative.apk"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.7.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/newarch/{{matrix}}/reactnative.apk
+              - --farm=bb
+              - --device=ANDROID_12
+              - --a11y-locator
+              - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
+        env:
+          RCT_NEW_ARCH_ENABLED: "1"
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar-app"
+        concurrency_method: eager
+        matrix:
+          - "0.71"
+          - "0.72"
 
-  - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
-    depends_on: "build-react-native-android-fixture-new-arch"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download: "test/react-native/features/fixtures/generated/newarch/{{matrix}}/reactnative.apk"
-        upload: ./test/react-native/maze_output/**/*
-      docker-compose#v4.7.0:
-        pull: react-native-maze-runner
-        run: react-native-maze-runner
-        service-ports: true
-        command:
-          - --app=/app/features/fixtures/generated/newarch/{{matrix}}/reactnative.apk
-          - --farm=bb
-          - --device=ANDROID_12
-          - --a11y-locator
-          - --fail-fast
-          - --no-tunnel
-          - --aws-public-ip
-    env: 
-      RCT_NEW_ARCH_ENABLED: "1"
-    retry:
-      manual:
-        permit_on_passed: true
-    concurrency: 25
-    concurrency_group: "bitbar-app"
-    concurrency_method: eager
-    matrix:
-      - "0.71"
-      - "0.72"
+      - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (Old Arch) end-to-end tests"
+        depends_on: "build-react-native-ios-fixture-old-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/oldarch/{{matrix}}/output/reactnative.ipa"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.12.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/oldarch/{{matrix}}/output/reactnative.ipa
+              - --farm=bb
+              - --device=IOS_14
+              - --a11y-locator
+              - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar-app"
+        concurrency_method: eager
+        matrix:
+          - "0.71"
+          - "0.72"
 
-  - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (Old Arch) end-to-end tests"
-    depends_on: "build-react-native-ios-fixture-old-arch"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download: "test/react-native/features/fixtures/generated/oldarch/{{matrix}}/output/reactnative.ipa"
-        upload: ./test/react-native/maze_output/**/*
-      docker-compose#v4.12.0:
-        pull: react-native-maze-runner
-        run: react-native-maze-runner
-        service-ports: true
-        command:
-          - --app=/app/features/fixtures/generated/oldarch/{{matrix}}/output/reactnative.ipa
-          - --farm=bb
-          - --device=IOS_14
-          - --a11y-locator
-          - --fail-fast
-          - --no-tunnel
-          - --aws-public-ip
-    retry:
-      manual:
-        permit_on_passed: true
-    concurrency: 25
-    concurrency_group: "bitbar-app"
-    concurrency_method: eager
-    matrix:
-      - "0.71"
-      - "0.72"
-
-  - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (New Arch) end-to-end tests"
-    depends_on: "build-react-native-ios-fixture-new-arch"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download: "test/react-native/features/fixtures/generated/newarch/{{matrix}}/output/reactnative.ipa"
-        upload: ./test/react-native/maze_output/**/*
-      docker-compose#v4.12.0:
-        pull: react-native-maze-runner
-        run: react-native-maze-runner
-        service-ports: true
-        command:
-          - --app=/app/features/fixtures/generated/newarch/{{matrix}}/output/reactnative.ipa
-          - --farm=bb
-          - --device=IOS_14
-          - --a11y-locator
-          - --fail-fast
-          - --no-tunnel
-          - --aws-public-ip
-    env: 
-      RCT_NEW_ARCH_ENABLED: "1"
-    retry:
-      manual:
-        permit_on_passed: true
-    concurrency: 25
-    concurrency_group: "bitbar-app"
-    concurrency_method: eager
-    matrix:
-      - "0.71"
-      - "0.72"
+      - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (New Arch) end-to-end tests"
+        depends_on: "build-react-native-ios-fixture-new-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/newarch/{{matrix}}/output/reactnative.ipa"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.12.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/newarch/{{matrix}}/output/reactnative.ipa
+              - --farm=bb
+              - --device=IOS_14
+              - --a11y-locator
+              - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
+        env:
+          RCT_NEW_ARCH_ENABLED: "1"
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar-app"
+        concurrency_method: eager
+        matrix:
+          - "0.71"
+          - "0.72"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       <<: *common-environment
       BITBAR_USERNAME:
       BITBAR_ACCESS_KEY:
+      RCT_NEW_ARCH_ENABLED:
     ports:
       - "9000-9499:9339"
     networks:


### PR DESCRIPTION
## Goal

This is used to decide whether to run the native resource attributes
test:

https://github.com/bugsnag/bugsnag-js-performance/blob/97d6d053228b777c6ec05c698dcb4babad493c45/test/react-native/features/support/env.rb#L8-L10

As it was missing from the environment, that test was always skipped but now the test should run when using the new architecture and be skipped on the old architecture

I also added a group to the pipeline file so Buildkite looks a bit neater:

<img width="1163" alt="image" src="https://github.com/bugsnag/bugsnag-js-performance/assets/282732/fd5d3129-f4ba-425b-917d-d875020d70e5">