### PR TITLE
Add LCP to firefox web vitals after version 122

### DIFF
--- a/test/browser/features/lib/browser.rb
+++ b/test/browser/features/lib/browser.rb
@@ -122,10 +122,12 @@ class Browser
 
   def firefox_supported_vitals
     case @version
+    when (122..)
+      ["fcp", "fid_end", "fid_start", "lcp", "ttfb"]
     when (89..)
-      ["ttfb", "fcp", "fid_start", "fid_end"]
+      ["fcp", "fid_end", "fid_start", "ttfb"]
     when (84..)
-      ["ttfb", "fcp", "cls"]
+      ["fcp", "cls", "ttfb"]
     else
       ["ttfb"]
     end


### PR DESCRIPTION
## Goal

Update assertions for web vitals on [Firefox 122](https://www.mozilla.org/en-US/firefox/122.0/releasenotes/) to include [Largest Contentful Paint ](https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint)