### PR TITLE
Add `tracePropagationUrls` config option for React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Added
+
+- (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
+
 ## v2.4.1 (2024-04-18)
 
 ### Fixed

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -12,6 +12,11 @@ import { type BrowserConfiguration } from '../config'
 
 export interface BrowserNetworkRequestInfo extends NetworkRequestInfo {
   readonly type: PerformanceResourceTiming['initiatorType']
+
+  /**
+   * Experimental. Whether to propagate trace context by adding a `traceparent` header to the request.
+   */
+  propagateTraceContext?: boolean
 }
 
 const permittedPrefixes = ['http://', 'https://', '/', './', '../']

--- a/packages/platforms/browser/tests/browser.test.ts
+++ b/packages/platforms/browser/tests/browser.test.ts
@@ -90,8 +90,6 @@ describe('Browser client integration tests', () => {
       const fullBatch = JSON.parse(mockFetch.mock.calls[1][1].body)
       expect(fullBatch.resourceSpans[0].scopeSpans[0].spans).toHaveLength(100)
 
-      console.log(mockFetch.mock.calls[1][1].headers)
-
       // Header should be updated
       expect(mockFetch).toHaveBeenLastCalledWith('/test', expect.objectContaining({
         headers: expect.objectContaining({

--- a/packages/platforms/react-native/lib/config.ts
+++ b/packages/platforms/react-native/lib/config.ts
@@ -1,5 +1,6 @@
 import {
   isBoolean,
+  isStringOrRegExpArray,
   isStringWithLength,
   schema,
   type ConfigOption,
@@ -18,6 +19,7 @@ export interface ReactNativeSchema extends CoreSchema {
   wrapperComponentProvider: ConfigOption<WrapperComponentProvider | null>
   autoInstrumentNetworkRequests: ConfigOption<boolean>
   networkRequestCallback: ConfigOption<NetworkRequestCallback<ReactNativeNetworkRequestInfo>>
+  tracePropagationUrls: ConfigOption<Array<string | RegExp>>
 }
 
 export interface ReactNativeConfiguration extends Configuration {
@@ -27,6 +29,7 @@ export interface ReactNativeConfiguration extends Configuration {
   generateAnonymousId?: boolean
   networkRequestCallback?: NetworkRequestCallback<ReactNativeNetworkRequestInfo>
   wrapperComponentProvider?: WrapperComponentProvider | null
+  tracePropagationUrls?: Array<string | RegExp>
 }
 
 function createSchema (): ReactNativeSchema {
@@ -61,6 +64,11 @@ function createSchema (): ReactNativeSchema {
       defaultValue: defaultNetworkRequestCallback,
       message: 'should be a function',
       validate: isNetworkRequestCallback
+    },
+    tracePropagationUrls: {
+      defaultValue: [],
+      message: 'should be an array of string|RegExp',
+      validate: isStringOrRegExpArray
     }
   }
 }

--- a/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -14,6 +14,15 @@ class MockRequestTracker extends RequestTracker {
   })
 }
 
+const createConfig = (overrides: Partial<ReactNativeConfiguration> = {}) => {
+  return createConfiguration<ReactNativeConfiguration>({
+    endpoint: ENDPOINT,
+    autoInstrumentNetworkRequests: true,
+    tracePropagationUrls: [],
+    ...overrides
+  })
+}
+
 describe('network span plugin', () => {
   let xhrTracker: MockRequestTracker
   let spanFactory: MockSpanFactory<ReactNativeConfiguration>
@@ -29,10 +38,7 @@ describe('network span plugin', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
     expect(xhrTracker.onStart).not.toHaveBeenCalled()
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     expect(xhrTracker.onStart).toHaveBeenCalled()
   })
@@ -40,16 +46,13 @@ describe('network span plugin', () => {
   it('starts a span on request start', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: TEST_URL, startTime: 2 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
 
-    // traceparent headers are not added to same-origin requests by default
+    // currently traceparent headers are not added to any requests by default
     const res2 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: SAME_ORIGIN_TEST_URL, startTime: 2 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
@@ -58,10 +61,7 @@ describe('network span plugin', () => {
   it('ends a span on request end', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
@@ -84,10 +84,7 @@ describe('network span plugin', () => {
   it('does not track requests when autoInstrumentNetworkRequests = false', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: false
-    }))
+    plugin.configure(createConfig({ autoInstrumentNetworkRequests: false }))
 
     expect(xhrTracker.onStart).not.toHaveBeenCalled()
   })
@@ -95,10 +92,7 @@ describe('network span plugin', () => {
   it('does not track requests to the configured traces endpoint', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: `${ENDPOINT}`, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
@@ -108,10 +102,7 @@ describe('network span plugin', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
     const NET_INFO_REACHABILITY_URL = 'https://clients3.google.com/generate_204?_=1701691583660'
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: NET_INFO_REACHABILITY_URL, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
@@ -129,10 +120,7 @@ describe('network span plugin', () => {
   it.each(expectedProtocols)('tracks requests over all expected protocols', (url) => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalled()
@@ -153,10 +141,7 @@ describe('network span plugin', () => {
   it.each(unexpectedProtocols)('does not track requests over unexpected protocols', (url) => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
@@ -165,10 +150,7 @@ describe('network span plugin', () => {
   it('discards the span if the status is 0', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
@@ -180,10 +162,7 @@ describe('network span plugin', () => {
   it('discards the span if there is an error', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
@@ -205,9 +184,7 @@ describe('network span plugin', () => {
 
   it('prevents creating a span when networkRequestCallback returns null', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
+    plugin.configure(createConfig({
       networkRequestCallback: (networkRequestInfo) => networkRequestInfo.url === 'no-delivery' ? null : networkRequestInfo
     }))
 
@@ -220,9 +197,7 @@ describe('network span plugin', () => {
 
   it('uses a modified url from networkRequestCallback', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
+    plugin.configure(createConfig({
       networkRequestCallback: (networkRequestInfo) => ({
         type: networkRequestInfo.type,
         url: 'modified-url'
@@ -246,32 +221,54 @@ describe('network span plugin', () => {
     expect(span).toHaveAttribute('http.status_code', 200)
   })
 
-  it('prevents adding trace propagation headers when networkRequestCallback returns { propagateTraceContext: false }', () => {
+  it('adds trace propagation headers when url matches tracePropagationUrls (string)', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
-      networkRequestCallback: (networkRequestInfo) => ({ ...networkRequestInfo, propagateTraceContext: false })
+    plugin.configure(createConfig({
+      tracePropagationUrls: [TEST_URL]
     }))
+
+    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(res.extraRequestHeaders).toEqual([
+      { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
+    ])
+  })
+
+  it('adds trace propagation headers when url matches tracePropagationUrls (RegExp)', () => {
+    const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
+    plugin.configure(createConfig({
+      tracePropagationUrls: [
+        /^(http(s)?(:\/\/))?(www\.)?test-url\.com(\/.*)?$/
+      ]
+    }))
+
+    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(res.extraRequestHeaders).toEqual([
+      { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
+    ])
+  })
+
+  it('does not add trace propagation headers when tracePropagationUrls is empty', () => {
+    const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
+    plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 
-  it('adds trace propagation headers when networkRequestCallback returns { propagateTraceContext: true }', () => {
+  it('does not add trace propagation headers when url does not match tracePropagationUrls', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
-      networkRequestCallback: (networkRequestInfo) => ({ ...networkRequestInfo, propagateTraceContext: true })
+    plugin.configure(createConfig({
+      tracePropagationUrls: [
+        'http://noheader.com/',
+        /^(http(s)?(:\/\/))?(www\.)?noheader\.com(\/.*)?$/
+      ]
     }))
 
-    // by default when the origin is different trace propagation headers are not added, unless the networkRequestCallback returns { propagateTraceContext: true }
-    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
+    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
-    expect(res.extraRequestHeaders).toEqual([
-      { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
-    ])
+    expect(res.extraRequestHeaders).toEqual([])
   })
 })

--- a/packages/platforms/react-native/tests/config.test.ts
+++ b/packages/platforms/react-native/tests/config.test.ts
@@ -104,4 +104,39 @@ describe('ReactNativeSchema', () => {
       })
     })
   })
+
+  describe('tracePropagationUrls', () => {
+    it('defaults to an empty array', () => {
+      const schema = createSchema()
+
+      expect(schema.tracePropagationUrls.defaultValue).toStrictEqual([])
+    })
+
+    it.each([
+      [false, 123],
+      [false, false],
+      [false, null],
+      [false, undefined],
+      [false, ''],
+      [false, 'a'],
+      [false, /a/],
+      [false, {}],
+      [false, { a: 1, b: 2 }],
+      [false, [[]]],
+      [false, [['a']]],
+      [false, ['a', /b/, 1]],
+
+      [true, []],
+      [true, ['a']],
+      [true, [/a/]],
+      [true, ['a', 'b', 'c']],
+      [true, [/a/, /b/, /c/]],
+      [true, ['a', /b/, 'c']]
+    ])('returns %s from validation for the value %p', (expected, value) => {
+      const schema = createSchema()
+      const validate = schema.tracePropagationUrls.validate
+
+      expect(validate(value)).toBe(expected)
+    })
+  })
 })

--- a/packages/request-tracker/lib/network-request-callback.ts
+++ b/packages/request-tracker/lib/network-request-callback.ts
@@ -1,9 +1,5 @@
 export interface NetworkRequestInfo {
   url: string | null
-  /**
-   * Experimental. Whether to propagate trace context by adding a `traceparent` header to the request.
-   */
-  propagateTraceContext?: boolean
 }
 
 export type NetworkRequestCallback <T extends NetworkRequestInfo> = (networkRequestInfo: T) => T | null

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
@@ -5,12 +5,11 @@ import { ScenarioContext } from '../lib/ScenarioContext'
 export const config = {
   maximumBatchSize: 5,
   autoInstrumentAppStarts: false,
+  tracePropagationUrls: [/^http:\/\/.+:\d{4}\/reflect$/],
   networkRequestCallback: (requestInfo) => {
     if (requestInfo.url.endsWith('/command')) return null
-
-    requestInfo.propagateTraceContext = true
-    return requestInfo;
-  },
+    return requestInfo
+  }
 }
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))


### PR DESCRIPTION
## Goal

Replaces the `propagateTraceContext` boolean in the network request callback with a new config option `tracePropagationUrls` (an array of RegExp's or strings) to control which requests get propagation headers (in React Native only). 

## Design

`tracePropagationUrls` is an array of RegExp's or strings (similar to `settleIgnoreUrls` in the browser package)

`propagateTraceContext` has been removed from the base `NetworkRequestInfo` interface in the request-tracker package and added to `BrowserNetworkRequestInfo` instead.

## Testing

Updated the unit and e2e tests