### PR TITLE
[PLAT-11566] Instrument navigation spans

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,13 +12,13 @@ steps:
   #
   # Upload each basic pipeline
   #
-  # - label: ":pipeline_upload: Basic browser pipeline"
-  #   commands:
-  #     - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
+  - label: ":pipeline_upload: Basic browser pipeline"
+    commands:
+      - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
-  # - label: ":pipeline_upload: React Native pipeline"
-  #   commands:
-  #     - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
+  - label: ":pipeline_upload: React Native pipeline"
+    commands:
+      - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
 
   - label: ":pipeline_upload: React Native Navigation pipeline"
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,13 +12,13 @@ steps:
   #
   # Upload each basic pipeline
   #
-  - label: ":pipeline_upload: Basic browser pipeline"
-    commands:
-      - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
+  # - label: ":pipeline_upload: Basic browser pipeline"
+  #   commands:
+  #     - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
-  - label: ":pipeline_upload: React Native pipeline"
-    commands:
-      - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
+  # - label: ":pipeline_upload: React Native pipeline"
+  #   commands:
+  #     - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
 
   - label: ":pipeline_upload: React Native Navigation pipeline"
     commands:

--- a/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
+++ b/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
@@ -43,10 +43,14 @@ describe('ReactNativeNavigationPlugin', () => {
 
     jest.advanceTimersByTime(100)
 
-    expect(spanFactory.createdSpans).toContainEqual(expect.objectContaining({
-      name: '[Navigation]TestScreen',
-      startTime: 0,
-      endTime: 0
-    }))
+    expect(spanFactory.endSpan).toHaveBeenCalledTimes(1)
+    expect(spanFactory.createdSpans).toHaveLength(1)
+
+    const span = spanFactory.createdSpans[0]
+    expect(span.name).toEqual('[Navigation]TestScreen')
+    expect(span).toHaveAttribute('bugsnag.span.category', 'navigation')
+    expect(span).toHaveAttribute('bugsnag.span.first_class', false)
+    expect(span).toHaveAttribute('bugsnag.navigation.route', 'TestScreen')
+    expect(span).toHaveAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
   })
 })

--- a/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
+++ b/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
@@ -3,13 +3,47 @@ import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance
 import ReactNativeNavigationPlugin from '../lib/react-native-navigation-plugin'
 import { Navigation } from 'react-native-navigation'
 
+jest.mock('react-native-navigation', () => {
+  return {
+    Navigation: {
+      events: jest.fn().mockReturnValue({
+        registerCommandListener: jest.fn(),
+        registerCommandCompletedListener: jest.fn(),
+        registerComponentDidAppearListener: jest.fn()
+      })
+    }
+  }
+})
+
 describe('ReactNativeNavigationPlugin', () => {
-  it('is configurable', () => {
+  it('creates a navigation span when the route changes', () => {
     const plugin = new ReactNativeNavigationPlugin(Navigation)
     const configuration = createConfiguration<ReactNativeConfiguration>()
     const spanFactory = new MockSpanFactory()
-    expect(() => {
-      plugin.configure(configuration, spanFactory)
-    }).not.toThrow()
+    plugin.configure(configuration, spanFactory)
+
+    // Simulate a route change
+    jest.mocked(Navigation.events().registerCommandListener).mock.calls[0][0]('push', {
+      commandId: '1',
+      componentId: '123'
+    })
+
+    jest.mocked(Navigation.events().registerComponentDidAppearListener).mock.calls[0][0]({
+      componentId: '123',
+      componentName: 'TestScreen',
+      componentType: 'Component'
+    })
+
+    jest.mocked(Navigation.events().registerCommandCompletedListener).mock.calls[0][0]({
+      commandId: '1',
+      completionTime: 1000,
+      commandName: 'push'
+    })
+
+    expect(spanFactory.createdSpans).toContainEqual(expect.objectContaining({
+      name: '[Navigation]TestScreen',
+      startTime: expect.any(Number),
+      endTime: 1000
+    }))
   })
 })

--- a/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
+++ b/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
@@ -8,11 +8,18 @@ jest.mock('react-native-navigation', () => {
     Navigation: {
       events: jest.fn().mockReturnValue({
         registerCommandListener: jest.fn(),
-        registerCommandCompletedListener: jest.fn(),
         registerComponentDidAppearListener: jest.fn()
       })
     }
   }
+})
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
 })
 
 describe('ReactNativeNavigationPlugin', () => {
@@ -34,16 +41,12 @@ describe('ReactNativeNavigationPlugin', () => {
       componentType: 'Component'
     })
 
-    jest.mocked(Navigation.events().registerCommandCompletedListener).mock.calls[0][0]({
-      commandId: '1',
-      completionTime: 1000,
-      commandName: 'push'
-    })
+    jest.advanceTimersByTime(100)
 
     expect(spanFactory.createdSpans).toContainEqual(expect.objectContaining({
       name: '[Navigation]TestScreen',
-      startTime: expect.any(Number),
-      endTime: 1000
+      startTime: 0,
+      endTime: 0
     }))
   })
 })

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -1,12 +1,40 @@
-import { type InternalConfiguration, type Plugin, type SpanFactory } from '@bugsnag/core-performance'
+import { type InternalConfiguration, type Plugin, type SpanFactory, type SpanInternal } from '@bugsnag/core-performance'
 import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance'
 import { type NavigationDelegate } from 'react-native-navigation/lib/dist/src/NavigationDelegate'
 
 class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
+  navigationSpan?: SpanInternal
+  startTime?: number
+
   constructor (private Navigation: NavigationDelegate) {}
 
+  private clearActiveSpan () {
+    this.startTime = undefined
+    this.navigationSpan = undefined
+  }
+
   configure (configuration: InternalConfiguration<ReactNativeConfiguration>, spanFactory: SpanFactory<ReactNativeConfiguration>) {
-    // TODO: Set up navigation listeners
+    this.Navigation.events().registerCommandListener((name, params) => {
+      this.startTime = performance.now()
+    })
+
+    this.Navigation.events().registerComponentDidAppearListener(event => {
+      const routeName = event.componentName
+
+      if (this.startTime) {
+        this.navigationSpan = spanFactory.startSpan('[Navigation]' + routeName, {
+          startTime: this.startTime
+        })
+      }
+    })
+
+    this.Navigation.events().registerCommandCompletedListener(event => {
+      const endTime = event.completionTime
+      if (this.navigationSpan) {
+        spanFactory.endSpan(this.navigationSpan, endTime)
+        this.clearActiveSpan()
+      }
+    })
   }
 }
 

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -42,7 +42,7 @@ class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
 
     // Navigation has occurred
     this.Navigation.events().registerComponentDidAppearListener(event => {
-      if (this.startTime) {
+      if (typeof this.startTime === 'number') {
         const routeName = event.componentName
         this.navigationSpan = spanFactory.startSpan('[Navigation]' + routeName, {
           startTime: this.startTime

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -3,8 +3,8 @@ import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance
 import { type NavigationDelegate } from 'react-native-navigation/lib/dist/src/NavigationDelegate'
 
 class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
-  navigationSpan?: SpanInternal
-  startTime?: number
+  private navigationSpan?: SpanInternal
+  private startTime?: number
 
   constructor (private Navigation: NavigationDelegate) {}
 

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -17,23 +17,21 @@ class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
     this.navigationSpan = undefined
   }
 
-  configure (configuration: InternalConfiguration<ReactNativeConfiguration>, spanFactory: SpanFactory<ReactNativeConfiguration>) {
-    const triggerNavigationEnd = () => {
-      const endTime = performance.now()
-      this.endTimeout = setTimeout(() => {
-        if (this.navigationSpan) {
-          spanFactory.endSpan(this.navigationSpan, endTime)
-          this.clearActiveSpan()
-        }
-      }, 100)
-    }
+  /** Trigger the end of the current navigation span after 100ms */
+  private triggerNavigationEnd = (spanFactory: SpanFactory<ReactNativeConfiguration>) => {
+    const endTime = performance.now()
+    this.endTimeout = setTimeout(() => {
+      if (this.navigationSpan) {
+        spanFactory.endSpan(this.navigationSpan, endTime)
+        this.clearActiveSpan()
+      }
+    }, 100)
+  }
 
+  configure (configuration: InternalConfiguration<ReactNativeConfiguration>, spanFactory: SpanFactory<ReactNativeConfiguration>) {
     // Potential for a navigation to occur
     this.Navigation.events().registerCommandListener((name, params) => {
-      if (this.startTimeout) {
-        clearTimeout(this.startTimeout)
-      }
-
+      this.clearActiveSpan()
       this.startTime = performance.now()
       this.startTimeout = setTimeout(() => {
         this.clearActiveSpan()
@@ -45,10 +43,16 @@ class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
       if (typeof this.startTime === 'number') {
         const routeName = event.componentName
         this.navigationSpan = spanFactory.startSpan('[Navigation]' + routeName, {
-          startTime: this.startTime
+          startTime: this.startTime,
+          isFirstClass: false,
+          parentContext: null
         })
 
-        triggerNavigationEnd()
+        this.navigationSpan.setAttribute('bugsnag.span.category', 'navigation')
+        this.navigationSpan.setAttribute('bugsnag.navigation.route', routeName)
+        this.navigationSpan.setAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
+
+        this.triggerNavigationEnd(spanFactory)
       }
     })
   }

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -3,36 +3,52 @@ import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance
 import { type NavigationDelegate } from 'react-native-navigation/lib/dist/src/NavigationDelegate'
 
 class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
-  private navigationSpan?: SpanInternal
   private startTime?: number
+  private startTimeout?: NodeJS.Timeout
+  private endTimeout?: NodeJS.Timeout
+  private navigationSpan?: SpanInternal
 
   constructor (private Navigation: NavigationDelegate) {}
 
   private clearActiveSpan () {
+    clearTimeout(this.startTimeout)
+    clearTimeout(this.endTimeout)
     this.startTime = undefined
     this.navigationSpan = undefined
   }
 
   configure (configuration: InternalConfiguration<ReactNativeConfiguration>, spanFactory: SpanFactory<ReactNativeConfiguration>) {
+    const triggerNavigationEnd = () => {
+      const endTime = performance.now()
+      this.endTimeout = setTimeout(() => {
+        if (this.navigationSpan) {
+          spanFactory.endSpan(this.navigationSpan, endTime)
+          this.clearActiveSpan()
+        }
+      }, 100)
+    }
+
+    // Potential for a navigation to occur
     this.Navigation.events().registerCommandListener((name, params) => {
+      if (this.startTimeout) {
+        clearTimeout(this.startTimeout)
+      }
+
       this.startTime = performance.now()
+      this.startTimeout = setTimeout(() => {
+        this.clearActiveSpan()
+      }, 1000)
     })
 
+    // Navigation has occurred
     this.Navigation.events().registerComponentDidAppearListener(event => {
-      const routeName = event.componentName
-
       if (this.startTime) {
+        const routeName = event.componentName
         this.navigationSpan = spanFactory.startSpan('[Navigation]' + routeName, {
           startTime: this.startTime
         })
-      }
-    })
 
-    this.Navigation.events().registerCommandCompletedListener(event => {
-      const endTime = event.completionTime
-      if (this.navigationSpan) {
-        spanFactory.endSpan(this.navigationSpan, endTime)
-        this.clearActiveSpan()
+        triggerNavigationEnd()
       }
     })
   }

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -7,11 +7,11 @@ import { clearPersistedState, setDeviceId, setSamplingProbability } from './Pers
 
 const isTurboModuleEnabled = () => global.__turboModuleProxy != null
 
-function loadReactNavigationScenario (scenario) {
+async function loadReactNavigationScenario (scenario) {
   if (typeof scenario.registerScreens === 'function') {
     scenario.registerScreens()
   } else {
-    const Navigation = require('react-native-navigation')
+    const Navigation = await import('react-native-navigation')
     Navigation.registerComponent('Scenario', () => scenario.App)
     Navigation.setRoot({
       root: {

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -8,8 +8,8 @@ import { clearPersistedState, setDeviceId, setSamplingProbability } from './Pers
 const isTurboModuleEnabled = () => global.__turboModuleProxy != null
 
 function loadReactNavigationScenario (scenario) {
-  if (scenario.load) {
-    scenario.load()
+  if (typeof scenario.registerScreens === 'function') {
+    scenario.registerScreens()
   } else {
     const Navigation = require('react-native-navigation')
     Navigation.registerComponent('Scenario', () => scenario.App)
@@ -43,7 +43,7 @@ async function runScenario (rootTag, scenarioName, apiKey, endpoint) {
   })
 
   if (process.env.REACT_NATIVE_NAVIGATION) {
-    loadReactNavigationScenario()
+    loadReactNavigationScenario(scenario)
   } else {
     const appParams = { rootTag }
     if (isTurboModuleEnabled()) {

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -1,5 +1,5 @@
 import { ReactNativeNavigationPlugin } from '@bugsnag/react-native-navigation-performance'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { SafeAreaView, Text } from 'react-native'
 import { Navigation } from 'react-native-navigation'
 
@@ -30,19 +30,35 @@ export function registerScreens() {
 }
 
 function Screen1(props) {
+    const [counter, setCounter] = useState(3)
+
     useEffect(() => {
-        setTimeout(() => {
+        function decrementCounter() {
+            if (counter > 0) {
+                setTimeout(() => {
+                    setCounter(c => c - 1)
+                    decrementCounter()
+                }, 1000)
+            }
+        }
+
+        decrementCounter()
+    }, [])
+
+    useEffect(() => {
+        if (counter === 0) {
             Navigation.push(props.componentId, {
                 component: {
                     name: 'Screen 2'
                 }
             })
-        }, 50)
-    }, [])
+        }
+    }, [counter])
 
     return (
         <SafeAreaView>
             <Text>Screen 1</Text>
+            <Text>Navigating in {counter}...</Text>
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -1,6 +1,6 @@
 import { ReactNativeNavigationPlugin } from '@bugsnag/react-native-navigation-performance'
-import React from 'react'
-import { Button, SafeAreaView, Text } from 'react-native'
+import React, { useEffect } from 'react'
+import { SafeAreaView, Text } from 'react-native'
 import { Navigation } from 'react-native-navigation'
 
 export const config = {
@@ -30,18 +30,19 @@ export function load() {
 }
 
 function Screen1(props) {
+    useEffect(() => {
+        setTimeout(() => {
+            Navigation.push(props.componentId, {
+                component: {
+                    name: 'Screen 2'
+                }
+            })
+        }, 50)
+    }, [])
+
     return (
         <SafeAreaView>
             <Text>Screen 1</Text>
-            <Button
-                title='Go to screen 2'
-                onPress={() => { 
-                    Navigation.push(props.componentId, { 
-                        component: { 
-                            name: 'Screen 2' 
-                        } 
-                    }) 
-                }} />
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -4,7 +4,7 @@ import { SafeAreaView, Text } from 'react-native'
 import { Navigation } from 'react-native-navigation'
 
 export const config = {
-    maximumBatchSize: 1,
+    maximumBatchSize: 2,
     autoInstrumentAppStarts: false,
     appVersion: '1.2.3',
     plugins: [new ReactNativeNavigationPlugin(Navigation)]

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -10,7 +10,7 @@ export const config = {
     plugins: [new ReactNativeNavigationPlugin(Navigation)]
 }
 
-export function load() {
+export function registerScreens() {
     Navigation.registerComponent('Screen 1', () => Screen1);
     Navigation.registerComponent('Screen 2', () => Screen2);
 

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -9,7 +9,7 @@ Feature: Navigation spans with React Native Navigation
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-    And the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:2"
 
     # Span 1
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[Navigation]Screen 1"

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -4,6 +4,15 @@ Feature: Navigation spans with React Native Navigation
   Scenario: Navigation Spans are automatically instrumented
     When I run 'RNNChangeRouteScenario'
     And I wait to receive a sampling request
+    And I wait for 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
+
+    And the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[Navigation]Screen 2"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -4,6 +4,7 @@ Feature: Navigation spans with React Native Navigation
   Scenario: Navigation Spans are automatically instrumented
     When I run 'RNNChangeRouteScenario'
     And I wait to receive a sampling request
+    And I click the element "Go to screen 2"
     And I wait for 1 span
 
     # Check the initial probability request

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -4,7 +4,6 @@ Feature: Navigation spans with React Native Navigation
   Scenario: Navigation Spans are automatically instrumented
     When I run 'RNNChangeRouteScenario'
     And I wait to receive a sampling request
-    And I click the element "Go to screen 2"
     And I wait for 1 span
 
     # Check the initial probability request

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -18,6 +18,9 @@ Feature: Navigation spans with React Native Navigation
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "navigation"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.route" equals "Screen 1"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
 
     # Span 2
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "[Navigation]Screen 2"
@@ -26,3 +29,6 @@ Feature: Navigation spans with React Native Navigation
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.startTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.endTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "navigation"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.route" equals "Screen 2"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -10,9 +10,19 @@ Feature: Navigation spans with React Native Navigation
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
     And the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[Navigation]Screen 2"
+
+    # Span 1
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[Navigation]Screen 1"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+
+    # Span 2
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "[Navigation]Screen 2"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.kind" equals 3
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.startTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.endTimeUnixNano" matches the regex "^[0-9]+$"


### PR DESCRIPTION
## Goal

Automatically instrument navigation spans when using `react-native-navigation`

## Design

Add event listeners to the `Navigation` library to start and automatically end a navigation span when the route changes

**Note:** this approach also creates a navigation span for the initial route due to the way the end to end test is instrumented

## Changeset

- Add event listeners to plugin
- Add navigation span attributes

## Testing

- Update unit tests to check that a span in automatically started on route change
- Update end to end tests to check that a span is automatically started on a route change