### PR TITLE
Fix invalid span duration when ending immediately

### DIFF
--- a/packages/react-navigation/lib/create-navigation-container.tsx
+++ b/packages/react-navigation/lib/create-navigation-container.tsx
@@ -6,6 +6,9 @@ import { NavigationContextProvider } from './navigation-context'
 
 type ParamList = Record<string, unknown>
 
+// Prevent rollup plugin from tree shaking NavigationContextProvider
+const Provider = NavigationContextProvider
+
 export const createNavigationContainer = <P extends ParamList>(Container = NavigationContainer, spanFactory: SpanFactory<ReactNativeConfiguration>) =>
   forwardRef<NavigationContainerRef<P>, NavigationContainerProps>(
     (props, _ref) => {
@@ -31,13 +34,13 @@ export const createNavigationContainer = <P extends ParamList>(Container = Navig
       }
 
       return (
-        <NavigationContextProvider spanFactory={spanFactory} currentRoute={routeName}>
+        <Provider spanFactory={spanFactory} currentRoute={routeName}>
           <Container
             {...rest}
             onStateChange={wrappedOnStateChange}
             ref={navigationContainerRef}
           />
-        </NavigationContextProvider>
+        </Provider>
       )
     }
   )

--- a/packages/react-navigation/lib/navigation-context.tsx
+++ b/packages/react-navigation/lib/navigation-context.tsx
@@ -31,7 +31,7 @@ export class NavigationContextProvider extends React.Component<Props, State> {
   state = {
     previousRoute: undefined,
     componentsLoading: 0,
-    lastRenderTime: performance.now()
+    lastRenderTime: 0
   }
 
   blockNavigationEnd = () => {
@@ -58,10 +58,14 @@ export class NavigationContextProvider extends React.Component<Props, State> {
   triggerNavigationEnd = () => {
     clearTimeout(this.timerRef)
 
+    // Spans ended without a specific end condition will need to use the time `triggerNavigationEnd` was called
+    const triggerNavigationEndTime = performance.now()
+
     this.timerRef = setTimeout(() => {
       if (this.state.componentsLoading === 0 && this.currentSpan) {
         this.currentSpan.setAttribute('bugsnag.navigation.ended_by', this.endCondition)
-        this.props.spanFactory.endSpan(this.currentSpan, this.state.lastRenderTime)
+        const endTime = this.state.lastRenderTime === 0 ? triggerNavigationEndTime : this.state.lastRenderTime
+        this.props.spanFactory.endSpan(this.currentSpan, endTime)
         this.currentSpan = undefined
       }
     }, 100)

--- a/packages/react-navigation/lib/react-navigation-native-plugin.ts
+++ b/packages/react-navigation/lib/react-navigation-native-plugin.ts
@@ -12,7 +12,7 @@ class ReactNavigationNativePlugin implements Plugin<ReactNativeConfiguration> {
 
   createNavigationContainer = () => {
     if (!this.spanFactory) throw new Error('Bugsnag: ReactNavigationNativePlugin not configured')
-    createNavigationContainer(NavigationContainer, this.spanFactory)
+    return createNavigationContainer(NavigationContainer, this.spanFactory)
   }
 }
 

--- a/packages/react-navigation/rollup.config.mjs
+++ b/packages/react-navigation/rollup.config.mjs
@@ -13,7 +13,7 @@ const config = createRollupConfig({
 
 config.acornInjectPlugins = [jsx()]
 config.plugins = config.plugins.concat([
-  noTreeShakingPlugin(['create-navigation-container.tsx', 'navigation-context.tsx']
+  noTreeShakingPlugin(['create-navigation-container.tsx', 'navigation-context.tsx', 'complete-navigation.tsx']
 )])
 
 export default config


### PR DESCRIPTION
## Goal

Ensure navigation spans are not ended with time of `0` when not using a `CompleteNavigation` component

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->