### PR TITLE
Add trace propagation headers for React Native

### DIFF
--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -37,7 +37,7 @@ const BugsnagPerformance = createClient({
   persistence,
   plugins: (spanFactory, spanContextStorage) => [
     new AppStartPlugin(appStartTime, spanFactory, clock, AppRegistry),
-    new NetworkRequestPlugin(spanFactory, xhrRequestTracker)
+    new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrRequestTracker)
   ],
   resourceAttributesSource,
   schema: createSchema(),

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioContext.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const ScenarioContext = React.createContext({
+  reflectEndpoint: '',
+})

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -4,6 +4,7 @@ import { AppRegistry } from 'react-native'
 import * as Scenarios from '../scenarios'
 import { getCurrentCommand } from './CommandRunner'
 import { clearPersistedState, setDeviceId, setSamplingProbability } from './Persistence'
+import { ScenarioContext } from './ScenarioContext' 
 
 const isTurboModuleEnabled = () => global.__turboModuleProxy != null
 
@@ -51,8 +52,17 @@ async function runScenario (rootTag, scenarioName, apiKey, endpoint) {
       appParams.fabric = true
       appParams.initialProps = { concurrentRoot: true }
     }
+
+    const reflectEndpoint = endpoint.replace('traces', 'reflect')
+
+    console.error(`[BugsnagPerformance] Reflect endpoint: ${reflectEndpoint}`)
+
+    const Scenario = () => 
+    <ScenarioContext.Provider value={{ reflectEndpoint }}>
+      <scenario.App />
+    </ScenarioContext.Provider>
   
-    AppRegistry.registerComponent(scenarioName, () => scenario.App)
+    AppRegistry.registerComponent(scenarioName, () => Scenario)
     AppRegistry.runApplication(scenarioName, appParams)
   }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
@@ -1,0 +1,106 @@
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import React, { useContext, useEffect } from 'react'
+import { ScenarioContext } from '../lib/ScenarioContext'
+
+export const config = {
+  maximumBatchSize: 1,
+  autoInstrumentAppStarts: false,
+  networkRequestCallback: (requestInfo) => {
+    if (requestInfo.url.endsWith('/command')) return null
+
+    requestInfo.propagateTraceContext = true
+    return requestInfo;
+  },
+}
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+const fetchWithObjectLiteralHeadersInOptions = async (endpoint) => {
+  try {
+    await fetch(endpoint, { headers: { 'X-Test-Header': 'test' } })
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const fetchWithHeadersClassInOptions = async (endpoint) => {
+  try {
+    await fetch(endpoint, { headers: new Headers({ 'X-Test-Header': 'test' }) })
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const fetchWithObjectLiteralHeadersInRequest = async (endpoint) => {
+  try {
+    const request = new Request(endpoint, { headers: { 'X-Test-Header': 'test' }})
+    await fetch(request)
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const fetchWithHeadersClassInRequest = async (endpoint) => {
+  try {
+    const request = new Request(endpoint, { headers: new Headers({ 'X-Test-Header': 'test' }) })
+    await fetch(request)
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const xhrWithHeaders = async (endpoint) => {
+  return new Promise((resolve, reject) => {
+    const xhrSuccess = new XMLHttpRequest()
+   
+    xhrSuccess.onload = () => {
+      if (xhrSuccess.readyState === 4) {
+        resolve() 
+      }
+    }
+
+    xhrSuccess.onerror = () => {
+      console.error('[BugsnagPerformance] error sending xhr request', xhr)
+      reject()
+    }
+
+    xhrSuccess.open('GET', endpoint)
+    xhrSuccess.setRequestHeader('X-Test-Header', 'test')
+    xhrSuccess.send()
+  })
+}
+
+export const App = () => {
+  const { reflectEndpoint } = useContext(ScenarioContext)
+
+  useEffect(() => {
+    (async () => {
+        await delay(250)
+
+        await fetchWithObjectLiteralHeadersInOptions(reflectEndpoint)
+        await fetchWithHeadersClassInOptions(reflectEndpoint)
+
+        await fetchWithObjectLiteralHeadersInRequest(reflectEndpoint)
+        await fetchWithHeadersClassInRequest(reflectEndpoint)
+
+        await xhrWithHeaders(reflectEndpoint)
+    })()
+}, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>TracePropagationScenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -8,6 +8,7 @@ export * as NetworkRequestFailedScenario from './NetworkRequestFailedScenario'
 export * as NetworkRequestScenario from './NetworkRequestScenario'
 export * as SpanTriggeredByCommandScenario from './SpanTriggeredByCommandScenario'
 export * as WrapperComponentProviderScenario from './WrapperComponentProviderScenario'
+export * as TracePropagationScenario from './TracePropagationScenario'
 
 // React Native Navigation Scenarios
 export * as ReactNativeNavigationScenario from './ReactNativeNavigationScenario'

--- a/test/react-native/features/traceparent.feature
+++ b/test/react-native/features/traceparent.feature
@@ -1,0 +1,49 @@
+Feature: Trace propagation headers
+
+    Scenario: traceparent headers are added to requests
+        When I run 'TracePropagationScenario'
+
+        And I wait to receive 5 reflections
+        And I wait to receive 5 traces
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"


### PR DESCRIPTION
## Goal

Set the `traceparent` header on intercepted network requests in React Native

## Design

Follows the same approach as the existing browser implementation

## Testing

Added unit and e2e tests. 

Introduced the concept of a `ScenarioContext` in the RN test fixture to allow data to be passed down into scenario components (in this case the reflect endpoint)