### PR TITLE
Fix flakey test: wait for element to appear in angular e2e tests

### DIFF
--- a/test/browser/features/angular.feature
+++ b/test/browser/features/angular.feature
@@ -6,6 +6,7 @@ Feature: Angular
 
     Scenario: Route change spans are automatically instrumented
         Given I navigate to the test URL "/angular/dist"
+        And the element "customers" is present
         And I click the element "customers"
         When I wait to receive 1 trace
 
@@ -25,6 +26,7 @@ Feature: Angular
 
     Scenario: Route with a custom URL matcher
         Given I navigate to the test URL "/angular/dist"
+        And the element "customMatching" is present
         And I click the element "customMatching"
         When I wait to receive 1 trace
 


### PR DESCRIPTION
## Goal

Fixes an Angular test flake on iOS - the angular test fixture renders a loading screen initially, and then lazy loads the app component that contains the elements. On some occasions the component hasn't loaded when we try to click the element, so the test now waits for the element to appear before clicking