### PR TITLE
Make react-native-file-access a peer dependency

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "1.1.0"
+  "version": "1.2.0-alpha.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18246,6 +18246,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-native-file-access/-/react-native-file-access-3.0.4.tgz",
       "integrity": "sha512-sDmGeIIiSlLSrdtvEtADQ1uMoF+Zoegvu/Wr0z0Ej9lU8tHX0C1q+fJnCEBJSUjQ31rSzlabjWgQDKbpOEBdWg==",
+      "dev": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -21122,14 +21123,15 @@
         "@bugsnag/core-performance": "^1.0.0",
         "@bugsnag/cuid": "^3.0.2",
         "@bugsnag/delivery-fetch-performance": "^1.0.0",
-        "@bugsnag/request-tracker-performance": "^1.0.0",
-        "react-native-file-access": "^3.0.4"
+        "@bugsnag/request-tracker-performance": "^1.0.0"
       },
       "devDependencies": {
-        "babel-preset-react-native": "^4.0.1"
+        "babel-preset-react-native": "^4.0.1",
+        "react-native-file-access": "^3.0.4"
       },
       "peerDependencies": {
-        "react-native": "*"
+        "react-native": "*",
+        "react-native-file-access": "^3.0.4"
       }
     },
     "packages/request-tracker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21093,37 +21093,37 @@
     },
     "packages/core": {
       "name": "@bugsnag/core-performance",
-      "version": "1.0.0",
+      "version": "1.2.0-alpha.0",
       "license": "MIT"
     },
     "packages/delivery-fetch": {
       "name": "@bugsnag/delivery-fetch-performance",
-      "version": "1.0.0",
+      "version": "1.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^1.0.0"
+        "@bugsnag/core-performance": "^1.2.0-alpha.0"
       }
     },
     "packages/platforms/browser": {
       "name": "@bugsnag/browser-performance",
-      "version": "1.0.0",
+      "version": "1.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^1.0.0",
+        "@bugsnag/core-performance": "^1.2.0-alpha.0",
         "@bugsnag/cuid": "^3.0.2",
-        "@bugsnag/delivery-fetch-performance": "^1.0.0",
-        "@bugsnag/request-tracker-performance": "^1.0.0"
+        "@bugsnag/delivery-fetch-performance": "^1.2.0-alpha.0",
+        "@bugsnag/request-tracker-performance": "^1.2.0-alpha.0"
       }
     },
     "packages/platforms/react-native": {
       "name": "@bugsnag/react-native-performance",
-      "version": "1.0.0",
+      "version": "1.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^1.0.0",
+        "@bugsnag/core-performance": "^1.2.0-alpha.0",
         "@bugsnag/cuid": "^3.0.2",
-        "@bugsnag/delivery-fetch-performance": "^1.0.0",
-        "@bugsnag/request-tracker-performance": "^1.0.0"
+        "@bugsnag/delivery-fetch-performance": "^1.2.0-alpha.0",
+        "@bugsnag/request-tracker-performance": "^1.2.0-alpha.0"
       },
       "devDependencies": {
         "babel-preset-react-native": "^4.0.1",
@@ -21136,10 +21136,10 @@
     },
     "packages/request-tracker": {
       "name": "@bugsnag/request-tracker-performance",
-      "version": "1.0.0",
+      "version": "1.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^1.0.0"
+        "@bugsnag/core-performance": "^1.2.0-alpha.0"
       }
     },
     "packages/test-utilities": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/core-performance",
-  "version": "1.0.0",
+  "version": "1.2.0-alpha.0",
   "description": "Core performance client",
   "keywords": [
     "bugsnag",

--- a/packages/delivery-fetch/package.json
+++ b/packages/delivery-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/delivery-fetch-performance",
-  "version": "1.0.0",
+  "version": "1.2.0-alpha.0",
   "description": "BugSnag performance monitoring delivery mechanism using the fetch API",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^1.0.0"
+    "@bugsnag/core-performance": "^1.2.0-alpha.0"
   },
   "type": "module",
   "main": "dist/delivery.js",

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/browser-performance",
-  "version": "1.0.0",
+  "version": "1.2.0-alpha.0",
   "description": "BugSnag performance monitoring for browsers",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -21,10 +21,10 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^1.0.0",
-    "@bugsnag/delivery-fetch-performance": "^1.0.0",
-    "@bugsnag/request-tracker-performance": "^1.0.0",
-    "@bugsnag/cuid": "^3.0.2"
+    "@bugsnag/core-performance": "^1.2.0-alpha.0",
+    "@bugsnag/cuid": "^3.0.2",
+    "@bugsnag/delivery-fetch-performance": "^1.2.0-alpha.0",
+    "@bugsnag/request-tracker-performance": "^1.2.0-alpha.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/react-native-performance",
-  "version": "1.0.0",
+  "version": "1.2.0-alpha.0",
   "description": "BugSnag performance monitoring for React Native",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -15,10 +15,10 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^1.0.0",
+    "@bugsnag/core-performance": "^1.2.0-alpha.0",
     "@bugsnag/cuid": "^3.0.2",
-    "@bugsnag/delivery-fetch-performance": "^1.0.0",
-    "@bugsnag/request-tracker-performance": "^1.0.0"
+    "@bugsnag/delivery-fetch-performance": "^1.2.0-alpha.0",
+    "@bugsnag/request-tracker-performance": "^1.2.0-alpha.0"
   },
   "devDependencies": {
     "babel-preset-react-native": "^4.0.1",

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -18,14 +18,15 @@
     "@bugsnag/core-performance": "^1.0.0",
     "@bugsnag/cuid": "^3.0.2",
     "@bugsnag/delivery-fetch-performance": "^1.0.0",
-    "@bugsnag/request-tracker-performance": "^1.0.0",
-    "react-native-file-access": "^3.0.4"
+    "@bugsnag/request-tracker-performance": "^1.0.0"
   },
   "devDependencies": {
-    "babel-preset-react-native": "^4.0.1"
+    "babel-preset-react-native": "^4.0.1",
+    "react-native-file-access": "^3.0.4"
   },
   "peerDependencies": {
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-file-access": "^3.0.4"
   },
   "scripts": {
     "build": "rollup --config",

--- a/packages/request-tracker/package.json
+++ b/packages/request-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/request-tracker-performance",
-  "version": "1.0.0",
+  "version": "1.2.0-alpha.0",
   "description": "BugSnag performance request tracker for monitoring XHR and fetch requests",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^1.0.0"
+    "@bugsnag/core-performance": "^1.2.0-alpha.0"
   },
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Goal

`react-native-file-access` requires linking and must be installed directly by the user - this PR changes it from a dependency to a peerDependency