### PR TITLE
[PLAT-11721] Test app start spans with react-native-navigation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,13 +12,13 @@ steps:
   #
   # Upload each basic pipeline
   #
-  # - label: ":pipeline_upload: Basic browser pipeline"
-  #   commands:
-  #     - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
+  - label: ":pipeline_upload: Basic browser pipeline"
+    commands:
+      - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
-  # - label: ":pipeline_upload: React Native pipeline"
-  #   commands:
-  #     - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
+  - label: ":pipeline_upload: React Native pipeline"
+    commands:
+      - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
 
   - label: ":pipeline_upload: React Native Navigation pipeline"
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,13 +12,13 @@ steps:
   #
   # Upload each basic pipeline
   #
-  - label: ":pipeline_upload: Basic browser pipeline"
-    commands:
-      - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
+  # - label: ":pipeline_upload: Basic browser pipeline"
+  #   commands:
+  #     - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
-  - label: ":pipeline_upload: React Native pipeline"
-    commands:
-      - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
+  # - label: ":pipeline_upload: React Native pipeline"
+  #   commands:
+  #     - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
 
   - label: ":pipeline_upload: React Native Navigation pipeline"
     commands:

--- a/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
+++ b/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
@@ -45,7 +45,7 @@ export class AppStartPlugin implements Plugin<ReactNativeConfiguration> {
         this.spanFactory.endSpan(appStartSpan, this.clock.now())
       }, [])
 
-      return <>{children}</>
+      return children
     }
 
     const instrumentedComponentProvider: WrapperComponentProvider = (appParams) => ({ children }) => {

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
@@ -1,20 +1,15 @@
 import { CompleteNavigation, ReactNativeNavigationPlugin } from '@bugsnag/react-native-navigation-performance'
 import React, { useEffect, useState } from 'react'
 import { SafeAreaView, Text } from 'react-native'
-import BugsnagPerformance from '@bugsnag/react-native-performance'
 import { Navigation } from 'react-native-navigation'
 
 export const config = {
-    maximumBatchSize: 4,
+    maximumBatchSize: 3,
     appVersion: '1.2.3',
     plugins: [new ReactNativeNavigationPlugin(Navigation)]
 }
 
-let parentSpan
-
 export function registerScreens() {
-    parentSpan = BugsnagPerformance.startSpan('ParentSpan')
-
     Navigation.registerComponent('Screen 1', () => Screen1);
     Navigation.registerComponent('Screen 2', () => Screen2);
 
@@ -58,10 +53,6 @@ function Screen2(props) {
         setTimeout(() => {
             setLoaded(true)
         }, 50)
-
-        setTimeout(() => {
-            parentSpan.end()
-        }, 250)
     }, [])
 
     return (

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
@@ -57,8 +57,11 @@ function Screen2(props) {
     useEffect(() => {
         setTimeout(() => {
             setLoaded(true)
-            parentSpan.end()
         }, 50)
+
+        setTimeout(() => {
+            parentSpan.end()
+        }, 250)
     }, [])
 
     return (

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
@@ -1,15 +1,20 @@
 import { CompleteNavigation, ReactNativeNavigationPlugin } from '@bugsnag/react-native-navigation-performance'
 import React, { useEffect, useState } from 'react'
 import { SafeAreaView, Text } from 'react-native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
 import { Navigation } from 'react-native-navigation'
 
 export const config = {
-    maximumBatchSize: 3,
+    maximumBatchSize: 4,
     appVersion: '1.2.3',
     plugins: [new ReactNativeNavigationPlugin(Navigation)]
 }
 
+let parentSpan
+
 export function registerScreens() {
+    parentSpan = BugsnagPerformance.startSpan('ParentSpan')
+
     Navigation.registerComponent('Screen 1', () => Screen1);
     Navigation.registerComponent('Screen 2', () => Screen2);
 
@@ -52,6 +57,7 @@ function Screen2(props) {
     useEffect(() => {
         setTimeout(() => {
             setLoaded(true)
+            parentSpan.end()
         }, 50)
     }, [])
 

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/ReactNativeNavigationScenario.js
@@ -4,8 +4,7 @@ import { SafeAreaView, Text } from 'react-native'
 import { Navigation } from 'react-native-navigation'
 
 export const config = {
-    maximumBatchSize: 2,
-    autoInstrumentAppStarts: false,
+    maximumBatchSize: 3,
     appVersion: '1.2.3',
     plugins: [new ReactNativeNavigationPlugin(Navigation)]
 }
@@ -30,35 +29,19 @@ export function registerScreens() {
 }
 
 function Screen1(props) {
-    const [counter, setCounter] = useState(3)
-
     useEffect(() => {
-        function decrementCounter() {
-            if (counter > 0) {
-                setTimeout(() => {
-                    setCounter(c => c - 1)
-                    decrementCounter()
-                }, 1000)
-            }
-        }
-
-        decrementCounter()
-    }, [])
-
-    useEffect(() => {
-        if (counter === 0) {
+        setTimeout(() => {
             Navigation.push(props.componentId, {
                 component: {
                     name: 'Screen 2'
                 }
             })
-        }
-    }, [counter])
+        }, 250)
+    }, [])
 
     return (
         <SafeAreaView>
             <Text>Screen 1</Text>
-            <Text>Navigating in {counter}...</Text>
         </SafeAreaView>
     )
 }
@@ -75,7 +58,7 @@ function Screen2(props) {
     return (
         <SafeAreaView>
             <Text>Screen 2</Text>
-            {loaded && <CompleteNavigation on="mount"/>}
+            <CompleteNavigation on={loaded} />
         </SafeAreaView>
     )
 }

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -9,7 +9,7 @@ Feature: Navigation spans with React Native Navigation
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-    And the trace "Bugsnag-Span-Sampling" header equals "1:2"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:3"
 
     And a span named "[AppStart/ReactNativeInit]" contains the attributes:
       | attribute                       | type        | value                                 |

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -9,14 +9,14 @@ Feature: Navigation spans with React Native Navigation
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-    And the trace "Bugsnag-Span-Sampling" header equals "1:3"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:4"
 
     And a span named "[AppStart/ReactNativeInit]" contains the attributes:
       | attribute                       | type        | value                                 |
       | bugsnag.span.category           | stringValue | app_start                             |
       | bugsnag.app_start.type          | stringValue | ReactNativeInit                       |
 
-    And a span named "[Navigation]Screen 1" has a parent named "[AppStart/ReactNativeInit]"
+    And a span named "[Navigation]Screen 1" has a parent named "ParentSpan"
     And a span named "[Navigation]Screen 1" contains the attributes:
       | attribute                       | type        | value                                        |
       | bugsnag.span.category           | stringValue | navigation                                   |
@@ -24,6 +24,7 @@ Feature: Navigation spans with React Native Navigation
       | bugsnag.navigation.triggered_by | stringValue | @bugsnag/react-native-navigation-performance |
       | bugsnag.navigation.ended_by     | stringValue | immediate                                    |
 
+    And a span named "[Navigation]Screen 2" has a parent named "ParentSpan"
     And a span named "[Navigation]Screen 2" contains the attributes:
       | attribute                         | type        | value                                        |
       | bugsnag.span.category             | stringValue | navigation                                   |

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -9,14 +9,13 @@ Feature: Navigation spans with React Native Navigation
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
 
-    And the trace "Bugsnag-Span-Sampling" header equals "1:4"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:3"
 
     And a span named "[AppStart/ReactNativeInit]" contains the attributes:
       | attribute                       | type        | value                                 |
       | bugsnag.span.category           | stringValue | app_start                             |
       | bugsnag.app_start.type          | stringValue | ReactNativeInit                       |
 
-    And a span named "[Navigation]Screen 1" has a parent named "ParentSpan"
     And a span named "[Navigation]Screen 1" contains the attributes:
       | attribute                       | type        | value                                        |
       | bugsnag.span.category           | stringValue | navigation                                   |
@@ -24,7 +23,6 @@ Feature: Navigation spans with React Native Navigation
       | bugsnag.navigation.triggered_by | stringValue | @bugsnag/react-native-navigation-performance |
       | bugsnag.navigation.ended_by     | stringValue | immediate                                    |
 
-    And a span named "[Navigation]Screen 2" has a parent named "ParentSpan"
     And a span named "[Navigation]Screen 2" contains the attributes:
       | attribute                         | type        | value                                        |
       | bugsnag.span.category             | stringValue | navigation                                   |

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -11,31 +11,23 @@ Feature: Navigation spans with React Native Navigation
 
     And the trace "Bugsnag-Span-Sampling" header equals "1:2"
 
-    # Span 1
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[Navigation]Screen 1"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "navigation"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.route" equals "Screen 1"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.navigation.ended_by" equals "immediate"
+    And a span named "[AppStart/ReactNativeInit]" contains the attributes:
+      | attribute                       | type        | value                                 |
+      | bugsnag.span.category           | stringValue | app_start                             |
+      | bugsnag.app_start.type          | stringValue | ReactNativeInit                       |
 
-    # Span 2
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "[Navigation]Screen 2"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.kind" equals 3
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.startTimeUnixNano" matches the regex "^[0-9]+$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.endTimeUnixNano" matches the regex "^[0-9]+$"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "navigation"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.route" equals "Screen 2"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.triggered_by" equals "@bugsnag/react-native-navigation-performance"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.navigation.ended_by" is one of:
-      | immediate |
-      | mount |
-      | unmount |
-      | condition |
-      
+    And a span named "[Navigation]Screen 1" has a parent named "[AppStart/ReactNativeInit]"
+    And a span named "[Navigation]Screen 1" contains the attributes:
+      | attribute                       | type        | value                                        |
+      | bugsnag.span.category           | stringValue | navigation                                   |
+      | bugsnag.navigation.route        | stringValue | Screen 1                                     |
+      | bugsnag.navigation.triggered_by | stringValue | @bugsnag/react-native-navigation-performance |
+      | bugsnag.navigation.ended_by     | stringValue | immediate                                    |
+
+    And a span named "[Navigation]Screen 2" contains the attributes:
+      | attribute                         | type        | value                                        |
+      | bugsnag.span.category             | stringValue | navigation                                   |
+      | bugsnag.navigation.route          | stringValue | Screen 2                                     |
+      | bugsnag.navigation.triggered_by   | stringValue | @bugsnag/react-native-navigation-performance |
+      # | bugsnag.navigation.previous_route | stringValue | Screen 1                                     |
+      # | bugsnag.navigation.ended_by       | stringValue | condition                                    |


### PR DESCRIPTION
## Goal

Ensure AppStart spans are instrumented when using `react-native-navigation`

## Testing

Updated end to end test fixture and assertions