### PR TITLE
[PLAT-11455] First input delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- (browser) Prevent throwing an error in edge cases when `performance.getEntriesByType()` returns undefined [#401](https://github.com/bugsnag/bugsnag-js-performance/pull/401)
+
 ## v2.2.0 (2024-02-01)
 
 This release adds support for automatic span instrumentation when using React Navigation in React Native apps. See [online docs](https://docs.bugsnag.com/performance/integration-guides/react-native/navigation-libraries) for details.

--- a/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
@@ -37,7 +37,9 @@ export const instrumentPageLoadPhaseSpans = (
     spanFactory.endSpan(span, endTime)
   }
 
-  const entry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming
+  const entries = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]
+  const entry = Array.isArray(entries) && entries[0]
+
   if (entry) {
     createPageLoadPhaseSpan('Unload', entry.unloadEventStart, entry.unloadEventEnd)
     createPageLoadPhaseSpan('Redirect', entry.redirectStart, entry.redirectEnd)

--- a/packages/platforms/browser/lib/web-vitals.ts
+++ b/packages/platforms/browser/lib/web-vitals.ts
@@ -94,7 +94,8 @@ export class WebVitals {
   }
 
   private firstContentfulPaint () {
-    const entry = this.performance.getEntriesByName('first-contentful-paint', 'paint')[0]
+    const entries = this.performance.getEntriesByName('first-contentful-paint', 'paint')
+    const entry = Array.isArray(entries) && entries[0]
 
     if (entry) {
       return entry.startTime
@@ -102,7 +103,8 @@ export class WebVitals {
   }
 
   private timeToFirstByte () {
-    const entry = this.performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming
+    const entries = this.performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]
+    const entry = Array.isArray(entries) && entries[0]
 
     let responseStart: number
 
@@ -121,7 +123,8 @@ export class WebVitals {
   }
 
   private firstInputDelay () {
-    const entry = this.performance.getEntriesByType('first-input')[0] as PerformanceEventTiming
+    const entries = this.performance.getEntriesByType('first-input') as PerformanceEventTiming[]
+    const entry = Array.isArray(entries) && entries[0]
 
     if (entry) {
       return {

--- a/packages/platforms/browser/tests/web-vitals.test.ts
+++ b/packages/platforms/browser/tests/web-vitals.test.ts
@@ -1,0 +1,23 @@
+import { IncrementingClock, MockSpanFactory } from '@bugsnag/js-performance-test-utilities'
+import { PerformanceFake, PerformanceObserverManager } from './utilities'
+import { WebVitals } from '../lib/web-vitals'
+
+describe('WebVitals', () => {
+  it('does not throw when performance.getEntriesByType returns undefined', () => {
+    expect(() => {
+      const clock = new IncrementingClock('1970-01-01T00:00:00Z')
+      const manager = new PerformanceObserverManager()
+      const performance = new PerformanceFake()
+
+      // @ts-expect-error overwrite getEntriesByType to return undefined
+      performance.getEntriesByType = jest.fn(() => undefined)
+      // @ts-expect-error overwrite getEntriesByName to return undefined
+      performance.getEntriesByName = jest.fn(() => undefined)
+
+      const webVitals = new WebVitals(performance, clock, manager.createPerformanceObserverFakeClass())
+      const spanFactory = new MockSpanFactory()
+      const span = spanFactory.startSpan('test span', {})
+      webVitals.attachTo(span)
+    }).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Goal

Prevent throwing an error in edge cases when `performance.getEntriesByType()` returns undefined

## Changeset

Add additional guard when getting entries for web vitals

## Testing

Add unit test to ensure error is not thrown when `getEntriesByType` returns `undefined`