### PR TITLE
[PLAT-11800] Delay initial span batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- (browser) Delay span batching while inital sampling request is in flight [#433](https://github.com/bugsnag/bugsnag-js-performance/pull/433)
+
 ## v2.4.0 (2024-03-27)
 
 ### Added

--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -6,7 +6,7 @@ import { type RetryQueue } from './retry-queue'
 import { type ReadonlySampler } from './sampler'
 import { type SpanEnded } from './span'
 
-type MinimalProbabilityManager = Pick<ProbabilityManager, 'setProbability'>
+type MinimalProbabilityManager = Pick<ProbabilityManager, 'setProbability' | 'fetchingInitialProbability'>
 
 export class BatchProcessor<C extends Configuration> implements Processor {
   private readonly delivery: Delivery
@@ -66,6 +66,11 @@ export class BatchProcessor<C extends Configuration> implements Processor {
 
   async flush () {
     this.stop()
+
+    // we're still waiting for the initial probability value to be fetched
+    if (this.probabilityManager.fetchingInitialProbability) {
+      await this.probabilityManager.fetchingInitialProbability
+    }
 
     const batch = this.prepareBatch()
 

--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -67,7 +67,6 @@ export class BatchProcessor<C extends Configuration> implements Processor {
   async flush () {
     this.stop()
 
-    // we're still waiting for the initial probability value to be fetched
     if (this.probabilityManager.fetchingInitialProbability) {
       await this.probabilityManager.fetchingInitialProbability
     }

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -15,7 +15,6 @@ export interface Configuration {
   logger?: Logger
   appVersion?: string
   enabledReleaseStages?: string[] | null
-  samplingProbability?: number
   plugins?: Array<Plugin<Configuration>>
 }
 
@@ -42,7 +41,6 @@ export interface CoreSchema extends Schema {
   logger: ConfigOption<Logger>
   appVersion: ConfigOption<string>
   enabledReleaseStages: ConfigOption<string[] | null>
-  samplingProbability: ConfigOption<number>
   plugins: ConfigOption<Array<Plugin<Configuration>>>
 }
 
@@ -81,11 +79,6 @@ export const schema: CoreSchema = {
     defaultValue: null,
     message: 'should be an array of strings',
     validate: (value: unknown): value is string[] | null => value === null || isStringArray(value)
-  },
-  samplingProbability: {
-    defaultValue: 1.0,
-    message: 'should be a number between 0 and 1',
-    validate: (value: unknown): value is number => isNumber(value) && value >= 0 && value <= 1
   },
   plugins: {
     defaultValue: [],

--- a/packages/core/lib/probability-manager.ts
+++ b/packages/core/lib/probability-manager.ts
@@ -114,7 +114,7 @@ class ProbabilityManager {
         }
 
         // Initial sampling request has been made, and we can unblock batching
-        if (milliseconds === 0 && this.resolveInitialProbability) {
+        if (this.resolveInitialProbability) {
           this.resolveInitialProbability()
           this.resolveInitialProbability = undefined
           this.fetchingInitialProbability = undefined

--- a/packages/core/lib/probability-manager.ts
+++ b/packages/core/lib/probability-manager.ts
@@ -117,6 +117,7 @@ class ProbabilityManager {
         if (milliseconds === 0 && this.resolveInitialProbability) {
           this.resolveInitialProbability()
           this.resolveInitialProbability = undefined
+          this.fetchingInitialProbability = undefined
         }
       },
       milliseconds

--- a/packages/core/tests/batch-processor.test.ts
+++ b/packages/core/tests/batch-processor.test.ts
@@ -193,6 +193,9 @@ describe('BatchProcessor', () => {
     const delivery = new InMemoryDelivery()
     const clock = new IncrementingClock('1970-01-01T00:00:00Z')
     const sampler = new Sampler(1.0)
+    const persistence = new InMemoryPersistence()
+
+    persistence.save('bugsnag-sampling-probability', { value: 1.0, time: Date.now() })
 
     const batchProcessor = new BatchProcessor(
       delivery,
@@ -200,7 +203,7 @@ describe('BatchProcessor', () => {
       { add: jest.fn(), flush: jest.fn() },
       sampler,
       await ProbabilityManager.create(
-        new InMemoryPersistence(),
+        persistence,
         sampler,
         new ProbabilityFetcher(delivery, 'api key')
       ),

--- a/packages/core/tests/batch-processor.test.ts
+++ b/packages/core/tests/batch-processor.test.ts
@@ -14,6 +14,8 @@ import {
 
 jest.useFakeTimers()
 
+const minimalProbabilityManager = { setProbability () { return Promise.resolve() }, fetchingInitialProbability: undefined }
+
 describe('BatchProcessor', () => {
   it('delivers after reaching the specified span limit', async () => {
     const delivery = new InMemoryDelivery()
@@ -23,7 +25,7 @@ describe('BatchProcessor', () => {
       createConfiguration(),
       { add: jest.fn(), flush: jest.fn() },
       new Sampler(1.0),
-      { setProbability () { return Promise.resolve() } },
+      minimalProbabilityManager,
       new TracePayloadEncoder(clock, createConfiguration(), resourceAttributesSource)
     )
 
@@ -49,7 +51,7 @@ describe('BatchProcessor', () => {
       createConfiguration(),
       { add: jest.fn(), flush: jest.fn() },
       new Sampler(1.0),
-      { setProbability () { return Promise.resolve() } },
+      minimalProbabilityManager,
       new TracePayloadEncoder(clock, createConfiguration(), resourceAttributesSource)
     )
 
@@ -70,7 +72,7 @@ describe('BatchProcessor', () => {
       createConfiguration(),
       { add: jest.fn(), flush: jest.fn() },
       new Sampler(1.0),
-      { setProbability () { return Promise.resolve() } },
+      minimalProbabilityManager,
       new TracePayloadEncoder(clock, createConfiguration(), resourceAttributesSource)
     )
 
@@ -97,7 +99,7 @@ describe('BatchProcessor', () => {
       configuration,
       { add: jest.fn(), flush: jest.fn() },
       new Sampler(1.0),
-      { setProbability () { return Promise.resolve() } },
+      minimalProbabilityManager,
       new TracePayloadEncoder(clock, configuration, resourceAttributesSource)
     )
 
@@ -119,7 +121,7 @@ describe('BatchProcessor', () => {
       createConfiguration({ logger }),
       retryQueue,
       new Sampler(1.0),
-      { setProbability () { return Promise.resolve() } },
+      minimalProbabilityManager,
       new TracePayloadEncoder(clock, createConfiguration(), resourceAttributesSource)
     )
 
@@ -146,7 +148,7 @@ describe('BatchProcessor', () => {
       createConfiguration({ logger }),
       retryQueue,
       new Sampler(1.0),
-      { setProbability () { return Promise.resolve() } },
+      minimalProbabilityManager,
       new TracePayloadEncoder(clock, createConfiguration(), resourceAttributesSource)
     )
 
@@ -173,7 +175,7 @@ describe('BatchProcessor', () => {
       createConfiguration({ logger }),
       retryQueue,
       new Sampler(1.0),
-      { setProbability () { return Promise.resolve() } },
+      minimalProbabilityManager,
       new TracePayloadEncoder(clock, createConfiguration(), resourceAttributesSource)
     )
 

--- a/packages/platforms/browser/tests/__mocks__/@bugsnag/delivery-fetch-performance.ts
+++ b/packages/platforms/browser/tests/__mocks__/@bugsnag/delivery-fetch-performance.ts
@@ -1,0 +1,82 @@
+import {
+  responseStateFromStatusCode,
+  type BackgroundingListener,
+  type Clock,
+  type Delivery,
+  type DeliveryFactory,
+  type DeliveryPayload,
+  type TracePayload
+} from '@bugsnag/core-performance'
+
+export const requests: DeliveryPayload[] = []
+
+type Fetch = typeof fetch
+
+// manually mock response
+const response = {
+  status: 200,
+  headers: new Headers({ 'Bugsnag-Sampling-Probability': '1.0' })
+}
+
+export const setNextSamplingProbability = (probability: number) => {
+  const newProbability = probability.toString()
+  response.headers.set('Bugsnag-Sampling-Probability', newProbability)
+}
+
+export const mockFetch = jest.fn((endpoint: string, options) => Promise.resolve(response))
+
+function samplingProbabilityFromHeaders (headers: Headers): number | undefined {
+  const value = headers.get('Bugsnag-Sampling-Probability')
+
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const asNumber = Number.parseFloat(value)
+
+  if (Number.isNaN(asNumber) || asNumber < 0 || asNumber > 1) {
+    return undefined
+  }
+
+  return asNumber
+}
+
+function createFetchDeliveryFactory (
+  fetch: Fetch,
+  clock: Clock,
+  backgroundingListener?: BackgroundingListener
+): DeliveryFactory {
+  return function fetchDeliveryFactory (endpoint: string): Delivery {
+    return {
+      async send (payload: TracePayload) {
+        requests.push({ resourceSpans: payload.body.resourceSpans })
+
+        const body = JSON.stringify(payload.body)
+
+        payload.headers['Bugsnag-Sent-At'] = clock.date().toISOString()
+
+        try {
+          const response = await mockFetch(endpoint, {
+            method: 'POST',
+            keepalive: false,
+            body,
+            headers: payload.headers
+          })
+
+          return {
+            state: responseStateFromStatusCode(response.status),
+            samplingProbability: samplingProbabilityFromHeaders(response.headers)
+          }
+        } catch (err) {
+          if (body.length > 10e5) {
+            return { state: 'failure-discard' }
+          }
+
+          return { state: 'failure-retryable' }
+        }
+      }
+    }
+  }
+}
+
+export default createFetchDeliveryFactory

--- a/packages/platforms/browser/tests/browser.test.ts
+++ b/packages/platforms/browser/tests/browser.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options { "url": "https://bugsnag.com/browser-integration-tests" }
+*/
+
+import { VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
+import BugsnagPerformance from '../lib/browser'
+
+// eslint-disable-next-line jest/no-mocks-import
+import { mockFetch, requests, setNextSamplingProbability } from './__mocks__/@bugsnag/delivery-fetch-performance'
+
+jest.useFakeTimers()
+
+describe('Browser client integration tests', () => {
+  describe('Sampling', () => {
+    it('(potential flake) uses the sampling header from the response for the next batch', async () => {
+      setNextSamplingProbability(0.999999)
+
+      BugsnagPerformance.start({
+        apiKey: VALID_API_KEY,
+        endpoint: '/test',
+        autoInstrumentFullPageLoads: false
+      })
+
+      // Advance to next tick
+      await jest.advanceTimersByTimeAsync(1)
+
+      // Check for initial sampling request
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith('/test', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          resourceSpans: []
+        })
+      }))
+
+      // Create and end span and await batch timeout
+      BugsnagPerformance.startSpan('test span').end()
+
+      await jest.advanceTimersByTimeAsync(30000)
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      const deliveredSpan = requests[1].resourceSpans[0].scopeSpans[0].spans[0]
+      expect(deliveredSpan.attributes).toContainEqual({ key: 'bugsnag.sampling.p', value: { doubleValue: 0.999999 } })
+    })
+  })
+})


### PR DESCRIPTION
## Goal

This PR ensures that the correct sampling rate is used for a batch which is filled before the initial sampling request has been made by delaying batching while the request is in flight.

The config option for `samplingProbability` has also been removed.

## Testing

Add integration test for browser client which awaits the initial sampling request when a full batch is created before starting bugsnag