### PR TITLE
Improve react-native mock

### DIFF
--- a/packages/platforms/react-native/__mocks__/react-native.ts
+++ b/packages/platforms/react-native/__mocks__/react-native.ts
@@ -1,15 +1,134 @@
-import * as ReactNative from 'react-native'
+type Os = 'android' | 'ios' | 'other'
+interface SelectOptions<T> { android: T, ios: T, default: T }
+type PlatformConstants
+  = { Manufacturer: string, Model: string }
+  | Record<string, never>
 
-export const Platform = {
-  ...ReactNative.Platform,
-  OS: 'ios',
-  Version: '1.2.3',
-  isTesting: true
+export const Platform = new class {
+  private os: Os = 'ios'
+
+  /**
+   * A test helper to allow running a test on a different OS without polluting
+   * other tests. When the callback finishes the OS will be reset to 'ios'
+   *
+   * For example:
+   *   it('works', async () => {
+   *     expect(Platform.OS).toBe('ios')
+   *
+   *     await Platform.bugsnagWithTestPlatformSetTo('android', async () => {
+   *       await doTestStuff()
+   *       // etc...
+   *       expect(Platform.OS).toBe('android')
+   *     })
+   *
+   *     expect(Platform.OS).toBe('ios')
+   *   })
+   */
+  async bugsnagWithTestPlatformSetTo<T> (os: Os, callback: () => Promise<T>): Promise<T> {
+    this.os = os
+
+    try {
+      return await callback()
+    } finally {
+      this.os = 'ios'
+    }
+  }
+
+  select<T> (options: SelectOptions<T>): T {
+    switch (this.os) {
+      case 'ios':
+        return options.ios
+
+      case 'android':
+        return options.android
+
+      case 'other':
+        return options.default
+    }
+  }
+
+  get OS (): Os {
+    return this.os
+  }
+
+  get Version (): string | number {
+    switch (this.os) {
+      case 'ios':
+        return '1.2.3'
+
+      case 'android':
+        return 123
+
+      case 'other':
+        return ''
+    }
+  }
+
+  get constants (): PlatformConstants {
+    switch (this.os) {
+      case 'ios':
+      case 'other':
+        // Manufacturer and Model are Android specific and the only constants we
+        // currently use
+        return {}
+
+      case 'android':
+        return {
+          Manufacturer: 'bug',
+          Model: 'snag'
+        }
+    }
+  }
+}()
+
+interface DeviceInfoIos {
+  arch: string
+  model: string
+  bundleVersion: string
 }
 
-export default Object.setPrototypeOf(
-  {
-    Platform
-  },
-  ReactNative
-)
+interface DeviceInfoAndroid {
+  arch: string
+  model: string
+  versionCode: string
+}
+
+type DeviceInfo
+  = DeviceInfoIos
+  | DeviceInfoAndroid
+  | Record<string, never>
+
+const BugsnagReactNativePerformance = {
+  getDeviceInfo (): DeviceInfo {
+    switch (Platform.OS) {
+      case 'ios':
+        return {
+          arch: 'arm64',
+          model: 'iPhone14,1',
+          bundleVersion: '12345'
+        }
+
+      case 'android':
+        return {
+          arch: 'x86',
+          model: 'TheGoodPhone1',
+          versionCode: '6789'
+        }
+
+      case 'other':
+        return {}
+    }
+  }
+}
+
+export const TurboModuleRegistry = {
+  get (name: string): typeof BugsnagReactNativePerformance | null {
+    switch (name) {
+      case 'BugsnagReactNativePerformance':
+        return BugsnagReactNativePerformance
+
+      default:
+        return null
+    }
+  }
+}

--- a/packages/platforms/react-native/lib/native.ts
+++ b/packages/platforms/react-native/lib/native.ts
@@ -1,6 +1,6 @@
 import { TurboModuleRegistry } from 'react-native'
-import type { Spec } from './NativeBugsnagPerformance'
+import { type Spec } from './NativeBugsnagPerformance'
 
-const NativeBugsnagPerformance = TurboModuleRegistry.get('BugsnagReactNativePerformance') || undefined
+const NativeBugsnagPerformance = TurboModuleRegistry.get('BugsnagReactNativePerformance')
 
-export default NativeBugsnagPerformance as Spec
+export default NativeBugsnagPerformance as Spec | null

--- a/packages/platforms/react-native/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/react-native/tests/resource-attributes-source.test.ts
@@ -1,54 +1,21 @@
 import { InMemoryPersistence } from '@bugsnag/core-performance'
+import { Platform } from 'react-native'
 import { createConfiguration } from '@bugsnag/js-performance-test-utilities'
 import { type ReactNativeConfiguration } from '../lib/config'
 import resourceAttributesSourceFactory from '../lib/resource-attributes-source'
 
-const NativeBugsnagPerformanceFake = {
-  getDeviceInfo: () => {
-    return {
-      arch: 'arm64',
-      model: 'iPhone14,1',
-      bundleVersion: '12345'
-    }
-  }
-}
-
-jest.mock('react-native', () => {
-  return {
-    _esModule: true,
-    TurboModuleRegistry: {
-      get: () => {
-        return NativeBugsnagPerformanceFake
-      }
-    },
-    Platform: {
-      OS: 'ios',
-      Version: '1.2.3',
-      select: (options: { android?: string, ios?: string, default?: string }) => {
-        return options.ios
-      },
-      constants: {
-        Manufacturer: undefined, // only exists on Android
-        Model: undefined // only exists on Android
-      }
-    }
-  }
-})
-
 describe('resourceAttributesSource', () => {
   it('includes all expected attributes (iOS)', async () => {
-    const configuraiton = createConfiguration<ReactNativeConfiguration>({ releaseStage: 'test', appVersion: '1.0.0', appName: 'Test App', codeBundleId: '12345678' })
+    const configuration = createConfiguration<ReactNativeConfiguration>({ releaseStage: 'test', appVersion: '1.0.0', appName: 'Test App', codeBundleId: '12345678' })
     const resourceAttributesSource = resourceAttributesSourceFactory(new InMemoryPersistence())
-    const resourceAttributes = await resourceAttributesSource(configuraiton)
+    const resourceAttributes = await resourceAttributesSource(configuration)
     const jsonAttributes = resourceAttributes.toJson()
 
-    function getAttribute (key: string) {
-      const matchingAttribute = jsonAttributes.find(attribute => attribute?.key === key)
-      return matchingAttribute?.value
-    }
+    const getAttribute = (key: string) => jsonAttributes.find(attribute => attribute?.key === key)?.value
 
     expect(getAttribute('bugsnag.app.code_bundle_id')).toStrictEqual({ stringValue: '12345678' })
     expect(getAttribute('bugsnag.app.bundle_version')).toStrictEqual({ stringValue: '12345' })
+    expect(getAttribute('bugsnag.app.version_code')).toBeUndefined()
     expect(getAttribute('host.arch')).toStrictEqual({ stringValue: 'arm64' })
     expect(getAttribute('deployment.environment')).toStrictEqual({ stringValue: 'test' })
     expect(getAttribute('device.id')).toStrictEqual({ stringValue: expect.stringMatching(/^c[a-z0-9]{20,32}$/) })
@@ -63,19 +30,45 @@ describe('resourceAttributesSource', () => {
     expect(getAttribute('telemetry.sdk.version')).toStrictEqual({ stringValue: '__VERSION__' })
   })
 
+  it('includes all expected attributes (Android)', async () => {
+    // @ts-expect-error 'bugsnagWithTestPlatformSetTo' is an extension added by
+    //                  our Platform mock (see '__mocks__/react-native.ts')
+    await Platform.bugsnagWithTestPlatformSetTo('android', async () => {
+      const configuration = createConfiguration<ReactNativeConfiguration>({ releaseStage: 'test', appVersion: '1.0.0', appName: 'Test App', codeBundleId: '12345678' })
+      const resourceAttributesSource = resourceAttributesSourceFactory(new InMemoryPersistence())
+      const resourceAttributes = await resourceAttributesSource(configuration)
+      const jsonAttributes = resourceAttributes.toJson()
+
+      const getAttribute = (key: string) => jsonAttributes.find(attribute => attribute?.key === key)?.value
+
+      expect(getAttribute('bugsnag.app.code_bundle_id')).toStrictEqual({ stringValue: '12345678' })
+      expect(getAttribute('bugsnag.app.bundle_version')).toBeUndefined()
+      expect(getAttribute('bugsnag.app.version_code')).toStrictEqual({ stringValue: '6789' })
+      expect(getAttribute('host.arch')).toStrictEqual({ stringValue: 'x86' })
+      expect(getAttribute('deployment.environment')).toStrictEqual({ stringValue: 'test' })
+      expect(getAttribute('device.id')).toStrictEqual({ stringValue: expect.stringMatching(/^c[a-z0-9]{20,32}$/) })
+      expect(getAttribute('device.manufacturer')).toStrictEqual({ stringValue: 'bug' })
+      expect(getAttribute('device.model.identifier')).toStrictEqual({ stringValue: 'TheGoodPhone1' })
+      expect(getAttribute('os.type')).toStrictEqual({ stringValue: 'linux' })
+      expect(getAttribute('os.name')).toStrictEqual({ stringValue: 'android' })
+      expect(getAttribute('os.version')).toStrictEqual({ stringValue: '123' })
+      expect(getAttribute('service.name')).toStrictEqual({ stringValue: 'Test App' })
+      expect(getAttribute('service.version')).toStrictEqual({ stringValue: '1.0.0' })
+      expect(getAttribute('telemetry.sdk.name')).toStrictEqual({ stringValue: 'bugsnag.performance.reactnative' })
+      expect(getAttribute('telemetry.sdk.version')).toStrictEqual({ stringValue: '__VERSION__' })
+    })
+  })
+
   it('uses the persisted device ID if one exists', async () => {
     const persistence = new InMemoryPersistence()
     await persistence.save('bugsnag-anonymous-id', 'an device ID :)')
 
-    const configuraiton = createConfiguration<ReactNativeConfiguration>()
+    const configuration = createConfiguration<ReactNativeConfiguration>()
     const resourceAttributesSource = resourceAttributesSourceFactory(persistence)
-    const resourceAttributes = await resourceAttributesSource(configuraiton)
+    const resourceAttributes = await resourceAttributesSource(configuration)
     const jsonAttributes = resourceAttributes.toJson()
 
-    function getAttribute (key: string) {
-      const matchingAttribute = jsonAttributes.find(attribute => attribute?.key === key)
-      return matchingAttribute?.value
-    }
+    const getAttribute = (key: string) => jsonAttributes.find(attribute => attribute?.key === key)?.value
 
     expect(getAttribute('device.id')).toStrictEqual({ stringValue: 'an device ID :)' })
   })


### PR DESCRIPTION
## Goal

When adding more native code, I found the existing React Native mock didn't quite work as expected. Notably it requires tests to add additional mocking in the test file itself, which causes some redundancy and makes it easy to do the wrong thing

This PR improves the RN mock so that no additional mocking is required in the tests themselves. I've also added support for multiple platforms (iOS is still the default) so that any different behaviour on Android can be tested as well. While we still need e2e tests to prove it works on devices, it's a lot easier & quicker to run the unit tests while developing