### PR TITLE
[PLAT-11567] Complete navigation component

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,13 +12,13 @@ steps:
   #
   # Upload each basic pipeline
   #
-  # - label: ":pipeline_upload: Basic browser pipeline"
-  #   commands:
-  #     - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
+  - label: ":pipeline_upload: Basic browser pipeline"
+    commands:
+      - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
-  # - label: ":pipeline_upload: React Native pipeline"
-  #   commands:
-  #     - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
+  - label: ":pipeline_upload: React Native pipeline"
+    commands:
+      - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
 
   - label: ":pipeline_upload: React Native Navigation pipeline"
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,13 +12,13 @@ steps:
   #
   # Upload each basic pipeline
   #
-  - label: ":pipeline_upload: Basic browser pipeline"
-    commands:
-      - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
+  # - label: ":pipeline_upload: Basic browser pipeline"
+  #   commands:
+  #     - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
-  - label: ":pipeline_upload: React Native pipeline"
-    commands:
-      - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
+  # - label: ":pipeline_upload: React Native pipeline"
+  #   commands:
+  #     - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
 
   - label: ":pipeline_upload: React Native Navigation pipeline"
     commands:

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,9 @@ const paths = {
   '@bugsnag/request-tracker-performance': ['./packages/request-tracker/lib/index.ts'],
   '@bugsnag/react-router-performance': ['./packages/react-router/lib/index.ts'],
   '@bugsnag/vue-router-performance': ['./packages/vue-router/lib/index.ts'],
-  '@bugsnag/angular-performance': ['./packages/angular/lib/index.ts']
+  '@bugsnag/angular-performance': ['./packages/angular/lib/index.ts'],
+  '@bugsnag/react-native-navigation-performance': ['./packages/react-native-navigation/lib/index.ts'],
+  '@bugsnag/react-navigation-performance': ['./packages/react-navigation/lib/index.ts']
 }
 
 // convert the tsconfig "paths" option into Jest's "moduleNameMapper" option
@@ -106,6 +108,7 @@ module.exports = {
     '!**/packages/*/**/*.d.ts',
     '!**/packages/*/**/*.test.ts',
     '!**/packages/*/**/tests/**/*',
+    '!**/packages/*/**/__tests__/**/*',
     '!<rootDir>/packages/test-utilities/**/*',
     '!<rootDir>/test/**/*'
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24782,12 +24782,15 @@
       "devDependencies": {
         "@bugsnag/core-performance": "*",
         "@bugsnag/react-native-performance": "*",
+        "@react-native/babel-preset": "^0.74.0",
+        "@testing-library/jest-native": "^5.4.3",
+        "@testing-library/react-native": "^12.4.1",
         "react-native-navigation": "7.37.2"
       },
       "peerDependencies": {
         "@bugsnag/core-performance": "^2.2.0",
         "@bugsnag/react-native-performance": "^2.2.0",
-        "react-native-navigation": "7.37.2"
+        "react-native-navigation": "*"
       }
     },
     "packages/react-navigation": {

--- a/packages/react-native-navigation/__mocks__/@bugsnag/react-native-performance.ts
+++ b/packages/react-native-navigation/__mocks__/@bugsnag/react-native-performance.ts
@@ -1,0 +1,20 @@
+import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import { type Plugin, type Configuration } from '@bugsnag/core-performance'
+
+const plugins: Array<Plugin<Configuration>> = []
+
+const BugsnagPerformance = {
+  start: jest.fn((configuration: ReactNativeConfiguration) => {
+    plugins.length = 0
+    configuration.plugins?.forEach(plugin => plugins.push(plugin))
+  }),
+  getPlugin: jest.fn((Constructor) => {
+    for (const plugin of plugins) {
+      if (plugin instanceof Constructor) {
+        return plugin
+      }
+    }
+  })
+}
+
+export default BugsnagPerformance

--- a/packages/react-native-navigation/__mocks__/react-native-navigation.ts
+++ b/packages/react-native-navigation/__mocks__/react-native-navigation.ts
@@ -1,0 +1,6 @@
+export const Navigation = {
+  events: jest.fn().mockReturnValue({
+    registerCommandListener: jest.fn(),
+    registerComponentDidAppearListener: jest.fn()
+  })
+}

--- a/packages/react-native-navigation/__tests__/CompleteNavigation.test.tsx
+++ b/packages/react-native-navigation/__tests__/CompleteNavigation.test.tsx
@@ -1,0 +1,105 @@
+import { VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+import { fireEvent, render, screen } from '@testing-library/react-native'
+import { useState } from 'react'
+import { Button, View } from 'react-native'
+import { Navigation } from 'react-native-navigation'
+import { CompleteNavigation } from '../lib/CompleteNavigation'
+import ReactNativeNavigationPlugin from '../lib/react-native-navigation-plugin'
+
+jest.mock('@bugsnag/react-native-performance')
+jest.mock('react-native-navigation')
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+// The CompleteNavigation component calls the BugsnagPerformance.getPlugin() method
+// to retrieve the instance of the plugin, so we need to mock the client
+function createMockClient (plugin: ReactNativeNavigationPlugin) {
+  jest.spyOn(plugin, 'blockNavigationEnd')
+  jest.spyOn(plugin, 'unblockNavigationEnd')
+
+  BugsnagPerformance.start({
+    apiKey: VALID_API_KEY,
+    plugins: [plugin]
+  })
+}
+
+describe('CompleteNavigation', () => {
+  it('calls the appropriate methods on mount', () => {
+    const plugin = new ReactNativeNavigationPlugin(Navigation)
+    createMockClient(plugin)
+
+    render(
+        <View>
+            <CompleteNavigation on='mount' />
+        </View>
+    )
+
+    // Wait for component to mount
+    jest.advanceTimersByTime(1)
+    expect(plugin.blockNavigationEnd).toHaveBeenCalledTimes(1)
+    expect(plugin.unblockNavigationEnd).toHaveBeenCalledTimes(1)
+    expect(plugin.unblockNavigationEnd).toHaveBeenCalledWith('mount')
+  })
+
+  it('calls the appropriate methods on unmount', () => {
+    const plugin = new ReactNativeNavigationPlugin(Navigation)
+    createMockClient(plugin)
+
+    function TestApp () {
+      const [showComponent, setShowComponent] = useState(true)
+
+      return (
+          <View>
+            {showComponent && <CompleteNavigation on='unmount' />}
+            <Button title='Unmount component' onPress={() => { setShowComponent(false) }} />
+          </View>
+      )
+    }
+
+    render(<TestApp />)
+
+    // Wait for component to mount
+    jest.advanceTimersByTime(1)
+    expect(plugin.blockNavigationEnd).toHaveBeenCalledTimes(1)
+    expect(plugin.unblockNavigationEnd).not.toHaveBeenCalled()
+
+    fireEvent.press(screen.getByText('Unmount component'))
+    expect(plugin.unblockNavigationEnd).toHaveBeenCalledTimes(1)
+    expect(plugin.unblockNavigationEnd).toHaveBeenCalledWith('unmount')
+  })
+
+  it('calls the appropriate method when the "on" condition changes to true', () => {
+    const plugin = new ReactNativeNavigationPlugin(Navigation)
+    createMockClient(plugin)
+
+    function TestApp () {
+      const [loaded, setLoaded] = useState(false)
+
+      return (
+          <View>
+            <CompleteNavigation on={loaded} />
+            <Button title='Finish loading' onPress={() => { setLoaded(true) }} />
+          </View>
+      )
+    }
+
+    render(<TestApp />)
+
+    // Wait for component to mount
+    jest.advanceTimersByTime(1)
+    expect(plugin.blockNavigationEnd).toHaveBeenCalledTimes(1)
+    expect(plugin.unblockNavigationEnd).not.toHaveBeenCalled()
+
+    // Update the condition prop
+    fireEvent.press(screen.getByText('Finish loading'))
+    expect(plugin.unblockNavigationEnd).toHaveBeenCalledTimes(1)
+    expect(plugin.unblockNavigationEnd).toHaveBeenCalledWith('condition')
+  })
+})

--- a/packages/react-native-navigation/__tests__/CompleteNavigation.test.tsx
+++ b/packages/react-native-navigation/__tests__/CompleteNavigation.test.tsx
@@ -1,7 +1,7 @@
 import { VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
 import BugsnagPerformance from '@bugsnag/react-native-performance'
 import { fireEvent, render, screen } from '@testing-library/react-native'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { Button, View } from 'react-native'
 import { Navigation } from 'react-native-navigation'
 import { CompleteNavigation } from '../lib/CompleteNavigation'

--- a/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
+++ b/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
@@ -3,16 +3,7 @@ import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance
 import ReactNativeNavigationPlugin from '../lib/react-native-navigation-plugin'
 import { Navigation } from 'react-native-navigation'
 
-jest.mock('react-native-navigation', () => {
-  return {
-    Navigation: {
-      events: jest.fn().mockReturnValue({
-        registerCommandListener: jest.fn(),
-        registerComponentDidAppearListener: jest.fn()
-      })
-    }
-  }
-})
+jest.mock('react-native-navigation')
 
 beforeEach(() => {
   jest.useFakeTimers()

--- a/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
+++ b/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
@@ -1,7 +1,7 @@
 import { MockSpanFactory, createConfiguration } from '@bugsnag/js-performance-test-utilities'
 import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance'
-import ReactNativeNavigationPlugin from '../lib/react-native-navigation-plugin'
 import { Navigation } from 'react-native-navigation'
+import ReactNativeNavigationPlugin from '../lib/react-native-navigation-plugin'
 
 jest.mock('react-native-navigation')
 
@@ -43,5 +43,55 @@ describe('ReactNativeNavigationPlugin', () => {
     expect(span).toHaveAttribute('bugsnag.span.first_class', false)
     expect(span).toHaveAttribute('bugsnag.navigation.route', 'TestScreen')
     expect(span).toHaveAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
+    expect(span).toHaveAttribute('bugsnag.navigation.ended_by', 'immediate')
+  })
+
+  it('does not end the current navigation while there are components waiting', () => {
+    const plugin = new ReactNativeNavigationPlugin(Navigation)
+    const configuration = createConfiguration<ReactNativeConfiguration>()
+    const spanFactory = new MockSpanFactory()
+    plugin.configure(configuration, spanFactory)
+
+    // Simulate a route change
+    jest.mocked(Navigation.events().registerCommandListener).mock.calls[1][0]('push', {
+      commandId: '1',
+      componentId: '123'
+    })
+
+    jest.mocked(Navigation.events().registerComponentDidAppearListener).mock.calls[1][0]({
+      componentId: '123',
+      componentName: 'TestScreen',
+      componentType: 'Component'
+    })
+
+    expect(spanFactory.startSpan).toHaveBeenCalledTimes(1)
+
+    plugin.blockNavigationEnd()
+    plugin.blockNavigationEnd()
+    plugin.blockNavigationEnd()
+
+    jest.advanceTimersByTime(100)
+
+    expect(spanFactory.endSpan).not.toHaveBeenCalled()
+
+    plugin.unblockNavigationEnd('mount')
+    jest.advanceTimersByTime(100)
+    expect(spanFactory.endSpan).not.toHaveBeenCalled()
+
+    plugin.unblockNavigationEnd('unmount')
+    jest.advanceTimersByTime(100)
+    expect(spanFactory.endSpan).not.toHaveBeenCalled()
+
+    plugin.unblockNavigationEnd('condition')
+    jest.advanceTimersByTime(100)
+    expect(spanFactory.endSpan).toHaveBeenCalled()
+
+    const span = spanFactory.createdSpans[0]
+    expect(span.name).toEqual('[Navigation]TestScreen')
+    expect(span).toHaveAttribute('bugsnag.span.category', 'navigation')
+    expect(span).toHaveAttribute('bugsnag.span.first_class', false)
+    expect(span).toHaveAttribute('bugsnag.navigation.route', 'TestScreen')
+    expect(span).toHaveAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
+    expect(span).toHaveAttribute('bugsnag.navigation.ended_by', 'condition')
   })
 })

--- a/packages/react-native-navigation/lib/CompleteNavigation.tsx
+++ b/packages/react-native-navigation/lib/CompleteNavigation.tsx
@@ -1,0 +1,44 @@
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+import React, { type PropsWithChildren } from 'react'
+import ReactNativeNavigationPlugin from './react-native-navigation-plugin'
+
+interface Props extends PropsWithChildren {
+  on: 'mount' | 'unmount' | boolean
+}
+
+// @ts-expect-error throwing error for now
+const getPlugin = () => BugsnagPerformance.getPlugin(ReactNativeNavigationPlugin)
+
+/** End the current navigation span when the component is mounted, unmounted or the `on` prop is `true` */
+export class CompleteNavigation extends React.Component<Props> {
+  constructor (props: Props) {
+    super(props)
+    getPlugin()?.blockNavigationEnd()
+  }
+
+  componentDidMount () {
+    if (this.props.on === 'mount') {
+      setTimeout(() => {
+        getPlugin()?.unblockNavigationEnd('mount')
+      })
+    }
+  }
+
+  componentWillUnmount () {
+    if (this.props.on === 'unmount') {
+      getPlugin()?.unblockNavigationEnd('unmount')
+    }
+  }
+
+  componentDidUpdate (prevProps: Readonly<Props>) {
+    if (typeof this.props.on === 'boolean') {
+      if (this.props.on && !prevProps.on) {
+        getPlugin()?.unblockNavigationEnd('condition')
+      }
+    }
+  }
+
+  render () {
+    return this.props.children
+  }
+}

--- a/packages/react-native-navigation/lib/CompleteNavigation.tsx
+++ b/packages/react-native-navigation/lib/CompleteNavigation.tsx
@@ -6,34 +6,47 @@ interface Props extends PropsWithChildren {
   on: 'mount' | 'unmount' | boolean
 }
 
-// @ts-expect-error throwing error for now
-const getPlugin = () => BugsnagPerformance.getPlugin(ReactNativeNavigationPlugin)
-
 /** End the current navigation span when the component is mounted, unmounted or the `on` prop is `true` */
 export class CompleteNavigation extends React.Component<Props> {
+  private _plugin?: ReactNativeNavigationPlugin
+
+  private get plugin () {
+    if (this._plugin) return this._plugin
+
+    // @ts-expect-error signature does not match
+    this._plugin = BugsnagPerformance.getPlugin(ReactNativeNavigationPlugin)
+
+    return this._plugin
+  }
+
   constructor (props: Props) {
     super(props)
-    getPlugin()?.blockNavigationEnd()
+
+    if (this.plugin) {
+      this.plugin.blockNavigationEnd()
+    }
   }
 
   componentDidMount () {
     if (this.props.on === 'mount') {
       setTimeout(() => {
-        getPlugin()?.unblockNavigationEnd('mount')
+        if (this.plugin) {
+          this.plugin.unblockNavigationEnd('mount')
+        }
       })
     }
   }
 
   componentWillUnmount () {
-    if (this.props.on === 'unmount') {
-      getPlugin()?.unblockNavigationEnd('unmount')
+    if (this.props.on === 'unmount' && this.plugin) {
+      this.plugin.unblockNavigationEnd('unmount')
     }
   }
 
   componentDidUpdate (prevProps: Readonly<Props>) {
     if (typeof this.props.on === 'boolean') {
-      if (this.props.on && !prevProps.on) {
-        getPlugin()?.unblockNavigationEnd('condition')
+      if (this.props.on && !prevProps.on && this.plugin) {
+        this.plugin.unblockNavigationEnd('condition')
       }
     }
   }

--- a/packages/react-native-navigation/lib/index.ts
+++ b/packages/react-native-navigation/lib/index.ts
@@ -1,1 +1,2 @@
 export { default as ReactNativeNavigationPlugin } from './react-native-navigation-plugin'
+export { CompleteNavigation } from './CompleteNavigation'

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -1,58 +1,92 @@
-import { type InternalConfiguration, type Plugin, type SpanFactory, type SpanInternal } from '@bugsnag/core-performance'
-import { type ReactNativeConfiguration } from '@bugsnag/react-native-performance'
-import { type NavigationDelegate } from 'react-native-navigation/lib/dist/src/NavigationDelegate'
+import type { Plugin, SpanFactory, SpanInternal } from '@bugsnag/core-performance'
+import type { ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import type { NavigationDelegate } from 'react-native-navigation/lib/dist/src/NavigationDelegate'
+
+type Reason = 'immediate' | 'mount' | 'unmount' | 'condition'
+
+const NAVIGATION_START_TIMEOUT = 1000
+const NAVIGATION_COMPLETE_TIMEOUT = 100
 
 class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
+  private Navigation: NavigationDelegate
+  private currentNavigationSpan?: SpanInternal
   private startTime?: number
   private startTimeout?: NodeJS.Timeout
   private endTimeout?: NodeJS.Timeout
-  private navigationSpan?: SpanInternal
+  private componentsWaiting = 0
+  private spanFactory?: SpanFactory<ReactNativeConfiguration>
 
-  constructor (private Navigation: NavigationDelegate) {}
+  constructor (Navigation: NavigationDelegate) {
+    this.Navigation = Navigation
+  }
 
   private clearActiveSpan () {
     clearTimeout(this.startTimeout)
     clearTimeout(this.endTimeout)
     this.startTime = undefined
-    this.navigationSpan = undefined
+    this.currentNavigationSpan = undefined
   }
 
   /** Trigger the end of the current navigation span after 100ms */
-  private triggerNavigationEnd = (spanFactory: SpanFactory<ReactNativeConfiguration>) => {
-    const endTime = performance.now()
+  private triggerNavigationEnd = (spanFactory: SpanFactory<ReactNativeConfiguration>, endedBy: Reason, endTime = performance.now()) => {
+    clearTimeout(this.endTimeout)
+
     this.endTimeout = setTimeout(() => {
-      if (this.navigationSpan) {
-        spanFactory.endSpan(this.navigationSpan, endTime)
+      if (this.componentsWaiting === 0 && this.currentNavigationSpan) {
+        this.currentNavigationSpan.setAttribute('bugsnag.navigation.ended_by', endedBy)
+        spanFactory.endSpan(this.currentNavigationSpan, endTime)
         this.clearActiveSpan()
       }
-    }, 100)
+    }, NAVIGATION_COMPLETE_TIMEOUT)
   }
 
-  configure (configuration: InternalConfiguration<ReactNativeConfiguration>, spanFactory: SpanFactory<ReactNativeConfiguration>) {
+  /**
+   * Blocks the current navigation by incrementing the count of components waiting
+   */
+  blockNavigationEnd = () => {
+    this.componentsWaiting += 1
+  }
+
+  /**
+   * Unblocks the current navigation by decrementing the count of components waiting and setting the reason
+   */
+  unblockNavigationEnd = (endedBy: Reason) => {
+    const renderTime = performance.now()
+
+    this.componentsWaiting = Math.max(this.componentsWaiting - 1, 0)
+
+    if (this.spanFactory) {
+      this.triggerNavigationEnd(this.spanFactory, endedBy, renderTime)
+    }
+  }
+
+  configure (configuration: ReactNativeConfiguration, spanFactory: SpanFactory<ReactNativeConfiguration>) {
+    this.spanFactory = spanFactory
+
     // Potential for a navigation to occur
     this.Navigation.events().registerCommandListener((name, params) => {
       this.clearActiveSpan()
       this.startTime = performance.now()
       this.startTimeout = setTimeout(() => {
         this.clearActiveSpan()
-      }, 1000)
+      }, NAVIGATION_START_TIMEOUT)
     })
 
     // Navigation has occurred
     this.Navigation.events().registerComponentDidAppearListener(event => {
       if (typeof this.startTime === 'number') {
         const routeName = event.componentName
-        this.navigationSpan = spanFactory.startSpan('[Navigation]' + routeName, {
+        this.currentNavigationSpan = spanFactory.startSpan('[Navigation]' + routeName, {
           startTime: this.startTime,
           isFirstClass: false,
           parentContext: null
         })
 
-        this.navigationSpan.setAttribute('bugsnag.span.category', 'navigation')
-        this.navigationSpan.setAttribute('bugsnag.navigation.route', routeName)
-        this.navigationSpan.setAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
+        this.currentNavigationSpan.setAttribute('bugsnag.span.category', 'navigation')
+        this.currentNavigationSpan.setAttribute('bugsnag.navigation.route', routeName)
+        this.currentNavigationSpan.setAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
 
-        this.triggerNavigationEnd(spanFactory)
+        this.triggerNavigationEnd(spanFactory, 'immediate')
       }
     })
   }

--- a/packages/react-native-navigation/package.json
+++ b/packages/react-native-navigation/package.json
@@ -22,11 +22,14 @@
     "peerDependencies": {
         "@bugsnag/core-performance": "^2.2.0",
         "@bugsnag/react-native-performance": "^2.2.0",
-        "react-native-navigation": "7.37.2"
+        "react-native-navigation": "*"
     },
     "devDependencies": {
         "@bugsnag/core-performance": "*",
         "@bugsnag/react-native-performance": "*",
+        "@react-native/babel-preset": "^0.74.0",
+        "@testing-library/jest-native": "^5.4.3",
+        "@testing-library/react-native": "^12.4.1",
         "react-native-navigation": "7.37.2"
     },
     "type": "module",

--- a/packages/react-native-navigation/rollup.config.mjs
+++ b/packages/react-native-navigation/rollup.config.mjs
@@ -13,7 +13,7 @@ const config = createRollupConfig({
 
 config.acornInjectPlugins = [jsx()]
 config.plugins = config.plugins.concat([
-  noTreeShakingPlugin([])
+  noTreeShakingPlugin(['CompleteNavigation.tsx'])
 ])
 
 export default config

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -75,7 +75,7 @@ function Screen2(props) {
     return (
         <SafeAreaView>
             <Text>Screen 2</Text>
-            {loaded && <CompleteNavigation on="mount"/>}
+            <CompleteNavigation condition={loaded} />
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -1,4 +1,4 @@
-import { ReactNativeNavigationPlugin } from '@bugsnag/react-native-navigation-performance'
+import { CompleteNavigation, ReactNativeNavigationPlugin } from '@bugsnag/react-native-navigation-performance'
 import React, { useEffect, useState } from 'react'
 import { SafeAreaView, Text } from 'react-native'
 import { Navigation } from 'react-native-navigation'
@@ -66,7 +66,9 @@ function Screen1(props) {
 function Screen2(props) {
     return (
         <SafeAreaView>
-            <Text>Screen 2</Text>
+            <CompleteNavigation on="mount">
+                <Text>Screen 2</Text>
+            </CompleteNavigation>
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -64,11 +64,18 @@ function Screen1(props) {
 }
 
 function Screen2(props) {
+    const [loaded, setLoaded] = useState(false)
+
+    useEffect(() => {
+        setTimeout(() => {
+            setLoaded(true)
+        }, 50)
+    }, [])
+
     return (
         <SafeAreaView>
-            <CompleteNavigation on="mount">
-                <Text>Screen 2</Text>
-            </CompleteNavigation>
+            <Text>Screen 2</Text>
+            {loaded && <CompleteNavigation on="mount"/>}
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/react-native-navigation/ChangeRouteScenario.js
@@ -75,7 +75,7 @@ function Screen2(props) {
     return (
         <SafeAreaView>
             <Text>Screen 2</Text>
-            <CompleteNavigation condition={loaded} />
+            {loaded && <CompleteNavigation on="mount"/>}
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -33,4 +33,4 @@ Feature: Navigation spans with React Native Navigation
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "navigation"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.route" equals "Screen 2"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.ended_by" equals "mount"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.ended_by" equals "condition"

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -33,4 +33,9 @@ Feature: Navigation spans with React Native Navigation
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "navigation"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.route" equals "Screen 2"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.ended_by" equals "condition"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.ended_by" is one of:
+      | immediate |
+      | mount |
+      | unmount |
+      | condition |
+      

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -21,6 +21,7 @@ Feature: Navigation spans with React Native Navigation
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "navigation"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.route" equals "Screen 1"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.ended_by" equals "immediate"
 
     # Span 2
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "[Navigation]Screen 2"
@@ -32,3 +33,4 @@ Feature: Navigation spans with React Native Navigation
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "navigation"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.route" equals "Screen 2"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.ended_by" equals "mount"

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -33,4 +33,4 @@ Feature: Navigation spans with React Native Navigation
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "navigation"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.route" equals "Screen 2"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.ended_by" equals "mount"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.ended_by" equals "mount"


### PR DESCRIPTION
## Goal

Add `CompleteNavigation` component to make navigation spans more accurate 

## Design

Same pattern for component lifecycle methods as the `@bugsnag/react-navigation` plugin component, but leveraging the `getPlugin` method from `BugsnagPerformance` as we are not able to provide a wrapper component and leverage context to have a single point of reference for number of mounted components and the state of the current navigation span

## Changeset

- Added new component
- Updated plugin implementation to end spans depending on the number of components waiting
- Added `bugsnag.navigation.ended_by` span attribute

## Testing

- Unit tests for the NavigationComplete component
- Unit test that the plugin handles awaiting components and updating span attributes correctly
- Update end to end test to instrument `NavigationComplete` component (there is currently a bug on iOS, so the assertion for the ended_by span attribute is currently loose and will be improved in a separate ticket as this affects both plugins)