### PR TITLE
[PLAT-11722] Previous route span attribute

### DIFF
--- a/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
+++ b/packages/react-native-navigation/__tests__/react-native-navigation-plugin.test.ts
@@ -138,6 +138,7 @@ describe('ReactNativeNavigationPlugin', () => {
     expect(span).toHaveAttribute('bugsnag.span.category', 'navigation')
     expect(span).toHaveAttribute('bugsnag.span.first_class', true)
     expect(span).toHaveAttribute('bugsnag.navigation.route', 'SecondScreen')
+    expect(span).toHaveAttribute('bugsnag.navigation.previous_route', 'FirstScreen')
     expect(span).toHaveAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
     expect(span).toHaveAttribute('bugsnag.navigation.ended_by', 'immediate')
   })

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -16,7 +16,7 @@ class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
   private endedBy: Reason = 'immediate'
   private componentsWaiting = 0
   private spanFactory?: SpanFactory<ReactNativeConfiguration>
-  private lastRouteName?: string
+  private previousRoute?: string
 
   constructor (Navigation: NavigationDelegate) {
     this.Navigation = Navigation
@@ -93,11 +93,11 @@ class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
         this.currentNavigationSpan.setAttribute('bugsnag.navigation.route', routeName)
         this.currentNavigationSpan.setAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
 
-        if (this.lastRouteName) {
-          this.currentNavigationSpan.setAttribute('bugsnag.navigation.previous_route', this.lastRouteName)
+        if (this.previousRoute) {
+          this.currentNavigationSpan.setAttribute('bugsnag.navigation.previous_route', this.previousRoute)
         }
 
-        this.lastRouteName = routeName
+        this.previousRoute = routeName
 
         this.endedBy = 'immediate'
 

--- a/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -16,6 +16,7 @@ class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
   private endedBy: Reason = 'immediate'
   private componentsWaiting = 0
   private spanFactory?: SpanFactory<ReactNativeConfiguration>
+  private lastRouteName?: string
 
   constructor (Navigation: NavigationDelegate) {
     this.Navigation = Navigation
@@ -91,6 +92,12 @@ class ReactNativeNavigationPlugin implements Plugin<ReactNativeConfiguration> {
         this.currentNavigationSpan.setAttribute('bugsnag.span.category', 'navigation')
         this.currentNavigationSpan.setAttribute('bugsnag.navigation.route', routeName)
         this.currentNavigationSpan.setAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-native-navigation-performance')
+
+        if (this.lastRouteName) {
+          this.currentNavigationSpan.setAttribute('bugsnag.navigation.previous_route', this.lastRouteName)
+        }
+
+        this.lastRouteName = routeName
 
         this.endedBy = 'immediate'
 

--- a/packages/react-navigation/lib/navigation-context.tsx
+++ b/packages/react-navigation/lib/navigation-context.tsx
@@ -89,6 +89,10 @@ export class NavigationContextProvider extends React.Component<Props, State> {
       span.setAttribute('bugsnag.navigation.route', currentRoute)
       span.setAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-navigation-performance')
 
+      if (this.state.previousRoute) {
+        span.setAttribute('bugsnag.navigation.previous_route', this.state.previousRoute)
+      }
+
       this.currentSpan = span
       this.endCondition = 'immediate'
 

--- a/packages/react-navigation/test/navigation-context.test.tsx
+++ b/packages/react-navigation/test/navigation-context.test.tsx
@@ -64,6 +64,10 @@ describe('NavigationContextProvider', () => {
     expect(secondRouteSpan.name).toEqual('[Navigation]route-2')
     expect(secondRouteSpan).toHaveAttribute('bugsnag.span.category', 'navigation')
     expect(secondRouteSpan).toHaveAttribute('bugsnag.span.first_class', true)
+    expect(secondRouteSpan).toHaveAttribute('bugsnag.navigation.route', 'route-2')
+    expect(secondRouteSpan).toHaveAttribute('bugsnag.navigation.previous_route', 'route-1')
+    expect(secondRouteSpan).toHaveAttribute('bugsnag.navigation.ended_by', 'condition')
+    expect(secondRouteSpan).toHaveAttribute('bugsnag.navigation.triggered_by', '@bugsnag/react-navigation-performance')
   })
 
   it('Prevents a navigation span from ending when navigation is blocked', () => {

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNavigationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNavigationScenario.js
@@ -2,10 +2,10 @@ import BugsnagPerformance from '@bugsnag/react-native-performance'
 import { ReactNavigationNativePlugin } from '@bugsnag/react-navigation-performance'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import React, { useEffect } from 'react'
-import { Button, SafeAreaView, Text } from 'react-native'
+import { SafeAreaView, Text } from 'react-native'
 
 export const config = {
-    maximumBatchSize: 2,
+    maximumBatchSize: 3,
     autoInstrumentAppStarts: false,
     appVersion: '1.2.3',
     plugins: [new ReactNavigationNativePlugin()]
@@ -23,28 +23,43 @@ export function App() {
 
     return (
         <BugsnagNavigationContainer>
-            <Stack.Navigator initialRouteName='Home'>
-                <Stack.Screen name='Home' component={HomeScreen} />
-                <Stack.Screen name='Details' component={DetailsScreen} />
+            <Stack.Navigator initialRouteName='Screen1'>
+                <Stack.Screen name='Screen1' component={Screen1} />
+                <Stack.Screen name='Screen2' component={Screen2} />
+                <Stack.Screen name='Screen3' component={Screen3} />
             </Stack.Navigator>
         </BugsnagNavigationContainer>
     );
 }
 
-function HomeScreen({ navigation }) {
+function Screen1({ navigation }) {
     useEffect(() => {
         parentSpan = BugsnagPerformance.startSpan('ParentSpan')
-        navigation.navigate('Details')
+        navigation.navigate('Screen2')
     }, [])
 
     return (
         <SafeAreaView>
-            <Text>HomeScreen</Text>
+            <Text>Screen1</Text>
         </SafeAreaView>
     )
 }
 
-function DetailsScreen({ navigation }) {
+function Screen2({ navigation }) {
+    useEffect(() => {
+        setTimeout(() => {
+            navigation.navigate('Screen3')
+        }, 250)
+    }, [])
+
+    return (
+        <SafeAreaView>
+            <Text>Screen2</Text>
+        </SafeAreaView>
+    )
+}
+
+function Screen3({ navigation }) {
     useEffect(() => {
         setTimeout(() => {
             if(parentSpan && typeof parentSpan.end === 'function') {
@@ -55,8 +70,7 @@ function DetailsScreen({ navigation }) {
 
     return (
         <SafeAreaView>
-            <Text>DetailsScreen</Text>
-            <Button title='Go back' onPress={() => { navigation.goBack() }} />
+            <Text>Screen3</Text>
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/react-navigation.feature
+++ b/test/react-native/features/react-navigation.feature
@@ -10,7 +10,7 @@ Feature: Navigation spans with React Navigation
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-    And the trace "Bugsnag-Span-Sampling" header equals "1:2"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:3"
     And a span named "[Navigation]Screen2" has a parent named "ParentSpan"
     And a span named "[Navigation]Screen2" contains the attributes:
       | attribute                       | type        | value                                 |

--- a/test/react-native/features/react-navigation.feature
+++ b/test/react-native/features/react-navigation.feature
@@ -5,16 +5,25 @@ Feature: Navigation spans with React Navigation
   Scenario: Navigation Spans are automatically instrumented
     When I run 'ReactNavigationScenario'
     And I wait to receive a sampling request
-    And I wait for 2 spans
+    And I wait for 3 spans
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
     And the trace "Bugsnag-Span-Sampling" header equals "1:2"
-    And a span named "[Navigation]Details" has a parent named "ParentSpan"
-    And a span named "[Navigation]Details" contains the attributes:
+    And a span named "[Navigation]Screen2" has a parent named "ParentSpan"
+    And a span named "[Navigation]Screen2" contains the attributes:
       | attribute                       | type        | value                                 |
       | bugsnag.span.category           | stringValue | navigation                            |
-      | bugsnag.navigation.route        | stringValue | Details                               |
+      | bugsnag.navigation.route        | stringValue | Screen2                               |
       | bugsnag.navigation.triggered_by | stringValue | @bugsnag/react-navigation-performance |
       | bugsnag.navigation.ended_by     | stringValue | immediate                             |
+
+    And a span named "[Navigation]Screen3" has a parent named "ParentSpan"
+    And a span named "[Navigation]Screen3" contains the attributes:
+      | attribute                         | type        | value                                 |
+      | bugsnag.span.category             | stringValue | navigation                            |
+      | bugsnag.navigation.route          | stringValue | Screen3                               |
+      | bugsnag.navigation.previous_route | stringValue | Screen2                               |
+      | bugsnag.navigation.triggered_by   | stringValue | @bugsnag/react-navigation-performance |
+      | bugsnag.navigation.ended_by       | stringValue | immediate                             |


### PR DESCRIPTION
## Goal

Add the `bugsnag.navigation.previous_route` span attribute

## Testing

Update unit tests and end to end tests to ensure the previous route is handled with the `@react-navigation/native` and `react-native-navigation` plugins