### PR TITLE
Export noops from browser package when window or document is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD
+
+- (browser) Export noops from browser package when window or document is undefined [#390](https://github.com/bugsnag/bugsnag-js-performance/pull/390)
+
 ## v2.1.0 (2023-12-12)
 
 ### Fixed

--- a/packages/platforms/browser/lib/browser.ts
+++ b/packages/platforms/browser/lib/browser.ts
@@ -1,62 +1,72 @@
-import { createClient, InMemoryQueue } from '@bugsnag/core-performance'
+import { type Client, createClient, createNoopClient, InMemoryQueue } from '@bugsnag/core-performance'
 import createFetchDeliveryFactory from '@bugsnag/delivery-fetch-performance'
 import { createFetchRequestTracker, createXmlHttpRequestTracker } from '@bugsnag/request-tracker-performance'
 import { FullPageLoadPlugin, NetworkRequestPlugin, ResourceLoadPlugin, RouteChangePlugin } from './auto-instrumentation'
 import createBrowserBackgroundingListener from './backgrounding-listener'
 import createClock from './clock'
-import { createSchema } from './config'
-import { createDefaultRoutingProvider } from './default-routing-provider'
+import { type BrowserConfiguration, createSchema } from './config'
+import { createDefaultRoutingProvider, createNoopRoutingProvider } from './default-routing-provider'
 import idGenerator from './id-generator'
-import createOnSettle from './on-settle'
+import createOnSettle, { createNoopOnSettle, type OnSettlePlugin } from './on-settle'
 import makeBrowserPersistence from './persistence'
 import createResourceAttributesSource from './resource-attributes-source'
 import createSpanAttributesSource from './span-attributes-source'
 import { WebVitals } from './web-vitals'
 
-const backgroundingListener = createBrowserBackgroundingListener(window)
-const spanAttributesSource = createSpanAttributesSource(document)
-const clock = createClock(performance, backgroundingListener)
-const persistence = makeBrowserPersistence(window)
-const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
-const fetchRequestTracker = createFetchRequestTracker(window, clock)
-const xhrRequestTracker = createXmlHttpRequestTracker(XMLHttpRequest, clock, document)
-const webVitals = new WebVitals(performance, clock, window.PerformanceObserver)
-export const onSettle = createOnSettle(
-  clock,
-  window,
-  fetchRequestTracker,
-  xhrRequestTracker,
-  performance
-)
-export const DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+export let onSettle: OnSettlePlugin
+export let DefaultRoutingProvider: ReturnType<typeof createDefaultRoutingProvider>
+let BugsnagPerformance: Client<BrowserConfiguration>
 
-const BugsnagPerformance = createClient({
-  backgroundingListener,
-  clock,
-  resourceAttributesSource,
-  spanAttributesSource,
-  deliveryFactory: createFetchDeliveryFactory(window.fetch, clock, backgroundingListener),
-  idGenerator,
-  schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
-  plugins: (spanFactory, spanContextStorage) => [
-    onSettle,
-    new FullPageLoadPlugin(
-      document,
-      window.location,
-      spanFactory,
-      webVitals,
+if (typeof window === 'undefined' || typeof document === 'undefined') {
+  onSettle = createNoopOnSettle()
+  DefaultRoutingProvider = createNoopRoutingProvider()
+  BugsnagPerformance = createNoopClient()
+} else {
+  const backgroundingListener = createBrowserBackgroundingListener(window)
+  const spanAttributesSource = createSpanAttributesSource(document)
+  const clock = createClock(performance, backgroundingListener)
+  const persistence = makeBrowserPersistence(window)
+  const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
+  const fetchRequestTracker = createFetchRequestTracker(window, clock)
+  const xhrRequestTracker = createXmlHttpRequestTracker(XMLHttpRequest, clock, document)
+  const webVitals = new WebVitals(performance, clock, window.PerformanceObserver)
+  onSettle = createOnSettle(
+    clock,
+    window,
+    fetchRequestTracker,
+    xhrRequestTracker,
+    performance
+  )
+  DefaultRoutingProvider = createDefaultRoutingProvider(onSettle, window.location)
+
+  BugsnagPerformance = createClient({
+    backgroundingListener,
+    clock,
+    resourceAttributesSource,
+    spanAttributesSource,
+    deliveryFactory: createFetchDeliveryFactory(window.fetch, clock, backgroundingListener),
+    idGenerator,
+    schema: createSchema(window.location.hostname, new DefaultRoutingProvider()),
+    plugins: (spanFactory, spanContextStorage) => [
       onSettle,
-      backgroundingListener,
-      performance
-    ),
-    // ResourceLoadPlugin should always come after FullPageLoad plugin, as it should use that
-    // span context as the parent of it's spans
-    new ResourceLoadPlugin(spanFactory, spanContextStorage, window.PerformanceObserver),
-    new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
-    new RouteChangePlugin(spanFactory, window.location, document)
-  ],
-  persistence,
-  retryQueueFactory: (delivery, retryQueueMaxSize) => new InMemoryQueue(delivery, retryQueueMaxSize)
-})
+      new FullPageLoadPlugin(
+        document,
+        window.location,
+        spanFactory,
+        webVitals,
+        onSettle,
+        backgroundingListener,
+        performance
+      ),
+      // ResourceLoadPlugin should always come after FullPageLoad plugin, as it should use that
+      // span context as the parent of it's spans
+      new ResourceLoadPlugin(spanFactory, spanContextStorage, window.PerformanceObserver),
+      new NetworkRequestPlugin(spanFactory, fetchRequestTracker, xhrRequestTracker),
+      new RouteChangePlugin(spanFactory, window.location, document)
+    ],
+    persistence,
+    retryQueueFactory: (delivery, retryQueueMaxSize) => new InMemoryQueue(delivery, retryQueueMaxSize)
+  })
+}
 
 export default BugsnagPerformance

--- a/packages/platforms/browser/lib/default-routing-provider.ts
+++ b/packages/platforms/browser/lib/default-routing-provider.ts
@@ -4,6 +4,18 @@ import { type RouteResolver, type RoutingProvider, type StartRouteChangeCallback
 
 export const defaultRouteResolver: RouteResolver = (url: URL) => url.pathname || '/'
 
+export const createNoopRoutingProvider = () => {
+  return class NoopRoutingProvider implements RoutingProvider {
+    resolveRoute: RouteResolver
+
+    constructor (resolveRoute = defaultRouteResolver) {
+      this.resolveRoute = resolveRoute
+    }
+
+    listenForRouteChanges (startRouteChangeSpan: StartRouteChangeCallback) {}
+  }
+}
+
 export const createDefaultRoutingProvider = (onSettle: OnSettle, location: Location) => {
   return class DefaultRoutingProvider implements RoutingProvider {
     resolveRoute: RouteResolver

--- a/packages/platforms/browser/lib/on-settle/index.ts
+++ b/packages/platforms/browser/lib/on-settle/index.ts
@@ -12,6 +12,12 @@ export type OnSettlePlugin = Plugin<BrowserConfiguration> & OnSettle
 
 const TIMEOUT_MILLISECONDS = 60 * 1000
 
+export function createNoopOnSettle (): OnSettlePlugin {
+  const noop = () => {}
+  noop.configure = () => {}
+  return noop as OnSettlePlugin
+}
+
 export default function createOnSettle (
   clock: Clock,
   window: Window,

--- a/packages/platforms/browser/tests/default-routing-provider.test.ts
+++ b/packages/platforms/browser/tests/default-routing-provider.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { createDefaultRoutingProvider, defaultRouteResolver } from '../lib/default-routing-provider'
+import { createDefaultRoutingProvider, createNoopRoutingProvider, defaultRouteResolver } from '../lib/default-routing-provider'
 
 jest.useFakeTimers()
 
@@ -81,5 +81,19 @@ describe('DefaultRoutingProvider', () => {
       expect(route).toBe('new route')
       expect(routeResolver).toHaveBeenCalled()
     })
+  })
+})
+
+describe('noopRoutingProvider', () => {
+  it('implements the expected API', () => {
+    expect(() => {
+      const NoopRoutingProvider = createNoopRoutingProvider()
+      const routeResolver = jest.fn(() => 'new route')
+      const routingProvider = new NoopRoutingProvider(routeResolver)
+
+      routingProvider.listenForRouteChanges(jest.fn())
+      expect(routingProvider.resolveRoute(new URL(window.location.href))).toBe('new route')
+      expect(routeResolver).toHaveBeenCalled()
+    }).not.toThrow()
   })
 })

--- a/packages/platforms/browser/tests/on-settle/index.test.ts
+++ b/packages/platforms/browser/tests/on-settle/index.test.ts
@@ -5,10 +5,11 @@
 import {
   IncrementingClock,
   VALID_API_KEY,
-  createTestClient
+  createTestClient,
+  createConfiguration
 } from '@bugsnag/js-performance-test-utilities'
 import { type BrowserConfiguration, type BrowserSchema, createSchema } from '../../lib/config'
-import createOnSettle from '../../lib/on-settle'
+import createOnSettle, { createNoopOnSettle } from '../../lib/on-settle'
 import {
   RequestTracker,
   type RequestEndContext,
@@ -422,5 +423,15 @@ describe('onSettle', () => {
 
     await jest.advanceTimersByTimeAsync(100)
     expect(settleCallback).toHaveBeenCalled()
+  })
+})
+
+describe('createNoopOnSettle', () => {
+  it('implements the expected API', () => {
+    expect(() => {
+      const noopOnSettle = createNoopOnSettle()
+      noopOnSettle(() => {})
+      noopOnSettle.configure(createConfiguration())
+    }).not.toThrow()
   })
 })


### PR DESCRIPTION
## Goal

Prevent the SDK from crashing when used in SSR frameworks such as Next or Nuxt. 

Currently `window` and `document` are accessed when the library is imported which causes a crash when the code is executed server-side as these are not defined.

This PR aims to prevent this and allow the SDK to be used in SSR apps, by exporting a noop client, onSettle and routing provider if `window` and `document` are undefined.

## Testing

Added unit tests for the onSettle and routing provider noops, and tested manually with a Next.js app