### PR TITLE
[PLAT-11785] Update android namepsace

### DIFF
--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.facebook.react'
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 33)
-  namespace "com.bugsnag.android.performance"
+  namespace "com.bugsnag.reactnative.performance"
 }
 
 repositories {


### PR DESCRIPTION
## Goal

To prevent an overlap with the native android library

## Changeset

Update the namepsace to `com.bugsnag.reactnative.performance`