### PR TITLE
fix cuid imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@
 
 - (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
 
+
+### Fixed
+
+- (core) Fix import of `@bugsnag/cuid` not working in node ESM environment [#445](https://github.com/bugsnag/bugsnag-js-performance/pull/445)
+
 ## v2.4.1 (2024-04-18)
 
 ### Fixed
 
-- (core) Delay span batching while inital sampling request is in flight [#433](https://github.com/bugsnag/bugsnag-js-performance/pull/433)
+- (core) Delay span batching while initial sampling request is in flight [#433](https://github.com/bugsnag/bugsnag-js-performance/pull/433)
 - (core) Refactor span batching to ensure correct sampling values for subsequent spans [#435](https://github.com/bugsnag/bugsnag-js-performance/pull/435)
 - (request-tracker) Ensure existing headers are preserved for fetch requests [#436](https://github.com/bugsnag/bugsnag-js-performance/pull/436)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3449,9 +3449,9 @@
       "link": true
     },
     "node_modules/@bugsnag/cuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.1.0.tgz",
-      "integrity": "sha512-U6vPVhFPLWLXQIGnmk/uPbyidB5xLVFfEdZDmmLbv41Be67re4mNsjMukHdUv669RXOWTDQNJ+bMODhuWpshkw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.1.1.tgz",
+      "integrity": "sha512-d2z4b0rEo3chI07FNN1Xds8v25CNeekecU6FC/2Fs9MxY2EipkZTThVcV2YinMn8dvRUlViKOyC50evoUxg8tw=="
     },
     "node_modules/@bugsnag/delivery-fetch-performance": {
       "resolved": "packages/delivery-fetch",
@@ -24680,7 +24680,7 @@
       "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/cuid": "^3.1.0"
+        "@bugsnag/cuid": "^3.1.1"
       }
     },
     "packages/delivery-fetch": {
@@ -24697,7 +24697,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/core-performance": "^2.4.1",
-        "@bugsnag/cuid": "^3.1.0",
+        "@bugsnag/cuid": "^3.1.1",
         "@bugsnag/delivery-fetch-performance": "^2.4.1",
         "@bugsnag/request-tracker-performance": "^2.4.1"
       }
@@ -24708,7 +24708,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/core-performance": "^2.4.1",
-        "@bugsnag/cuid": "^3.1.0",
+        "@bugsnag/cuid": "^3.1.1",
         "@bugsnag/delivery-fetch-performance": "^2.4.1",
         "@bugsnag/request-tracker-performance": "^2.4.1"
       },

--- a/packages/core/lib/persistence.ts
+++ b/packages/core/lib/persistence.ts
@@ -1,5 +1,7 @@
-import { isCuid } from '@bugsnag/cuid'
+import cuid from '@bugsnag/cuid'
 import { isPersistedProbability } from './validation'
+
+const { isCuid } = cuid
 
 export interface PersistedProbability {
   value: number

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,6 @@
     "dist"
   ],
   "dependencies": {
-    "@bugsnag/cuid": "^3.1.0"
+    "@bugsnag/cuid": "^3.1.1"
   }
 }

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@bugsnag/core-performance": "^2.4.1",
-    "@bugsnag/cuid": "^3.1.0",
+    "@bugsnag/cuid": "^3.1.1",
     "@bugsnag/delivery-fetch-performance": "^2.4.1",
     "@bugsnag/request-tracker-performance": "^2.4.1"
   },

--- a/packages/platforms/react-native/lib/persistence/file-based.ts
+++ b/packages/platforms/react-native/lib/persistence/file-based.ts
@@ -7,7 +7,9 @@ import {
 } from '@bugsnag/core-performance'
 import { type ReadWriteFile, type ReadableFile } from './file'
 import { Platform } from 'react-native'
-import { isCuid } from '@bugsnag/cuid'
+import cuid from '@bugsnag/cuid'
+
+const { isCuid } = cuid
 
 // this is intentionally very loose as the persisted file could contain anything
 type PersistedData = Record<string, unknown>

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bugsnag/core-performance": "^2.4.1",
-    "@bugsnag/cuid": "^3.1.0",
+    "@bugsnag/cuid": "^3.1.1",
     "@bugsnag/delivery-fetch-performance": "^2.4.1",
     "@bugsnag/request-tracker-performance": "^2.4.1"
   },


### PR DESCRIPTION


## Goal

Fixes the following error when using esm in node: Named export 'isCuid' not found. The requested module '@bugsnag/cuid' is a CommonJS module, which may not support all module.exports as named exports. CommonJS modules can always be imported via the default export

## Testing

- Reproduced the error using a "qwik" project as reported by one of our customers. Then made the same changes manually to the files in node_modules to verify the error is resolved