### PR TITLE
Ensure existing headers are preserved for fetch requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- (request-tracker) Ensure existing headers are preserved for fetch requests [#436](https://github.com/bugsnag/bugsnag-js-performance/pull/436)
+
 ### Changed
 
 - (browser) Delay span batching while inital sampling request is in flight [#433](https://github.com/bugsnag/bugsnag-js-performance/pull/433)

--- a/packages/request-tracker/lib/request-tracker-fetch.ts
+++ b/packages/request-tracker/lib/request-tracker-fetch.ts
@@ -18,19 +18,23 @@ function isRequest (input: unknown): input is Request {
   return !!input && typeof input === 'object' && !(input instanceof URL)
 }
 
+function isHeadersInstance (input: unknown): input is Headers {
+  return !!input && typeof input === 'object' && input instanceof Headers
+}
+
 function createFetchRequestTracker (global: GlobalWithFetch, clock: Clock) {
   const requestTracker = new RequestTracker()
   const originalFetch = global.fetch
 
-  global.fetch = function fetch (input?: unknown, init?: unknown) {
+  global.fetch = function fetch (input: unknown, init?: unknown) {
     const startContext = createStartContext(clock.now(), input, init, global.document && global.document.baseURI)
 
     const { onRequestEnd, extraRequestHeaders } = requestTracker.start(startContext)
 
     // Add the headers to the `init` received from the caller
-    const patchedInit = mergeRequestHeaders(init as RequestInit, extraRequestHeaders)
+    const modifiedParams = mergeRequestHeaders(input as RequestInfo, init as RequestInit, extraRequestHeaders)
 
-    return originalFetch.call(this, input as RequestInfo, patchedInit).then(response => {
+    return originalFetch.call(this, modifiedParams[0], modifiedParams[1]).then(response => {
       onRequestEnd({ status: response.status, endTime: clock.now(), state: 'success' })
       return response
     }).catch(error => {
@@ -42,17 +46,42 @@ function createFetchRequestTracker (global: GlobalWithFetch, clock: Clock) {
   return requestTracker
 }
 
-function mergeRequestHeaders (init: RequestInit, extraRequestHeaders?: Array<Record<string, string>>): RequestInit {
-  if (!extraRequestHeaders) return init
+function mergeRequestHeaders (input: RequestInfo, init?: RequestInit, extraRequestHeaders?: Array<Record<string, string>>): Parameters<typeof fetch> {
+  if (!extraRequestHeaders) return [input, init]
 
-  const extraHeaders: Record<string, string> = {}
-  for (const h of extraRequestHeaders) {
-    for (const [name, value] of Object.entries(h)) {
-      extraHeaders[name] = value
-    }
+  const extraHeaders = extraRequestHeaders.reduce((headers, current) => ({ ...headers, ...current }), {})
+
+  if (isRequest(input) && (!init || !init.headers)) {
+    mergeInputRequestHeaders(extraHeaders, input)
+  } else {
+    init = mergeInitRequestHeaders(extraHeaders, init)
   }
 
-  return { ...init, headers: { ...extraHeaders, ...init?.headers } }
+  return [input, init]
+}
+
+function mergeInputRequestHeaders (extraRequestHeaders: Record<string, string>, input: Request) {
+  for (const [name, value] of Object.entries(extraRequestHeaders)) {
+    if (!input.headers.has(name)) {
+      input.headers.set(name, value)
+    }
+  }
+}
+
+function mergeInitRequestHeaders (extraRequestHeaders: Record<string, string>, init?: RequestInit): RequestInit {
+  if (!init) init = {}
+
+  if (isHeadersInstance(init.headers)) {
+    for (const [name, value] of Object.entries(extraRequestHeaders)) {
+      if (!init.headers.has(name)) {
+        init.headers.set(name, value)
+      }
+    }
+
+    return init
+  } else {
+    return { ...init, headers: { ...extraRequestHeaders, ...init.headers } }
+  }
 }
 
 export default createFetchRequestTracker

--- a/test/browser/features/fixtures/packages/traceparent/index.html
+++ b/test/browser/features/fixtures/packages/traceparent/index.html
@@ -9,7 +9,14 @@
         <h1>traceparent</h1>
 
         <button id="xhr">xhr</button>
-        <button id="fetch">fetch</button>
+
+        <button id="fetch-simple-headers-in-options">fetch</button>
+        <button id="fetch-headers-class-in-options">fetch</button>
+
+        <button id="fetch-simple-headers-in-request">fetch</button>
+        <button id="fetch-headers-class-in-request">fetch</button>
+        
+        <button id="fetch-headers-in-request-and-options">fetch</button>
 
         <script src="./dist/bundle.js" type="module"></script>
     </body>

--- a/test/browser/features/fixtures/packages/traceparent/src/index.js
+++ b/test/browser/features/fixtures/packages/traceparent/src/index.js
@@ -24,7 +24,25 @@ document.getElementById("xhr").addEventListener("click", () => {
   xhr.send()
 })
 
-document.getElementById("fetch").addEventListener("click", () => {
+document.getElementById("fetch-simple-headers-in-options").addEventListener("click", () => {
   fetch(reflectEndpoint, { headers: { 'X-Test-Header': 'test' }})
 })
 
+document.getElementById("fetch-headers-class-in-options").addEventListener("click", () => {
+  fetch(reflectEndpoint, { headers: new Headers({ 'X-Test-Header': 'test' })})
+})
+
+document.getElementById("fetch-simple-headers-in-request").addEventListener("click", () => {
+  const request = new Request(reflectEndpoint, { headers: { 'X-Test-Header': 'test' }})
+  fetch(request)
+})
+
+document.getElementById("fetch-headers-class-in-request").addEventListener("click", () => {
+  const request = new Request(reflectEndpoint, { headers: new Headers({ 'X-Test-Header': 'test' })})
+  fetch(request)
+})
+
+document.getElementById("fetch-headers-in-request-and-options").addEventListener("click", () => {
+  const request = new Request(reflectEndpoint, { headers: new Headers({ 'X-Ignored-Header': 'will be ignored' })})
+  fetch(request, { headers: { 'X-Test-Header': 'test' }})
+})

--- a/test/browser/features/traceparent.feature
+++ b/test/browser/features/traceparent.feature
@@ -1,4 +1,4 @@
-Feature: Network spans
+Feature: Trace propagation headers
 
     Scenario: traceparent header is added to xhr requests
         Given I navigate to the test URL "/traceparent"
@@ -13,9 +13,9 @@ Feature: Network spans
 
         Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
-    Scenario: traceparent header is added to fetch requests
+    Scenario: traceparent header is added to fetch requests (simple headers in fetch options)
         Given I navigate to the test URL "/traceparent"
-        When I click the element "fetch"
+        When I click the element "fetch-simple-headers-in-options"
 
         And I wait to receive a reflection
         Then the reflection request method equals "GET"
@@ -24,4 +24,56 @@ Feature: Network spans
 
         And I wait to receive 1 trace
 
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+    Scenario: traceparent header is added to fetch requests (Headers class in fetch options)   
+        Given I navigate to the test URL "/traceparent"
+        When I click the element "fetch-headers-class-in-options"
+
+        And I wait to receive a reflection
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        And I wait to receive 1 trace
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+    Scenario: traceparent header is added to fetch requests (simple headers in Request object)   
+        Given I navigate to the test URL "/traceparent"
+        When I click the element "fetch-simple-headers-in-request"
+
+        And I wait to receive a reflection
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        And I wait to receive 1 trace
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+    Scenario: traceparent header is added to fetch requests (Headers class in Request object)
+        Given I navigate to the test URL "/traceparent"
+        When I click the element "fetch-headers-class-in-request"
+
+        And I wait to receive a reflection
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        And I wait to receive 1 trace
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+    Scenario: traceparent header is added to fetch requests (headers in both request and options)
+        Given I navigate to the test URL "/traceparent"
+        When I click the element "fetch-headers-in-request-and-options"
+
+        And I wait to receive a reflection
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        And I wait to receive 1 trace
+        
         Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"


### PR DESCRIPTION
## Goal

Fixes a bug in the fetch request tracker where any headers that are set in a `Request` object passed to `fetch` were not being preserved. Similarly if headers are set using the `Headers` class in the request options these would also be wiped.

This is because trace propagation headers were always being merged with the options object (the second argument passed to fetch) as an object literal, however request headers can be set in a few different ways:

- As an object literal in options
- As a `Headers` instance in options
- In a `Request` object passed as the first argument to `fetch`

The behaviour of `fetch` is such that if headers are set in the options object these will take precedence, and any headers defined in a `Request` object are ignored.

## Design

Reworked the `mergeRequestHeaders` logic to handle all of the cases listed above, with headers defined in `fetch` options taking precedence.

## Testing

Added additional unit test cases and e2e scenarios