### PR TITLE
[PLAT-10765] Fix PerformanceObserver.entryTypes is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- (browser) Fall back to unbuffered performance observer when buffer is not supported [#352](https://github.com/bugsnag/bugsnag-js-performance/pull/352) 
+
 ## v1.2.0 (2023-10-12)
 
 This release adds support for running BugSnag Performance in React Native apps. See [online docs](https://docs.bugsnag.com/performance/integration-guides/react-native) for details.

--- a/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/resource-load-plugin.ts
@@ -101,6 +101,11 @@ export class ResourceLoadPlugin implements Plugin<BrowserConfiguration> {
       }
     })
 
-    observer.observe({ type: 'resource', buffered: true })
+    try {
+      observer.observe({ type: 'resource', buffered: true })
+    } catch (err) {
+      configuration.logger.warn('Unable to get previous resource loads as buffered observer not supported, only showing resource loads from this point on')
+      observer.observe({ entryTypes: ['resource'] })
+    }
   }
 }


### PR DESCRIPTION
## Goal

handle a known bug in certain browsers, where the `entryType` parameter should be optional in `PerformanceObserver.observe()`

https://bugs.webkit.org/show_bug.cgi?id=209216