### PR TITLE
Skip flakey React Native test for background spans

### DIFF
--- a/test/react-native/features/manual-spans.feature
+++ b/test/react-native/features/manual-spans.feature
@@ -40,6 +40,8 @@ Feature: Manual spans
       | ios     | @skip     |
       | android | @not_null |
 
+  # This test will be removed as part of PLAT-11214
+  @skip
   Scenario: Spans can be logged from the background
     When I run 'BackgroundSpanScenario'
     And I wait to receive a sampling request

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -5,6 +5,10 @@ BeforeAll do
   Maze.config.enforce_bugsnag_integrity = false
 end
 
+Before('@skip') do
+  skip_this_scenario("Skipping scenario")
+end
+
 Before('@skip_ios_old_arch') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == 'ios' && !ENV["RCT_NEW_ARCH_ENABLED"]
 end


### PR DESCRIPTION
## Goal

This test is flakey and will be replaced as part of PLAT-11214 anyhow, so skipping for now