### PR TITLE
Avoid crash in unit test delivery system when given an invalid payload

### DIFF
--- a/packages/test-utilities/lib/in-memory-delivery.ts
+++ b/packages/test-utilities/lib/in-memory-delivery.ts
@@ -13,7 +13,7 @@ class InMemoryDelivery implements Delivery {
   private readonly samplingProbabilityStack: Array<number | undefined> = []
 
   send (payload: TracePayload) {
-    if (payload.body.resourceSpans.length === 0) {
+    if (payload.body?.resourceSpans?.length === 0) {
       this.samplingRequests.push(payload.body)
     } else {
       this.requests.push(payload.body)


### PR DESCRIPTION
## Goal

The `InMemoryDelivery` we use in unit tests crashes when given an invalid payload as it always expects `payload.body.resourceSpans` to exist

This is mostly a safe assumption as TypeScript should ensure this is the case, but in a future PR we'll be reading a payload from a JSON file and that can cause invalid payloads to be sent to delivery