### PR TITLE
[PLAT-10863] Add new net.host.connection.subtype span attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- (browser) Fall back to unbuffered performance observer when buffer is not supported [#352](https://github.com/bugsnag/bugsnag-js-performance/pull/352) 
+- (browser) Fall back to unbuffered performance observer when buffer is not supported [#352](https://github.com/bugsnag/bugsnag-js-performance/pull/352)
 
 ## v1.2.0 (2023-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - (react-native) Added `net.host.connection.type` span attribute [#334](https://github.com/bugsnag/bugsnag-js-performance/pull/334)
+- (react-native) Added `net.host.connection.subtype` span attribute [#360](https://github.com/bugsnag/bugsnag-js-performance/pull/360)
 
 ### Fixed
 

--- a/packages/platforms/react-native/lib/get-network-connection-type.ts
+++ b/packages/platforms/react-native/lib/get-network-connection-type.ts
@@ -2,6 +2,8 @@ import { type NetInfoStateType } from '@react-native-community/netinfo'
 
 export type NetworkConnectionType = 'wifi' | 'wired' | 'cell' | 'unavailable' | 'unknown'
 
+export type CellularGeneration = '2g' | '3g' | '4g' | '5g'
+
 function getNetworkConnectionType (state: NetInfoStateType): NetworkConnectionType {
   switch (state) {
     case 'none':

--- a/packages/platforms/react-native/lib/span-attributes-source.ts
+++ b/packages/platforms/react-native/lib/span-attributes-source.ts
@@ -2,14 +2,17 @@ import { type SpanAttributesSource } from '@bugsnag/core-performance'
 import NetInfo from '@react-native-community/netinfo'
 import { type AppStateStatic } from 'react-native'
 import { type ReactNativeConfiguration } from './config'
-import getNetworkConnectionType, { type NetworkConnectionType } from './get-network-connection-type'
+import getNetworkConnectionType, { type CellularGeneration, type NetworkConnectionType } from './get-network-connection-type'
 
 export function createSpanAttributesSource (appState: AppStateStatic) {
   let connectionType: NetworkConnectionType = 'unknown'
+  let cellularGeneration: CellularGeneration
 
   // Subscribe to network changes
   NetInfo.addEventListener(state => {
     connectionType = getNetworkConnectionType(state.type)
+    // @ts-expect-error cellularGeneration does not exist on type
+    cellularGeneration = state.details?.cellularGeneration
   })
 
   const spanAttributesSource: SpanAttributesSource<ReactNativeConfiguration> = {
@@ -19,6 +22,10 @@ export function createSpanAttributesSource (appState: AppStateStatic) {
     requestAttributes (span) {
       span.setAttribute('bugsnag.app.in_foreground', appState.currentState === 'active')
       span.setAttribute('net.host.connection.type', connectionType)
+
+      if (cellularGeneration && connectionType === 'cell') {
+        span.setAttribute('net.host.connection.subtype', cellularGeneration)
+      }
     }
   }
 


### PR DESCRIPTION
## Goal

Add the `net.host.connection.subtype` string attribute when the `net.host.connection.type` has the value `cell`

## Testing

Update unit tests to expect connection subtype attribute