### PR TITLE
Check requestEntropy methods are present in native module

### DIFF
--- a/packages/platforms/react-native/lib/id-generator.ts
+++ b/packages/platforms/react-native/lib/id-generator.ts
@@ -5,6 +5,12 @@ const POOL_SIZE = 1024
 
 const CALLS_BEFORE_POOL_REFRESH = 1000
 
+const isNativeModuleEnabled = (nativeModule: NativeBugsnag | null): nativeModule is NativeBugsnag => {
+  return nativeModule !== null &&
+  typeof nativeModule.requestEntropy === 'function' &&
+  typeof nativeModule.requestEntropyAsync === 'function'
+}
+
 export function toHex (value: number): string {
   const hex = value.toString(16)
 
@@ -28,8 +34,8 @@ export function createRandomString (): string {
 
 function createIdGenerator (NativeBugsnagPerformance: NativeBugsnag | null): IdGenerator {
   // If the native module is not available for any reason, fall back to a JS implementation
-  const requestEntropy = NativeBugsnagPerformance ? NativeBugsnagPerformance.requestEntropy : createRandomString
-  const requestEntropyAsync = NativeBugsnagPerformance ? NativeBugsnagPerformance.requestEntropyAsync : async () => createRandomString()
+  const requestEntropy = isNativeModuleEnabled(NativeBugsnagPerformance) ? NativeBugsnagPerformance.requestEntropy : createRandomString
+  const requestEntropyAsync = isNativeModuleEnabled(NativeBugsnagPerformance) ? NativeBugsnagPerformance.requestEntropyAsync : async () => createRandomString()
 
   // initialise the pool synchronously
   const randomValues = requestEntropy()


### PR DESCRIPTION
## Goal

On iOS the codegen for turbo modules doesn't run unless you run `pod install` with `RCT_NEW_ARCH_ENABLED=1`, and there are no compiler warnings or errors when the native module spec has changed - any new native methods added since the last codegen are just undefined at runtime.

We should therefore ensure the new native methods `requestEntropy` and `requestEntropyAsync` are present (as well as the native module itself) before using them.