### PR TITLE
Fixup release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## v2.3.0 (2024-03-19)
+## v2.3.0 (2024-03-20)
 
 This release adds support for instrumenting navigation spans when using the [react-native-navigation](https://github.com/wix/react-native-navigation) library
+
+### Added 
+
+- (react-native-navigation) Added `@bugsnag/react-native-navigation-performance` package [#404](https://github.com/bugsnag/bugsnag-js-performance/pull/404)
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24777,7 +24777,7 @@
     },
     "packages/react-native-navigation": {
       "name": "@bugsnag/react-native-navigation-performance",
-      "version": "0.0.1",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@bugsnag/core-performance": "*",

--- a/packages/react-native-navigation/package.json
+++ b/packages/react-native-navigation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bugsnag/react-native-navigation-performance",
-    "version": "0.0.1",
+    "version": "2.2.0",
     "description": "BugSnag performance monitoring for react-native-navigation",
     "homepage": "https://www.bugsnag.com/",
     "license": "MIT",


### PR DESCRIPTION
## Goal

Prevent all packages from being re-released during build process due to [package version inconsistency](https://lerna.js.org/docs/features/version-and-publish#fixedlocked-mode-default) 

> Note: If you have a major version zero, all updates are [considered breaking](https://semver.org/#spec-item-4). Because of that, running lerna publish with a major version zero and choosing any non-prerelease version number will cause new versions to be published for all packages, even if not all packages have changed since the last release.