### PR TITLE
Listen for pagehide and pageshow events in backgrounding listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - (browser) Fall back to unbuffered performance observer when buffer is not supported [#352](https://github.com/bugsnag/bugsnag-js-performance/pull/352)
+- (browser) Listen for pagehide and pageshow events in backgrounding listener [#362](https://github.com/bugsnag/bugsnag-js-performance/pull/362)
 
 ## v1.2.0 (2023-10-12)
 

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -13,7 +13,7 @@ import createResourceAttributesSource from './resource-attributes-source'
 import createSpanAttributesSource from './span-attributes-source'
 import { WebVitals } from './web-vitals'
 
-const backgroundingListener = createBrowserBackgroundingListener(document)
+const backgroundingListener = createBrowserBackgroundingListener(window)
 const spanAttributesSource = createSpanAttributesSource(document)
 const clock = createClock(performance, backgroundingListener)
 const persistence = makeBrowserPersistence(window)

--- a/packages/platforms/browser/tests/backgrounding-listener.test.ts
+++ b/packages/platforms/browser/tests/backgrounding-listener.test.ts
@@ -29,50 +29,150 @@ class DocumentStub {
   }
 }
 
+class WindowFake {
+  readonly #eventListeners = new Map<string, () => void>()
+
+  readonly document = new DocumentStub()
+
+  addEventListener (event: string, callback: () => void) {
+    this.#eventListeners.set(event, callback)
+  }
+
+  _hidePage () {
+    const callback = this.#eventListeners.get('pagehide')
+
+    if (callback) {
+      callback()
+    }
+  }
+
+  _showPage () {
+    const callback = this.#eventListeners.get('pageshow')
+
+    if (callback) {
+      callback()
+    }
+  }
+}
+
 describe('Browser BackgroundingListener', () => {
-  it('calls the registered callback with "in-foreground" when visibilityState changes to "visible"', () => {
-    const documentStub = new DocumentStub()
+  it('calls the registered callback immediately when visibilityState is "hidden" on registration', () => {
+    const windowFake = new WindowFake()
     const onStateChangeCallback = jest.fn()
 
-    const listener = createBrowserBackgroundingListener(documentStub)
-    listener.onStateChange(onStateChangeCallback)
+    const listener = createBrowserBackgroundingListener(windowFake)
+
+    windowFake.document.visibilityState = 'hidden'
 
     expect(onStateChangeCallback).not.toHaveBeenCalled()
 
-    documentStub.visibilityState = 'visible'
+    listener.onStateChange(onStateChangeCallback)
 
-    expect(onStateChangeCallback).toHaveBeenCalledWith('in-foreground')
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
   })
 
   it('calls the registered callback with "in-background" when visibilityState changes to "hidden"', () => {
-    const documentStub = new DocumentStub()
+    const windowFake = new WindowFake()
     const onStateChangeCallback = jest.fn()
 
-    const listener = createBrowserBackgroundingListener(documentStub)
+    const listener = createBrowserBackgroundingListener(windowFake)
     listener.onStateChange(onStateChangeCallback)
 
     expect(onStateChangeCallback).not.toHaveBeenCalled()
 
-    documentStub.visibilityState = 'hidden'
+    windowFake.document.visibilityState = 'hidden'
 
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
   })
 
-  it('calls the registered callback immediately when visibilityState is "hidden" on registration', () => {
-    const documentStub = new DocumentStub()
+  it('calls the registered callback with "in-foreground" when visibilityState changes to "visible"', () => {
+    const windowFake = new WindowFake()
     const onStateChangeCallback = jest.fn()
 
-    const listener = createBrowserBackgroundingListener(documentStub)
-
-    documentStub.visibilityState = 'hidden'
-
-    expect(onStateChangeCallback).not.toHaveBeenCalled()
-
+    windowFake.document.visibilityState = 'hidden'
+    const listener = createBrowserBackgroundingListener(windowFake)
     listener.onStateChange(onStateChangeCallback)
 
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+
+    windowFake.document.visibilityState = 'visible'
+
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-foreground')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(2)
+  })
+
+  it('calls the registered callback with "in-background" on pagehide', () => {
+    const windowFake = new WindowFake()
+    const onStateChangeCallback = jest.fn()
+
+    const listener = createBrowserBackgroundingListener(windowFake)
+    listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    windowFake._hidePage()
+
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls the registered callback with "in-foreground" on a pageshow', () => {
+    const windowFake = new WindowFake()
+    const onStateChangeCallback = jest.fn()
+
+    const listener = createBrowserBackgroundingListener(windowFake)
+    listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    windowFake._hidePage()
+
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+
+    windowFake._showPage()
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-foreground')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not call the registered callback with in-background if the page is already hidden', () => {
+    const windowFake = new WindowFake()
+    const onStateChangeCallback = jest.fn()
+
+    windowFake.document.visibilityState = 'hidden'
+    const listener = createBrowserBackgroundingListener(windowFake)
+    listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+
+    windowFake.document.visibilityState = 'hidden'
+
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+
+    windowFake._hidePage()
+
+    expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call the registered callback with in-foreground when the page is already visible', () => {
+    const windowFake = new WindowFake()
+    const onStateChangeCallback = jest.fn()
+
+    const listener = createBrowserBackgroundingListener(windowFake)
+    listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    windowFake.document.visibilityState = 'visible'
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    windowFake._showPage()
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Goal

On some versions of Mobile Safari the `visibilitychange` event does not fire if a page is cached/suspended when navigating away, which can mean spans that should be discarded are left open.

This PR updates the backgrounding listener to also listen for `pagehide` and `pageshow` events which do fire in that scenario.

The backgrounding listener now tracks the current backgrounding state to avoid notifying subscribers more than once when both `visibilitychange` and `pageshow`/`pagehide` events are fired


