### PR TITLE
Bump node to 18 for all RN test fixture builds and fix test flakes

### DIFF
--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -10,6 +10,7 @@ steps:
         agents:
           queue: macos-12-arm
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           BUILD_ANDROID: "true"
         artifact_paths:
@@ -30,6 +31,7 @@ steps:
         agents:
           queue: macos-12-arm
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "true"
           BUILD_ANDROID: "true"
@@ -51,6 +53,7 @@ steps:
         agents:
           queue: "macos-12-arm"
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           BUILD_IOS: "true"
           DEVELOPER_DIR: "/Applications/Xcode14.app"
@@ -73,6 +76,7 @@ steps:
         agents:
           queue: "macos-12-arm"
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_IOS: "true"

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
@@ -3,7 +3,7 @@ import React, { useContext, useEffect } from 'react'
 import { ScenarioContext } from '../lib/ScenarioContext'
 
 export const config = {
-  maximumBatchSize: 1,
+  maximumBatchSize: 5,
   autoInstrumentAppStarts: false,
   networkRequestCallback: (requestInfo) => {
     if (requestInfo.url.endsWith('/command')) return null

--- a/test/react-native/features/traceparent.feature
+++ b/test/react-native/features/traceparent.feature
@@ -4,46 +4,34 @@ Feature: Trace propagation headers
         When I run 'TracePropagationScenario'
 
         And I wait to receive 5 reflections
-        And I wait to receive 5 traces
+        
+        And I wait for 5 spans
+        Then every span string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect$"
 
-        Then the reflection request method equals "GET"
+        And the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"


### PR DESCRIPTION
## Goal

Some of the RN test fixture build began failing because they were still using node 16 and the RN CLI now requires node 18. This PR bumps the node version to 18 for all RN test fixture builds.

Also fixed a test flake in the trace propagation e2e tests due to span batches sometimes being larger than expected.
