### PR TITLE
Add file-based retry queue for React Native

### DIFF
--- a/packages/platforms/react-native/lib/persistence/index.ts
+++ b/packages/platforms/react-native/lib/persistence/index.ts
@@ -4,8 +4,10 @@ import { type DeviceInfo } from '../NativeBugsnagPerformance'
 import { File, NullFile, ReadOnlyFile } from './file'
 import FileBasedPersistence from './file-based'
 
-const PERSISTED_STATE_VERSION = 1
-const PERSISTED_STATE_PATH = `${Dirs.CacheDir}/bugsnag-performance-react-native/v${PERSISTED_STATE_VERSION}/persisted-state.json`
+const PERSISTENCE_VERSION = 1
+export const PERSISTENCE_DIRECTORY = `${Dirs.CacheDir}/bugsnag-performance-react-native/v${PERSISTENCE_VERSION}`
+
+const PERSISTED_STATE_PATH = `${PERSISTENCE_DIRECTORY}/persisted-state.json`
 
 export default function persistenceFactory (fileSystem: typeof FileSystem, deviceInfo?: DeviceInfo): FileBasedPersistence {
   const nativeDeviceIdFilePath = Platform.select({

--- a/packages/platforms/react-native/lib/retry-queue/directory.ts
+++ b/packages/platforms/react-native/lib/retry-queue/directory.ts
@@ -1,17 +1,8 @@
 import { isObject } from '@bugsnag/core-performance'
 import { Util, type FileSystem } from 'react-native-file-access'
+import timestampFromFilename from './timestamp-from-filename'
 
 type MinimalFileSystem = Pick<typeof FileSystem, 'ls' | 'exists' | 'isDir' | 'readFile' | 'writeFile' | 'mkdir' | 'unlink'>
-
-const FILENAME_REGEX = /^retry-([0-9]+)-.+\.json$/
-
-function timestampFromFilename (filename: string): bigint | undefined {
-  const match = FILENAME_REGEX.exec(filename)
-
-  if (match) {
-    return BigInt(match[1])
-  }
-}
 
 // sort filenames by newest -> oldest, i.e. the largest timestamps come first
 // any invalid filenames (where we can't parse a timestamp) are put at the end

--- a/packages/platforms/react-native/lib/retry-queue/directory.ts
+++ b/packages/platforms/react-native/lib/retry-queue/directory.ts
@@ -2,7 +2,7 @@ import { isObject } from '@bugsnag/core-performance'
 import { Util, type FileSystem } from 'react-native-file-access'
 import timestampFromFilename from './timestamp-from-filename'
 
-type MinimalFileSystem = Pick<typeof FileSystem, 'ls' | 'exists' | 'isDir' | 'readFile' | 'writeFile' | 'mkdir' | 'unlink'>
+export type MinimalFileSystem = Pick<typeof FileSystem, 'ls' | 'exists' | 'isDir' | 'readFile' | 'writeFile' | 'mkdir' | 'unlink'>
 
 // sort filenames by newest -> oldest, i.e. the largest timestamps come first
 // any invalid filenames (where we can't parse a timestamp) are put at the end

--- a/packages/platforms/react-native/lib/retry-queue/file-based.ts
+++ b/packages/platforms/react-native/lib/retry-queue/file-based.ts
@@ -1,0 +1,150 @@
+import {
+  type Delivery,
+  type DeliveryPayload,
+  type DeliverySpan,
+  type RetryQueue,
+  type TracePayload
+} from '@bugsnag/core-performance'
+import type Directory from './directory'
+import timestampFromFilename from './timestamp-from-filename'
+
+function getLatestSpan (body: DeliveryPayload): DeliverySpan | undefined {
+  let latestSpan: DeliverySpan | undefined
+  let biggestTimestamp: bigint | undefined
+
+  for (const resourceSpan of body.resourceSpans) {
+    for (const scopeSpan of resourceSpan.scopeSpans) {
+      for (const span of scopeSpan.spans) {
+        if (biggestTimestamp === undefined || BigInt(span.endTimeUnixNano) > biggestTimestamp) {
+          latestSpan = span
+
+          // store the biggest timestamp separately as a bigint so we don't need
+          // to parse it on every iteration
+          biggestTimestamp = BigInt(latestSpan.endTimeUnixNano)
+        }
+      }
+    }
+  }
+
+  return latestSpan
+}
+
+function isValidFilename (filename: string): boolean {
+  // if the filename is too short then it can't be valid
+  if (filename.length < MININUM_FILENAME_LENGTH) {
+    return false
+  }
+
+  const timestamp = timestampFromFilename(filename)
+
+  // if we can't parse a timestamp then the filename can't be valid
+  if (!timestamp) {
+    return false
+  }
+
+  const nowInNanoseconds = BigInt(Date.now()) * NANOSECONDS_IN_MILLISECONDS
+
+  // files that are older than 24 hours are not valid as the data may not be
+  // relevant anymore
+  if (timestamp < nowInNanoseconds - NANOSECONDS_IN_DAY) {
+    return false
+  }
+
+  // files that have a timestamp more than 24 hours in the future are not
+  // valid as something may have gone wrong with the clock and this is
+  // unlikely to be a timezone issue
+  if (timestamp > nowInNanoseconds + NANOSECONDS_IN_DAY) {
+    return false
+  }
+
+  return true
+}
+
+// the minimum possible length of a payload filename (i.e. a 1 character
+// timestamp and span ID)
+const MININUM_FILENAME_LENGTH = 'retry-0-0.json'.length
+const NANOSECONDS_IN_MILLISECONDS = BigInt(1_000_000)
+const NANOSECONDS_IN_DAY = BigInt(24 * 60 * 60_000) * NANOSECONDS_IN_MILLISECONDS
+
+// the outcome of flushing a single file — either delete it (e.g. success or
+// permanent failure) or leave it alone for the next flush (retryable failure)
+const enum FlushOutcome { DeleteFile, LeaveFile }
+
+export default class FileBasedRetryQueue implements RetryQueue {
+  private readonly delivery: Delivery
+  private readonly directory: Directory
+
+  constructor (delivery: Delivery, directory: Directory) {
+    this.delivery = delivery
+    this.directory = directory
+  }
+
+  async add (payload: TracePayload, _time: number): Promise<void> {
+    const span = getLatestSpan(payload.body)
+
+    if (!span) {
+      return
+    }
+
+    // we use the latest span's timestamp in the filename so we can decide
+    // whether to keep or discard the span without parsing the payload
+    // as we can't be sure of nanosecond precision in JS environments, we also
+    // append the span ID so file names are unique across batches
+    const filename = `retry-${span.endTimeUnixNano}-${span.spanId}.json`
+
+    try {
+      const json = JSON.stringify(payload)
+
+      await this.directory.write(filename, json)
+    } catch {
+    }
+  }
+
+  async flush (): Promise<void> {
+    const files = await this.directory.files()
+
+    for (const filename of files) {
+      try {
+        const outcome = await this.flushFile(filename)
+
+        if (outcome === FlushOutcome.DeleteFile) {
+          await this.directory.delete(filename)
+        }
+      } catch {
+      }
+    }
+  }
+
+  private async flushFile (filename: string): Promise<FlushOutcome> {
+    if (!isValidFilename(filename)) {
+      return FlushOutcome.DeleteFile
+    }
+
+    const payload = await this.getPayloadFromFile(filename)
+
+    if (!payload) {
+      return FlushOutcome.DeleteFile
+    }
+
+    const response = await this.delivery.send(payload)
+
+    switch (response.state) {
+      case 'success':
+      case 'failure-discard':
+        return FlushOutcome.DeleteFile
+
+      case 'failure-retryable':
+        // this file will be retried by the next flush so we can leave it alone
+        return FlushOutcome.LeaveFile
+    }
+
+    response.state satisfies never
+  }
+
+  private async getPayloadFromFile (name: string): Promise<TracePayload | undefined> {
+    try {
+      return JSON.parse(await this.directory.read(name))
+    } catch {
+    }
+  }
+}

--- a/packages/platforms/react-native/lib/retry-queue/index.ts
+++ b/packages/platforms/react-native/lib/retry-queue/index.ts
@@ -1,0 +1,17 @@
+import {
+  type Delivery,
+  type RetryQueue,
+  type RetryQueueFactory
+} from '@bugsnag/core-performance'
+
+import RetryQueueDirectory, { type MinimalFileSystem } from './directory'
+import FileBasedRetryQueue from './file-based'
+import { PERSISTENCE_DIRECTORY } from '../persistence'
+
+export default function createRetryQueueFactory (fileSystem: MinimalFileSystem): RetryQueueFactory {
+  return function fileBasedQueueFactory (delivery: Delivery, _retryQueueMaxSize: number): RetryQueue {
+    const directory = new RetryQueueDirectory(fileSystem, `${PERSISTENCE_DIRECTORY}/retry-queue`)
+
+    return new FileBasedRetryQueue(delivery, directory)
+  }
+}

--- a/packages/platforms/react-native/lib/retry-queue/timestamp-from-filename.ts
+++ b/packages/platforms/react-native/lib/retry-queue/timestamp-from-filename.ts
@@ -1,0 +1,9 @@
+const FILENAME_REGEX = /^retry-([0-9]+)-.+\.json$/
+
+export default function timestampFromFilename (filename: string): bigint | undefined {
+  const match = FILENAME_REGEX.exec(filename)
+
+  if (match) {
+    return BigInt(match[1])
+  }
+}

--- a/packages/platforms/react-native/tests/retry-queue/file-based.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/file-based.test.ts
@@ -1,0 +1,319 @@
+import FileBasedRetryQueue from '../../lib/retry-queue/file-based'
+import RetryQueueDirectory from '../../lib/retry-queue/directory'
+import FileSystemFake from '../utilities/file-system-fake'
+import { InMemoryDelivery, makePayloadCreator } from '@bugsnag/js-performance-test-utilities'
+
+const createPayload = makePayloadCreator()
+
+describe('RetryQueueDirectory', () => {
+  describe('add', () => {
+    it('writes a file to the retry queue directory', async () => {
+      const delivery = new InMemoryDelivery()
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a/b/c')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      const payload = createPayload({ spanId: 'abcd', endTimeUnixNano: '1234' })
+
+      await queue.add(payload, 0)
+
+      const contents = await directory.read('retry-1234-abcd.json')
+
+      expect(JSON.parse(contents)).toStrictEqual(payload)
+      expect(await directory.files()).toStrictEqual(['retry-1234-abcd.json'])
+    })
+
+    it('uses the span with the largest timestamp for the filename', async () => {
+      const delivery = new InMemoryDelivery()
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a/b/c')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      const payload = createPayload(
+        { spanId: 'abcd', endTimeUnixNano: '1234' },
+        { spanId: 'wxyz', endTimeUnixNano: '1235' }
+      )
+
+      await queue.add(payload, 0)
+
+      const contents = await directory.read('retry-1235-wxyz.json')
+
+      expect(JSON.parse(contents)).toStrictEqual(payload)
+      expect(await directory.files()).toStrictEqual(['retry-1235-wxyz.json'])
+    })
+
+    it('does not write a file if the payload has no spans', async () => {
+      const delivery = new InMemoryDelivery()
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a/b/c')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      await queue.add(createPayload(), 0)
+
+      expect(await directory.files()).toStrictEqual([])
+    })
+
+    it('writes separate files for different payloads', async () => {
+      const delivery = new InMemoryDelivery()
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/a/b/c')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      const payload1 = createPayload({ spanId: 'abcd', endTimeUnixNano: '1234' })
+      const payload2 = createPayload({ spanId: 'wxyz', endTimeUnixNano: '1235' })
+
+      await queue.add(payload1, 0)
+      await queue.add(payload2, 0)
+
+      expect(await directory.files()).toStrictEqual([
+        'retry-1235-wxyz.json',
+        'retry-1234-abcd.json'
+      ])
+
+      const contents1 = await directory.read('retry-1235-wxyz.json')
+      expect(JSON.parse(contents1)).toStrictEqual(payload2)
+
+      const contents2 = await directory.read('retry-1234-abcd.json')
+      expect(JSON.parse(contents2)).toStrictEqual(payload1)
+    })
+  })
+
+  describe('flush', () => {
+    it('delivers payloads in order of newest -> oldest', async () => {
+      const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+      const delivery = new InMemoryDelivery()
+      const fileSystem = new FileSystemFake()
+      const directory = new RetryQueueDirectory(fileSystem, '/aaa')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      const payload1 = createPayload({
+        spanId: 'abcd',
+        endTimeUnixNano: String(validEndTime + BigInt(99))
+      })
+
+      const payload2 = createPayload({
+        spanId: 'wxyz',
+        endTimeUnixNano: String(validEndTime + BigInt(999))
+      })
+
+      const payload3 = createPayload({
+        spanId: 'jjjj',
+        endTimeUnixNano: String(validEndTime + BigInt(9))
+      })
+
+      await queue.add(payload1, 0)
+      await queue.add(payload2, 0)
+      await queue.add(payload3, 0)
+
+      expect(await directory.files()).toStrictEqual([
+        `retry-${payload2.body.resourceSpans[0].scopeSpans[0].spans[0].endTimeUnixNano}-wxyz.json`,
+        `retry-${payload1.body.resourceSpans[0].scopeSpans[0].spans[0].endTimeUnixNano}-abcd.json`,
+        `retry-${payload3.body.resourceSpans[0].scopeSpans[0].spans[0].endTimeUnixNano}-jjjj.json`
+      ])
+
+      await queue.flush()
+
+      expect(delivery.requests[0]).toStrictEqual(payload2.body)
+      expect(delivery.requests[1]).toStrictEqual(payload1.body)
+      expect(delivery.requests[2]).toStrictEqual(payload3.body)
+      expect(delivery.requests).toHaveLength(3)
+
+      expect(await directory.files()).toStrictEqual([])
+    })
+
+    it('deletes files with invalid names', async () => {
+      const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+      const payload = createPayload({ spanId: 'a', endTimeUnixNano: validEndTime.toString() })
+
+      const fileSystem = new FileSystemFake()
+      await fileSystem.mkdir('/abc')
+
+      await Promise.all([
+        fileSystem.writeFile('/abc/retry-abc-123.json', 'swapped span id and timestamp'),
+        fileSystem.writeFile('/abc/retry-123-abc.txt', 'invalid extension'),
+        fileSystem.writeFile('/abc/:)', 'completely wrong'),
+        fileSystem.writeFile('/abc/retry-0-a.txt', 'invalid extension'),
+        fileSystem.writeFile(`/abc/retry-${validEndTime}-abcd.json`, JSON.stringify(payload))
+      ])
+
+      const delivery = new InMemoryDelivery()
+      const directory = new RetryQueueDirectory(fileSystem, '/abc')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      expect(await directory.files()).toStrictEqual([
+        `retry-${validEndTime}-abcd.json`,
+        'retry-abc-123.json',
+        'retry-123-abc.txt',
+        ':)',
+        'retry-0-a.txt'
+      ])
+
+      await queue.flush()
+
+      // only 1 request should be made with the valid payload
+      expect(delivery.requests[0]).toStrictEqual(payload.body)
+      expect(delivery.requests).toHaveLength(1)
+
+      // all the files should have been deleted
+      expect(await directory.files()).toStrictEqual([])
+    })
+
+    it('deletes files with invalid contents', async () => {
+      const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+      const payload = createPayload({ spanId: 'a', endTimeUnixNano: validEndTime.toString() })
+
+      const fileSystem = new FileSystemFake()
+      await fileSystem.mkdir('/abc')
+
+      await Promise.all([
+        fileSystem.writeFile('/abc/retry-abc-123.json', 'swapped span id and timestamp'),
+        fileSystem.writeFile('/abc/retry-123-abc.txt', 'invalid extension'),
+        fileSystem.writeFile('/abc/:)', 'completely wrong'),
+        fileSystem.writeFile('/abc/retry-0-a.txt', 'invalid extension'),
+        fileSystem.writeFile(`/abc/retry-${validEndTime + BigInt(2)}-ijkl.json`, JSON.stringify(payload)),
+        fileSystem.writeFile(`/abc/retry-${validEndTime + BigInt(1)}-efgh.json`, '{"invalid json :) }}}}')
+      ])
+
+      const delivery = new InMemoryDelivery()
+      const directory = new RetryQueueDirectory(fileSystem, '/abc')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      expect(await directory.files()).toStrictEqual([
+        `retry-${validEndTime + BigInt(2)}-ijkl.json`,
+        `retry-${validEndTime + BigInt(1)}-efgh.json`,
+        'retry-abc-123.json',
+        'retry-123-abc.txt',
+        ':)',
+        'retry-0-a.txt'
+      ])
+
+      await queue.flush()
+
+      expect(delivery.requests[0]).toStrictEqual(payload.body)
+      expect(delivery.requests).toHaveLength(1)
+
+      // all the files should have been deleted
+      expect(await directory.files()).toStrictEqual([])
+    })
+
+    it('deletes files after permanent delivery failure', async () => {
+      const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+      const payload1 = createPayload({ spanId: 'a', endTimeUnixNano: validEndTime.toString() })
+      const payload2 = createPayload({ spanId: 'b', endTimeUnixNano: (validEndTime + BigInt(1)).toString() })
+      const payload3 = createPayload({ spanId: 'c', endTimeUnixNano: (validEndTime + BigInt(2)).toString() })
+
+      const fileSystem = new FileSystemFake()
+      const delivery = new InMemoryDelivery()
+      const directory = new RetryQueueDirectory(fileSystem, '/abc')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      await queue.add(payload1, 1234)
+      await queue.add(payload2, 1234)
+      await queue.add(payload3, 1234)
+
+      expect(await directory.files()).toStrictEqual([
+        `retry-${validEndTime + BigInt(2)}-c.json`,
+        `retry-${validEndTime + BigInt(1)}-b.json`,
+        `retry-${validEndTime}-a.json`
+      ])
+
+      delivery.setNextResponseState('failure-discard')
+      delivery.setNextResponseState('success')
+
+      await queue.flush()
+
+      expect(delivery.requests).toStrictEqual([
+        payload3.body,
+        payload2.body,
+        payload1.body
+      ])
+
+      // all files should have been deleted
+      expect(await directory.files()).toStrictEqual([])
+    })
+
+    it('leaves files after retryable delivery failure', async () => {
+      const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+      const payload1 = createPayload({ spanId: 'a', endTimeUnixNano: validEndTime.toString() })
+      const payload2 = createPayload({ spanId: 'b', endTimeUnixNano: (validEndTime + BigInt(1)).toString() })
+      const payload3 = createPayload({ spanId: 'c', endTimeUnixNano: (validEndTime + BigInt(2)).toString() })
+
+      const fileSystem = new FileSystemFake()
+      const delivery = new InMemoryDelivery()
+      const directory = new RetryQueueDirectory(fileSystem, '/abc')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      await queue.add(payload1, 1234)
+      await queue.add(payload2, 1234)
+      await queue.add(payload3, 1234)
+
+      expect(await directory.files()).toStrictEqual([
+        `retry-${validEndTime + BigInt(2)}-c.json`,
+        `retry-${validEndTime + BigInt(1)}-b.json`,
+        `retry-${validEndTime}-a.json`
+      ])
+
+      delivery.setNextResponseState('failure-retryable')
+      delivery.setNextResponseState('success')
+
+      await queue.flush()
+
+      expect(delivery.requests).toStrictEqual([
+        payload3.body,
+        payload2.body,
+        payload1.body
+      ])
+
+      // the second file should be left alone
+      expect(await directory.files()).toStrictEqual([`retry-${validEndTime + BigInt(1)}-b.json`])
+    })
+
+    it('deletes files that are more than 24 hours old', async () => {
+      const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+      const payload1 = createPayload({ spanId: 'a', endTimeUnixNano: validEndTime.toString() })
+      const payload2 = createPayload({ spanId: 'c', endTimeUnixNano: '1234567890' })
+
+      const fileSystem = new FileSystemFake()
+      const delivery = new InMemoryDelivery()
+      const directory = new RetryQueueDirectory(fileSystem, '/abc')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      await queue.add(payload1, 1234)
+      await queue.add(payload2, 1234)
+
+      expect(await directory.files()).toStrictEqual([
+        `retry-${validEndTime}-a.json`,
+        'retry-1234567890-c.json'
+      ])
+
+      await queue.flush()
+
+      expect(delivery.requests).toStrictEqual([payload1.body])
+      expect(await directory.files()).toStrictEqual([])
+    })
+
+    it('deletes files that are more than 24 hours in the future', async () => {
+      const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+      const payload1 = createPayload({ spanId: 'a', endTimeUnixNano: validEndTime.toString() })
+      const payload2 = createPayload({ spanId: 'c', endTimeUnixNano: (validEndTime * BigInt(10)).toString() })
+
+      const fileSystem = new FileSystemFake()
+      const delivery = new InMemoryDelivery()
+      const directory = new RetryQueueDirectory(fileSystem, '/abc')
+      const queue = new FileBasedRetryQueue(delivery, directory)
+
+      await queue.add(payload1, 1234)
+      await queue.add(payload2, 1234)
+
+      expect(await directory.files()).toStrictEqual([
+        `retry-${validEndTime * BigInt(10)}-c.json`,
+        `retry-${validEndTime}-a.json`
+      ])
+
+      await queue.flush()
+
+      expect(delivery.requests).toStrictEqual([payload1.body])
+      expect(await directory.files()).toStrictEqual([])
+    })
+  })
+})

--- a/packages/platforms/react-native/tests/retry-queue/index.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/index.test.ts
@@ -1,0 +1,38 @@
+import createRetryQueueFactory from '../../lib/retry-queue'
+import FileBasedRetryQueue from '../../lib/retry-queue/file-based'
+import FileSystemFake from '../utilities/file-system-fake'
+import { InMemoryDelivery, makePayloadCreator } from '@bugsnag/js-performance-test-utilities'
+
+const EXPECTED_PATH = '/mock/CacheDir/bugsnag-performance-react-native/v1/retry-queue'
+const flushPromises = () => new Promise(process.nextTick)
+const createPayload = makePayloadCreator()
+
+describe('File based retry queue factory', () => {
+  it('returns a FileBasedRetryQueue', () => {
+    const retryQueueFactory = createRetryQueueFactory(new FileSystemFake())
+
+    expect(retryQueueFactory(new InMemoryDelivery(), 20)).toBeInstanceOf(FileBasedRetryQueue)
+  })
+
+  it('uses the correct path to the persistence directory', async () => {
+    const fileSystem = new FileSystemFake()
+    const retryQueueFactory = createRetryQueueFactory(fileSystem)
+
+    const delivery = new InMemoryDelivery()
+    const queue = retryQueueFactory(delivery, 20)
+
+    const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+    const payload = createPayload({ spanId: 'abcd', endTimeUnixNano: validEndTime.toString() })
+    queue.add(payload, 0)
+
+    await flushPromises()
+
+    const file = await fileSystem.readFile(`${EXPECTED_PATH}/retry-${validEndTime}-abcd.json`)
+    expect(JSON.parse(file)).toStrictEqual(payload)
+
+    await queue.flush()
+
+    expect(delivery.requests[0]).toStrictEqual(payload.body)
+    expect(delivery.requests).toHaveLength(1)
+  })
+})

--- a/packages/platforms/react-native/tests/retry-queue/timestamp-from-filename.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/timestamp-from-filename.test.ts
@@ -1,0 +1,30 @@
+import timestampFromFilename from '../../lib/retry-queue/timestamp-from-filename'
+
+describe('timestampFromFilename', () => {
+  it.each([
+    ['retry-0-a.json', '0'],
+    ['retry-1-a.json', '1'],
+    ['retry-200000-a.json', '200000'],
+    ['retry-1234567890-a.json', '1234567890'],
+    ['retry-00000000000-a.json', '0'],
+    ['retry-999999999999999999999999999999999999-a.json', '999999999999999999999999999999999999']
+  ])('parses %s into the timestamp %s', (input, expected) => {
+    // ideally we'd want to do something like this:
+    // expect(timestampFromFilename(input)).toBe(BigInt(expected))
+    // but Jest can't serialise BigInts yet so we have to use strings for now
+    const actual = timestampFromFilename(input)
+
+    expect(actual?.toString()).toBe(expected)
+  })
+
+  it.each([
+    'retry-a-0.json',
+    'retry0a.json',
+    'retry-a-a.json',
+    'retry-1-a.txt',
+    'retry-1-a.json.txt',
+    'retry-retry-1-a.json'
+  ])('will not parse the invalid filename: %s', (input) => {
+    expect(timestampFromFilename(input)).toBeUndefined()
+  })
+})

--- a/packages/platforms/react-native/tsconfig.json
+++ b/packages/platforms/react-native/tsconfig.json
@@ -7,6 +7,7 @@
     "lib/NativeBugsnagPerformance.ts"
   ],
   "compilerOptions": {
+    "target": "ES2020",
     "types": ["../../../cuid"]
   }
 }

--- a/packages/test-utilities/lib/create-payload.ts
+++ b/packages/test-utilities/lib/create-payload.ts
@@ -1,0 +1,40 @@
+import { type DeliverySpan, type TracePayload } from '@bugsnag/core-performance'
+
+type PayloadCreator = (...spans: Array<Partial<DeliverySpan>>) => TracePayload
+
+export default function makePayloadCreator (): PayloadCreator {
+  let id = 0
+
+  return function createPayload (...spans: Array<Partial<DeliverySpan>>): TracePayload {
+    return {
+      body: {
+        resourceSpans: [
+          {
+            resource: {
+              attributes: []
+            },
+            scopeSpans: [
+              {
+                spans: spans.map((span: Partial<DeliverySpan>) => ({
+                  name: span.name || `span #${++id}`,
+                  kind: span.kind === undefined ? 1 : span.kind,
+                  spanId: span.spanId || 'span ' + String(id).repeat(27),
+                  traceId: 'trace ' + String(id).repeat(26),
+                  startTimeUnixNano: span.startTimeUnixNano || '123',
+                  endTimeUnixNano: span.endTimeUnixNano || '456',
+                  attributes: span.attributes || [],
+                  events: span.events || []
+                }))
+              }
+            ]
+          }
+        ]
+      },
+      headers: {
+        'Bugsnag-Api-Key': 'abcdefabcdefabcdefabcdefabcdef12',
+        'Content-Type': 'application/json' as const,
+        'Bugsnag-Span-Sampling': `1:${spans.length}`
+      }
+    }
+  }
+}

--- a/packages/test-utilities/lib/index.ts
+++ b/packages/test-utilities/lib/index.ts
@@ -2,6 +2,7 @@ import './matchers'
 
 export { default as ControllableBackgroundingListener } from './controllable-backgrounding-listener'
 export { default as createConfiguration } from './create-configuration'
+export { default as makePayloadCreator } from './create-payload'
 export * from './create-span'
 export { default as createTestClient } from './create-test-client'
 export { default as IncrementingClock } from './incrementing-clock'


### PR DESCRIPTION
## Goal

This PR adds a file based retry queue that works by writing failed payloads to disk and reading from them when `flush` is called

If delivery is successful or fails with the `failure-discard` state, the file gets deleted. Otherwise the file is left on disk to be retried on the next `flush` call

Files are stored with a filename in the format `retry-<timestamp>-<span ID>.json` where `timestamp` is the largest `endTimeUnixNano` in the payload's spans

Any file with a timestamp more than 24 hours in the past or future will be deleted when `flush` is called. Files with invalid names (i.e. do not match the format) will also be deleted

## Testing

This has only been unit tested so far so is not actually being used by the SDK yet