### PR TITLE
Move Edge-latest testing to BrowserStack

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -49,7 +49,7 @@ steps:
         concurrency_group: "bitbar"
         matrix:
           setup:
-            browser: [chrome, firefox, edge]
+            browser: [chrome, firefox]
             version: [latest]
           adjustments:
             - with: { browser: safari, version: 16 }
@@ -79,3 +79,4 @@ steps:
             - with: { browser: firefox, version: 60 }
             - with: { browser: edge, version: 80 }
             - with: { browser: safari, version: 11 }
+            - with: { browser: edge, version: latest }


### PR DESCRIPTION
## Goal

Move Edge-latest testing to BrowserStack.

## Changeset

Moves Edge Latest browser tests to BrowserStack temporarily to avoid a bug on BitBar (due to be fixed next week).

## Testing

Covered by CI.