### PR TITLE
Flush the retry queue in more situations on React Native

### DIFF
--- a/packages/platforms/react-native/__mocks__/@react-native-community/netinfo.ts
+++ b/packages/platforms/react-native/__mocks__/@react-native-community/netinfo.ts
@@ -39,7 +39,7 @@ const initialState: NetInfoState = {
 let listeners: NetInfoChangeHandler[] = []
 
 const MockNetInfo: typeof NetInfo = {
-  fetch: jest.fn(),
+  fetch: jest.fn(() => Promise.resolve(initialState)),
   refresh: jest.fn(),
   configure: jest.fn(),
   addEventListener: jest.fn((listener) => {

--- a/packages/platforms/react-native/__mocks__/react-native.ts
+++ b/packages/platforms/react-native/__mocks__/react-native.ts
@@ -137,3 +137,27 @@ export const TurboModuleRegistry = {
     }
   }
 }
+
+export type AppStateStatus = 'active' | 'inactive' | 'background'
+type AppStateChangeCallback = (status: AppStateStatus) => void
+
+export const AppState = new class {
+  #status: AppStateStatus = 'active'
+  readonly #eventListeners: AppStateChangeCallback[] = []
+
+  addEventListener (event: string, listener: AppStateChangeCallback): void {
+    this.#eventListeners.push(listener)
+  }
+
+  get currentState (): AppStateStatus {
+    return this.#status
+  }
+
+  bugsnagChangeAppStateStatus (status: AppStateStatus): void {
+    this.#status = status
+
+    for (const listener of this.#eventListeners) {
+      listener(this.#status)
+    }
+  }
+}()

--- a/packages/platforms/react-native/lib/retry-queue/index.ts
+++ b/packages/platforms/react-native/lib/retry-queue/index.ts
@@ -3,7 +3,8 @@ import {
   type RetryQueue,
   type RetryQueueFactory
 } from '@bugsnag/core-performance'
-import { AppState, type AppStateStatus } from 'react-native'
+import NetInfo, { type NetInfoState } from '@react-native-community/netinfo'
+import { AppState, Platform, type AppStateStatus } from 'react-native'
 
 import RetryQueueDirectory, { type MinimalFileSystem } from './directory'
 import FileBasedRetryQueue from './file-based'
@@ -17,10 +18,40 @@ export default function createRetryQueueFactory (fileSystem: MinimalFileSystem):
     // send any currently stored payloads from previous launches
     retryQueue.flush()
 
+    // store the last known network state value so we can see if it has changed
+    let lastNetworkState: NetInfoState | undefined
+
     // flush the retry queue when the app changes from background -> foreground
     // or vice versa
-    AppState.addEventListener('change', (_status: AppStateStatus): void => {
+    AppState.addEventListener('change', (status: AppStateStatus): void => {
       retryQueue.flush()
+
+      // on iOS the app doesn't get network information events when in the
+      // background so we need to fetch it when returning to the foreground
+      // to ensure 'lastNetworkState' doesn't get out of date
+      if (status === 'active' && Platform.OS === 'ios') {
+        NetInfo.fetch().then((newState: NetInfoState): void => {
+          lastNetworkState = newState
+        })
+      }
+    })
+
+    // flush the retry queue when the app gains network connectivity
+    NetInfo.addEventListener((newState: NetInfoState): void => {
+      // only flush if we've gained network connectivity since the last time it
+      // changed, e.g. we don't need to flush if going from a cellular
+      // connection to wifi as both connections should allow us to send spans
+      // we also don't flush the first time this is called (when
+      // 'lastNetworkState' is undefined) as net info calls this callback soon
+      // after registering it but we already flush the queue immediately
+      if (newState.isConnected &&
+        lastNetworkState !== undefined &&
+        !lastNetworkState.isConnected
+      ) {
+        retryQueue.flush()
+      }
+
+      lastNetworkState = newState
     })
 
     return retryQueue

--- a/packages/platforms/react-native/lib/retry-queue/index.ts
+++ b/packages/platforms/react-native/lib/retry-queue/index.ts
@@ -14,6 +14,9 @@ export default function createRetryQueueFactory (fileSystem: MinimalFileSystem):
     const directory = new RetryQueueDirectory(fileSystem, `${PERSISTENCE_DIRECTORY}/retry-queue`)
     const retryQueue = new FileBasedRetryQueue(delivery, directory)
 
+    // send any currently stored payloads from previous launches
+    retryQueue.flush()
+
     // flush the retry queue when the app changes from background -> foreground
     // or vice versa
     AppState.addEventListener('change', (_status: AppStateStatus): void => {

--- a/packages/platforms/react-native/tests/retry-queue/index.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/index.test.ts
@@ -4,6 +4,15 @@ import FileSystemFake from '../utilities/file-system-fake'
 import { InMemoryDelivery, makePayloadCreator } from '@bugsnag/js-performance-test-utilities'
 import { AppState } from 'react-native'
 
+// eslint-disable-next-line jest/no-mocks-import
+import {
+  NetInfoStateType,
+  notifyNetworkStateChange,
+  resetEventListeners
+} from '../../__mocks__/@react-native-community/netinfo'
+
+afterEach(resetEventListeners)
+
 const EXPECTED_PATH = '/mock/CacheDir/bugsnag-performance-react-native/v1/retry-queue'
 const flushPromises = () => new Promise(process.nextTick)
 const createPayload = makePayloadCreator()
@@ -75,6 +84,55 @@ describe('File based retry queue factory', () => {
 
     // @ts-expect-error we add this in our RN mock
     AppState.bugsnagChangeAppStateStatus(status)
+
+    await flushPromises()
+
+    expect(delivery.requests[0]).toStrictEqual(payload.body)
+    expect(delivery.requests).toHaveLength(1)
+  })
+
+  it('flushes the retry queue when the app gains network connectivity', async () => {
+    const fileSystem = new FileSystemFake()
+    const retryQueueFactory = createRetryQueueFactory(fileSystem)
+
+    const delivery = new InMemoryDelivery()
+    const queue = retryQueueFactory(delivery, 20)
+
+    const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+    const payload = createPayload({ spanId: 'abcd', endTimeUnixNano: validEndTime.toString() })
+    await queue.add(payload, 0)
+
+    expect(delivery.requests).toHaveLength(0)
+
+    notifyNetworkStateChange({
+      isConnected: false,
+      isInternetReachable: false,
+      type: NetInfoStateType.none,
+      details: null
+    })
+
+    // we just disconnected so there should be no requests
+    await flushPromises()
+    expect(delivery.requests).toHaveLength(0)
+
+    notifyNetworkStateChange({
+      isConnected: false,
+      isInternetReachable: false,
+      type: NetInfoStateType.none,
+      details: null
+    })
+
+    // another disconnection should still not send a request
+    await flushPromises()
+    expect(delivery.requests).toHaveLength(0)
+
+    // connecting should result in a flush
+    notifyNetworkStateChange({
+      isConnected: true,
+      isInternetReachable: true,
+      type: NetInfoStateType.ethernet,
+      details: { ipAddress: '1234', subnet: '5678', isConnectionExpensive: false }
+    })
 
     await flushPromises()
 

--- a/packages/platforms/react-native/tests/retry-queue/index.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/index.test.ts
@@ -2,6 +2,7 @@ import createRetryQueueFactory from '../../lib/retry-queue'
 import FileBasedRetryQueue from '../../lib/retry-queue/file-based'
 import FileSystemFake from '../utilities/file-system-fake'
 import { InMemoryDelivery, makePayloadCreator } from '@bugsnag/js-performance-test-utilities'
+import { AppState } from 'react-native'
 
 const EXPECTED_PATH = '/mock/CacheDir/bugsnag-performance-react-native/v1/retry-queue'
 const flushPromises = () => new Promise(process.nextTick)
@@ -31,6 +32,30 @@ describe('File based retry queue factory', () => {
     expect(JSON.parse(file)).toStrictEqual(payload)
 
     await queue.flush()
+
+    expect(delivery.requests[0]).toStrictEqual(payload.body)
+    expect(delivery.requests).toHaveLength(1)
+  })
+
+  it.each(
+    ['active', 'inactive', 'background']
+  )('flushes the retry queue when the app state status changes to "%s"', async (status) => {
+    const fileSystem = new FileSystemFake()
+    const retryQueueFactory = createRetryQueueFactory(fileSystem)
+
+    const delivery = new InMemoryDelivery()
+    const queue = retryQueueFactory(delivery, 20)
+
+    const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
+    const payload = createPayload({ spanId: 'abcd', endTimeUnixNano: validEndTime.toString() })
+    await queue.add(payload, 0)
+
+    expect(delivery.requests).toHaveLength(0)
+
+    // @ts-expect-error we add this in our RN mock
+    AppState.bugsnagChangeAppStateStatus(status)
+
+    await flushPromises()
 
     expect(delivery.requests[0]).toStrictEqual(payload.body)
     expect(delivery.requests).toHaveLength(1)


### PR DESCRIPTION
## Goal

Flush the retry queue in more situations on React Native — because there is a persistent queue, it makes sense to flush more often than in the browser SDK

Specifically the queue is flushed:

- when `BugsnagPerformance.start` is called
- when the app is backgrounded or foregrounded
- when the device gains network connectivity