### PR TITLE
pass --dist-tag next to publish

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -35,7 +35,7 @@ BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/platf
 if [ -z "${RETRY_PUBLISH:-}" ]; then
   case $VERSION in
     "prerelease" | "prepatch" | "preminor" | "premajor")
-      npx lerna version "$VERSION"  --no-push --no-private --dist-tag next
+      npx lerna version "$VERSION"  --no-push --no-private
       ;;
 
     *)
@@ -52,9 +52,25 @@ git push --follow-tags
 
 # publish
 if [ -z "${RETRY_PUBLISH:-}" ]; then
-  npx lerna publish from-git
+  case $VERSION in
+    "prerelease" | "prepatch" | "preminor" | "premajor")
+      npx lerna publish from-git --dist-tag next
+      ;;
+
+    *)
+      npx lerna publish from-git
+      ;;
+  esac
 else
-  npx lerna publish from-package
+  case $VERSION in
+    "prerelease" | "prepatch" | "preminor" | "premajor")
+      npx lerna publish from-package --dist-tag next
+      ;;
+
+    *)
+      npx lerna publish from-package
+      ;;
+  esac
 fi
 
 if [ "$BROWSER_PACKAGE_CHANGED" -eq 1 ] || [  -v FORCE_CDN_UPLOAD ]; then

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -33,15 +33,7 @@ BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/platf
 
 # increment package version numbers
 if [ -z "${RETRY_PUBLISH:-}" ]; then
-  case $VERSION in
-    "prerelease" | "prepatch" | "preminor" | "premajor")
-      npx lerna version "$VERSION"  --no-push --no-private
-      ;;
-
-    *)
-      npx lerna version "$VERSION" --no-push  --no-private
-      ;;
-  esac
+  npx lerna version "$VERSION"  --no-push --no-private
 fi
 
 # build packages


### PR DESCRIPTION
## Goal

- `--dist-tag` is not a valid option for `version`, it needs to be passed to `publish`

## Design

<!-- Why was this approach used? -->

## Changeset

- update the release script to pass `--dist-tag next` when publishing prereleases

## Testing

- performed a `2.3.0-alpha.0` of the `trace-propagation` branch using the updated script