### PR TITLE
Round timestamps to the nearest integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - (browser) Fall back to unbuffered performance observer when buffer is not supported [#352](https://github.com/bugsnag/bugsnag-js-performance/pull/352)
 - (browser) Listen for pagehide and pageshow events in backgrounding listener [#362](https://github.com/bugsnag/bugsnag-js-performance/pull/362)
+- (core) Round timestamps to the nearest integer [#364](https://github.com/bugsnag/bugsnag-js-performance/pull/364)
 
 ## v1.2.0 (2023-10-12)
 

--- a/packages/core/lib/clock.ts
+++ b/packages/core/lib/clock.ts
@@ -1,7 +1,7 @@
 const NANOSECONDS_IN_MILLISECONDS = 1_000_000
 
 export function millisecondsToNanoseconds (milliseconds: number): number {
-  return milliseconds * NANOSECONDS_IN_MILLISECONDS
+  return Math.round(milliseconds * NANOSECONDS_IN_MILLISECONDS)
 }
 
 export interface Clock {

--- a/packages/core/tests/clock.test.ts
+++ b/packages/core/tests/clock.test.ts
@@ -1,0 +1,8 @@
+import { millisecondsToNanoseconds } from '../lib/clock'
+
+describe('millisecondsToNanoseconds', () => {
+  it('rounds to the nearest integer', () => {
+    expect(millisecondsToNanoseconds(123456789.1122345)).toEqual(123456789_112235)
+    expect(millisecondsToNanoseconds(123456789.1122344)).toEqual(123456789_112234)
+  })
+})

--- a/packages/core/tests/clock.test.ts
+++ b/packages/core/tests/clock.test.ts
@@ -1,7 +1,7 @@
 import { millisecondsToNanoseconds } from '../lib/clock'
 
 describe('millisecondsToNanoseconds', () => {
-  it('rounds to the nearest integer', () => {
+  it('rounds to the nearest nanosecond', () => {
     expect(millisecondsToNanoseconds(123456789.1122345)).toEqual(123456789_112235)
     expect(millisecondsToNanoseconds(123456789.1122344)).toEqual(123456789_112234)
   })


### PR DESCRIPTION
## Goal

Browser timing APIs usually return a `DOMHighResTimestamp` (aka a double). These values are usually integers (i.e. whole milliseconds) but it is valid for them to contain a fractional part, representing nanoseconds

Currently we don’t do anything to handle this, which results in our encoded JSON payloads being invalid according to the OTEL spec

This PR updates the millisecond to nanosecond conversion to round nanoseconds to the nearest integer to ensure we always send a valid payload.

## Design

`performance.now` on React Native also returns a double, so went for implementing this in the core `millisecondsToNanoseconds` function as this is used to convert millisecond values by both of the platform-specific clocks