### PR TITLE
Add `RetryQueueDirectory`

### DIFF
--- a/packages/platforms/react-native/lib/retry-queue/directory.ts
+++ b/packages/platforms/react-native/lib/retry-queue/directory.ts
@@ -1,0 +1,108 @@
+import { isObject } from '@bugsnag/core-performance'
+import { Util, type FileSystem } from 'react-native-file-access'
+
+type MinimalFileSystem = Pick<typeof FileSystem, 'ls' | 'exists' | 'isDir' | 'readFile' | 'writeFile' | 'mkdir' | 'unlink'>
+
+const FILENAME_REGEX = /^retry-([0-9]+)-.+\.json$/
+
+function timestampFromFilename (filename: string): bigint | undefined {
+  const match = FILENAME_REGEX.exec(filename)
+
+  if (match) {
+    return BigInt(match[1])
+  }
+}
+
+// sort filenames by newest -> oldest, i.e. the largest timestamps come first
+// any invalid filenames (where we can't parse a timestamp) are put at the end
+function filenameSorter (a: string, b: string): number {
+  const aTimestamp = timestampFromFilename(a)
+
+  // put invalid filenames at the end of the array
+  if (!aTimestamp) {
+    return 1
+  }
+
+  const bTimestamp = timestampFromFilename(b)
+
+  if (!bTimestamp) {
+    return -1
+  }
+
+  if (aTimestamp > bTimestamp) {
+    return -1
+  }
+
+  if (aTimestamp < bTimestamp) {
+    return 1
+  }
+
+  return 0
+}
+
+export default class RetryQueueDirectory {
+  private readonly fileSystem: MinimalFileSystem
+  private readonly path: string
+
+  constructor (fileSystem: MinimalFileSystem, path: string) {
+    this.fileSystem = fileSystem
+    this.path = path
+  }
+
+  async files (): Promise<string[]> {
+    if (!await this.fileSystem.exists(this.path)) {
+      return []
+    }
+
+    const files: string[] = []
+
+    for (const file of await this.fileSystem.ls(this.path)) {
+      if (!await this.fileSystem.isDir(file)) {
+        files.push(Util.basename(file))
+      }
+    }
+
+    files.sort(filenameSorter)
+
+    return files
+  }
+
+  async read (name: string): Promise<string> {
+    const path = `${this.path}/${Util.basename(name)}`
+
+    if (await this.fileSystem.exists(path)) {
+      return await this.fileSystem.readFile(path)
+    }
+
+    return ''
+  }
+
+  async write (name: string, contents: string): Promise<void> {
+    await this.ensureExists()
+
+    const path = `${this.path}/${Util.basename(name)}`
+
+    await this.fileSystem.writeFile(path, contents)
+  }
+
+  async delete (name: string): Promise<void> {
+    const path = `${this.path}/${Util.basename(name)}`
+
+    if (await this.fileSystem.exists(path)) {
+      await this.fileSystem.unlink(path)
+    }
+  }
+
+  private async ensureExists (): Promise<void> {
+    try {
+      await this.fileSystem.mkdir(this.path)
+    } catch (err) {
+      // on Android mkdir will fail if the directory already exists, which isn't
+      // an error case we care about
+      // on iOS it will succeed unless there's a genuine error
+      if (isObject(err) && err.code !== 'EEXIST') {
+        throw err
+      }
+    }
+  }
+}

--- a/packages/platforms/react-native/tests/retry-queue/directory.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/directory.test.ts
@@ -1,0 +1,188 @@
+import RetryQueueDirectory from '../../lib/retry-queue/directory'
+import FileSystemFake from '../utilities/file-system-fake'
+
+describe('RetryQueueDirectory', () => {
+  describe('list', () => {
+    it('lists all files in directory', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a/b/c')
+
+      await fileSystem.mkdir('/a/b/c')
+
+      await Promise.all([
+        fileSystem.writeFile('/a/b/c/retry-1-d.json', ''),
+        fileSystem.writeFile('/a/b/c/retry-4-z.json', ''),
+        fileSystem.writeFile('/a/b/c/retry-3-a.json', ''),
+        fileSystem.writeFile('/a/b/c/retry-2-x.json', '')
+      ])
+
+      expect(await directory.files()).toStrictEqual([
+        'retry-4-z.json',
+        'retry-3-a.json',
+        'retry-2-x.json',
+        'retry-1-d.json'
+      ])
+    })
+
+    it('sorts invalid filenames to the end', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/x/y/z')
+
+      await fileSystem.mkdir('/x/y/z')
+
+      await Promise.all([
+        fileSystem.writeFile('/x/y/z/retry-12-x.json', ''),
+        fileSystem.writeFile('/x/y/z/retry-x-2.json', ''), // invalid
+        fileSystem.writeFile('/x/y/z/retry-45-y.json', ''),
+        fileSystem.writeFile('/x/y/z/retry-34-d.json', ''),
+        fileSystem.writeFile('/x/y/z/:).json', ''), // invalid
+        fileSystem.writeFile('/x/y/z/retry-23-j.json', '')
+      ])
+
+      expect(await directory.files()).toStrictEqual([
+        'retry-45-y.json',
+        'retry-34-d.json',
+        'retry-23-j.json',
+        'retry-12-x.json',
+        // invalid:
+        'retry-x-2.json',
+        ':).json'
+      ])
+    })
+
+    it('ignores sub-directories', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/aaa')
+
+      await Promise.all([
+        fileSystem.mkdir('/aaa'),
+        fileSystem.mkdir('/aaa/d'),
+        fileSystem.mkdir('/aaa/e')
+      ])
+
+      await Promise.all([
+        fileSystem.writeFile('/aaa/retry-1-d.json', ''),
+        fileSystem.writeFile('/aaa/retry-4-z.json', ''),
+        fileSystem.writeFile('/aaa/retry-3-a.json', ''),
+        fileSystem.writeFile('/aaa/retry-2-x.json', '')
+      ])
+
+      expect(await directory.files()).toStrictEqual([
+        'retry-4-z.json',
+        'retry-3-a.json',
+        'retry-2-x.json',
+        'retry-1-d.json'
+      ])
+
+      expect(await fileSystem.ls('/aaa')).toStrictEqual([
+        '/aaa/d',
+        '/aaa/e',
+        '/aaa/retry-1-d.json',
+        '/aaa/retry-4-z.json',
+        '/aaa/retry-3-a.json',
+        '/aaa/retry-2-x.json'
+      ])
+    })
+
+    it('ignores files in other directories', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a')
+
+      await Promise.all([
+        fileSystem.mkdir('/a'),
+        fileSystem.mkdir('/b'),
+        fileSystem.mkdir('/c')
+      ])
+
+      await Promise.all([
+        fileSystem.writeFile('/a/retry-1-d.json', ''),
+        fileSystem.writeFile('/b/retry-4-z.json', ''),
+        fileSystem.writeFile('/c/retry-3-a.json', ''),
+        fileSystem.writeFile('/a/retry-2-x.json', ''),
+        fileSystem.writeFile('/b/retry-7-o.json', ''),
+        fileSystem.writeFile('/c/retry-9-p.json', '')
+      ])
+
+      expect(await directory.files()).toStrictEqual([
+        'retry-2-x.json',
+        'retry-1-d.json'
+      ])
+    })
+
+    it('returns an empty list if the directory does not exist', async () => {
+      const directory = new RetryQueueDirectory(new FileSystemFake(), '/a/directory')
+
+      expect(await directory.files()).toStrictEqual([])
+    })
+
+    it('returns an empty list if the directory is empty', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a/directory')
+
+      await fileSystem.mkdir('/a/directory')
+
+      expect(await directory.files()).toStrictEqual([])
+    })
+  })
+
+  describe('read', () => {
+    it('reads the contents of the given file', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a')
+
+      await fileSystem.mkdir('/a')
+      await fileSystem.writeFile('/a/b.txt', 'hey there')
+
+      expect(await directory.read('b.txt')).toStrictEqual('hey there')
+    })
+
+    it('returns an empty string if the file does not exist', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a')
+
+      await fileSystem.mkdir('/a')
+
+      expect(await directory.read('b.txt')).toStrictEqual('')
+    })
+
+    it('returns an empty string if the directory does not exist', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a')
+
+      expect(await directory.read('b.txt')).toStrictEqual('')
+    })
+
+    it('does not traverse sub-directories', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a')
+
+      await fileSystem.mkdir('/a')
+      await fileSystem.mkdir('/a/b')
+      await fileSystem.writeFile('/a/b/c.txt', ':)')
+
+      expect(await directory.read('b/c.txt')).toStrictEqual('')
+    })
+  })
+
+  describe('write', () => {
+    it('writes to the given file', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/x')
+
+      await fileSystem.mkdir('/x')
+      await directory.write('y.z', 'hello')
+
+      expect(await directory.read('y.z')).toStrictEqual('hello')
+    })
+
+    it('will create the directory if it does not exist', async () => {
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a')
+
+      await directory.write('b.c', 'hi')
+
+      expect(await directory.read('b.c')).toStrictEqual('hi')
+      expect(await fileSystem.exists('/a/b.c')).toBe(true)
+    })
+  })
+})

--- a/packages/platforms/react-native/tests/utilities/file-system-fake.ts
+++ b/packages/platforms/react-native/tests/utilities/file-system-fake.ts
@@ -6,11 +6,6 @@ type FileSystemEntry
 
 type FileSystem = Map<string, FileSystemEntry>
 
-// TODO: keep?
-// function basename (path: string): string {
-//   return path.split('/').pop() || '/'
-// }
-
 function dirname (path: string): string {
   return path.split('/').slice(0, -1).join('/')
 }

--- a/packages/platforms/react-native/tests/utilities/file-system-fake.ts
+++ b/packages/platforms/react-native/tests/utilities/file-system-fake.ts
@@ -1,0 +1,110 @@
+enum FileSystemType { File, Directory }
+
+type FileSystemEntry
+  = { type: FileSystemType.File, name: string, data: string }
+  | { type: FileSystemType.Directory, name: string }
+
+type FileSystem = Map<string, FileSystemEntry>
+
+// TODO: keep?
+// function basename (path: string): string {
+//   return path.split('/').pop() || '/'
+// }
+
+function dirname (path: string): string {
+  return path.split('/').slice(0, -1).join('/')
+}
+
+export default class FileSystemFake {
+  private readonly entries: FileSystem
+
+  constructor () {
+    this.entries = new Map()
+  }
+
+  async ls (path: string): Promise<string[]> {
+    const entry = this.entries.get(path)
+
+    if (!entry) {
+      throw new Error(`path does not exist: ${path}`)
+    }
+
+    if (entry.type === FileSystemType.File) {
+      throw new Error(`cannot ls a file: ${entry.name}`)
+    }
+
+    const entries = []
+
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(path) && key !== path) {
+        entries.push(key)
+      }
+    }
+
+    return entries
+  }
+
+  async exists (path: string): Promise<boolean> {
+    return this.entries.has(path)
+  }
+
+  async isDir (path: string): Promise<boolean> {
+    const entry = this.entries.get(path)
+
+    if (entry) {
+      return entry.type === FileSystemType.Directory
+    }
+
+    return false
+  }
+
+  async readFile (path: string): Promise<string> {
+    const entry = this.entries.get(path)
+
+    if (!entry) {
+      throw new Error(`path does not exist: ${path}`)
+    }
+
+    if (entry.type === FileSystemType.Directory) {
+      throw new Error(`cannot call readFile on a directory: ${path}`)
+    }
+
+    return entry.data
+  }
+
+  async writeFile (path: string, data: string): Promise<void> {
+    const directory = dirname(path)
+    const entry = this.entries.get(directory)
+
+    if (!entry) {
+      throw new Error(`directory does not exist: ${directory}`)
+    }
+
+    if (entry.type === FileSystemType.File) {
+      throw new Error(`cannot use a file as a directory: ${JSON.stringify(entry)}`)
+    }
+
+    this.entries.set(path, {
+      type: FileSystemType.File,
+      name: path,
+      data
+    })
+  }
+
+  async mkdir (path: string): Promise<string> {
+    this.entries.set(path, {
+      type: FileSystemType.Directory,
+      name: path
+    })
+
+    return path
+  }
+
+  async unlink (path: string): Promise<void> {
+    if (!this.entries.has(path)) {
+      throw new Error(`path does not exist: ${path}`)
+    }
+
+    this.entries.delete(path)
+  }
+}


### PR DESCRIPTION
## Goal

This PR adds an abstraction over a directory for use with a new file-based retry queue to be added in a future PR

This is supported by a new fake implementation of `react-native-file-access` as the mock that ships with the library doesn't really deal with directories

The new `FileSystemFake` is implemented in 8919aaddacdac13fb15a4ea036554980d0a4261c, which is then consumed by the unit tests in the new `RetryQueueDirectory` in 202c62cb9c3fcce92a2768cc31cfa1074527bf9a