### PR TITLE
[PLAT-11769] Skip failing tests

### DIFF
--- a/test/react-native/features/discard-background-spans.feature
+++ b/test/react-native/features/discard-background-spans.feature
@@ -1,5 +1,7 @@
 Feature: Backgrounding listener
 
+  # Skip until PLAT-11769 has been resolved
+  @skip
   Scenario: Spans are discarded when app is in the background
     When I run 'BackgroundSpanScenario'
     And I wait to receive a sampling request


### PR DESCRIPTION
## Goal

Skip test scenario causing failures in overnight test runs due to an issue with bitbar