### PR TITLE
[PLAT-11983] Manual network span API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Changelog
 
-## TBD
+## [Unreleased]
 
 ### Added
 
 - (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
 - Add new `startNetworkSpan` method to `BugsnagPerformance` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)
-
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
 - Add new `startNetworkSpan` method to `BugsnagPerformance` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)
+- Change network span naming convention to `[HTTP/VERB]` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
+- Add new `startNetworkSpan` method to `BugsnagPerformance` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)
 
 
 ### Fixed

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -124,15 +124,6 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
       spanInternal.setAttribute('http.method', cleanOptions.options.method)
       spanInternal.setAttribute('http.url', cleanOptions.options.url)
 
-      // Optinal attributes
-      if (cleanOptions.options.title) {
-        spanInternal.setAttribute('bugsnag.browser.page.title', cleanOptions.options.title)
-      }
-
-      if (cleanOptions.options.referrer) {
-        spanInternal.setAttribute('bugsnag.browser.page.referrer', cleanOptions.options.referrer)
-      }
-
       const span = spanFactory.toPublicApi(spanInternal)
 
       // Overwrite end method to set status code attribute

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -17,6 +17,7 @@ import Sampler from './sampler'
 import { type Span, type SpanOptions } from './span'
 import { DefaultSpanContextStorage, type SpanContext, type SpanContextStorage } from './span-context'
 import { SpanFactory } from './span-factory'
+import { timeToNumber } from './time'
 
 interface Constructor<T> { new(): T, prototype: T }
 
@@ -125,8 +126,11 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
       const networkSpan: NetworkSpan = {
         ...span,
         end: (endOptions: NetworkSpanEndOptions) => {
-          spanInternal.setAttribute('http.status_code', endOptions.status)
-          span.end(endOptions.endTime)
+          spanFactory.endSpan(
+            spanInternal,
+            timeToNumber(options.clock, endOptions.endTime),
+            { 'http.status_code': endOptions.status }
+          )
         }
       }
 

--- a/packages/core/lib/network-span.ts
+++ b/packages/core/lib/network-span.ts
@@ -5,8 +5,6 @@ import { isStringWithLength } from './validation'
 export interface NetworkSpanOptions extends Omit<SpanOptions, 'makeCurrentContext'> {
   method: string
   url: string
-  title?: string
-  referrer?: string
 }
 
 export interface NetworkSpanEndOptions {
@@ -31,16 +29,6 @@ export const networkSpanOptionsSchema: SpanOptionSchema = {
     validate: isStringWithLength
   },
   url: {
-    message: 'should be a string',
-    getDefaultValue: () => undefined,
-    validate: isStringWithLength
-  },
-  title: {
-    message: 'should be a string',
-    getDefaultValue: () => undefined,
-    validate: isStringWithLength
-  },
-  referrer: {
     message: 'should be a string',
     getDefaultValue: () => undefined,
     validate: isStringWithLength

--- a/packages/core/lib/network-span.ts
+++ b/packages/core/lib/network-span.ts
@@ -1,4 +1,5 @@
 import { coreSpanOptionSchema, type SpanOptionSchema, type SpanOptions } from './span'
+import { type SpanContext } from './span-context'
 import { type Time } from './time'
 import { isStringWithLength } from './validation'
 
@@ -12,7 +13,7 @@ export interface NetworkSpanEndOptions {
   endTime?: Time
 }
 
-export interface NetworkSpan {
+export interface NetworkSpan extends SpanContext {
   end: (endOptions: NetworkSpanEndOptions) => void
 }
 

--- a/packages/core/lib/network-span.ts
+++ b/packages/core/lib/network-span.ts
@@ -1,0 +1,48 @@
+import { coreSpanOptionSchema, type SpanOptionSchema, type SpanOptions } from './span'
+import { type Time } from './time'
+import { isStringWithLength } from './validation'
+
+export interface NetworkSpanOptions extends Omit<SpanOptions, 'makeCurrentContext'> {
+  method: string
+  url: string
+  title?: string
+  referrer?: string
+}
+
+export interface NetworkSpanEndOptions {
+  status: number
+  endTime?: Time
+}
+
+export interface NetworkSpan {
+  end: (endOptions: NetworkSpanEndOptions) => void
+}
+
+// Clone core schema and remove makeCurrentContext
+// which should always be false for network spans
+const baseSchema = { ...coreSpanOptionSchema }
+delete baseSchema.makeCurrentContext
+
+export const networkSpanOptionsSchema: SpanOptionSchema = {
+  ...baseSchema,
+  method: {
+    message: 'should be a string',
+    getDefaultValue: () => undefined,
+    validate: isStringWithLength
+  },
+  url: {
+    message: 'should be a string',
+    getDefaultValue: () => undefined,
+    validate: isStringWithLength
+  },
+  title: {
+    message: 'should be a string',
+    getDefaultValue: () => undefined,
+    validate: isStringWithLength
+  },
+  referrer: {
+    message: 'should be a string',
+    getDefaultValue: () => undefined,
+    validate: isStringWithLength
+  }
+}

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -89,7 +89,7 @@ export class SpanFactory <C extends Configuration> {
   }
 
   startNetworkSpan (options: NetworkSpanOptions) {
-    const spanName = `[HTTP]/${options.method.toUpperCase()}`
+    const spanName = `[HTTP/${options.method.toUpperCase()}]`
     const cleanOptions = this.validateSpanOptions<NetworkSpanOptions>(spanName, options)
     const spanInternal = this.startSpan(cleanOptions.name, { ...cleanOptions.options, makeCurrentContext: false })
 

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -89,9 +89,9 @@ export class SpanFactory <C extends Configuration> {
   }
 
   startNetworkSpan (options: NetworkSpanOptions) {
-    // Use method as the span name, prefixed with [HTTP]
-    const cleanOptions = this.validateSpanOptions<NetworkSpanOptions>(options.method, options)
-    const spanInternal = this.startSpan(`[HTTP]${cleanOptions.name.toUpperCase()}`, { ...cleanOptions.options, makeCurrentContext: false })
+    const spanName = `[HTTP]/${options.method.toUpperCase()}`
+    const cleanOptions = this.validateSpanOptions<NetworkSpanOptions>(spanName, options)
+    const spanInternal = this.startSpan(cleanOptions.name, { ...cleanOptions.options, makeCurrentContext: false })
 
     spanInternal.setAttribute('bugsnag.span.category', 'network')
     spanInternal.setAttribute('http.method', options.method)

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -314,7 +314,7 @@ describe('Core', () => {
           await jest.runOnlyPendingTimersAsync()
 
           expect(delivery).toHaveSentSpan(expect.objectContaining({
-            name: '[HTTP]GET',
+            name: '[HTTP]/GET',
             kind: 3,
             events: [],
             spanId: 'a random 64 bit string',

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -314,7 +314,7 @@ describe('Core', () => {
           await jest.runOnlyPendingTimersAsync()
 
           expect(delivery).toHaveSentSpan(expect.objectContaining({
-            name: '[HTTP]/GET',
+            name: '[HTTP/GET]',
             kind: 3,
             events: [],
             spanId: 'a random 64 bit string',

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -1,12 +1,12 @@
-import { createNoopClient } from '../lib/core'
-import { type BackgroundingListener } from '../lib/backgrounding-listener'
-import { DefaultSpanContextStorage } from '../lib/span-context'
 import {
   ControllableBackgroundingListener,
-  createTestClient,
   InMemoryDelivery,
-  VALID_API_KEY
+  VALID_API_KEY,
+  createTestClient
 } from '@bugsnag/js-performance-test-utilities'
+import { type BackgroundingListener } from '../lib/backgrounding-listener'
+import { createNoopClient } from '../lib/core'
+import { DefaultSpanContextStorage } from '../lib/span-context'
 
 jest.useFakeTimers()
 
@@ -18,6 +18,7 @@ describe('Core', () => {
       expect(client).toStrictEqual({
         start: expect.any(Function),
         startSpan: expect.any(Function),
+        startNetworkSpan: expect.any(Function),
         currentSpanContext: undefined,
         getPlugin: expect.any(Function)
       })

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -306,9 +306,7 @@ describe('Core', () => {
 
           const span = client.startNetworkSpan({
             method: 'GET',
-            url: 'https://example.com',
-            title: 'Example',
-            referrer: 'https://referrer.com'
+            url: 'https://example.com'
           })
 
           span.end({ status: 200 })
@@ -327,8 +325,6 @@ describe('Core', () => {
 
           const deliveredSpan = delivery.requests[0].resourceSpans[0].scopeSpans[0].spans[0]
           expect(deliveredSpan).toHaveAttribute('bugsnag.span.category', 'network')
-          expect(deliveredSpan).toHaveAttribute('bugsnag.browser.page.title', 'Example')
-          expect(deliveredSpan).toHaveAttribute('bugsnag.browser.page.referrer', 'https://referrer.com')
           expect(deliveredSpan).toHaveAttribute('http.method', 'GET')
           expect(deliveredSpan).toHaveAttribute('http.url', 'https://example.com')
           expect(deliveredSpan).toHaveAttribute('http.status_code', 200)

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -1,10 +1,10 @@
-import type { SpanInternal, InternalConfiguration, Logger, Plugin, SpanFactory, SpanContextStorage } from '@bugsnag/core-performance'
+import type { InternalConfiguration, Logger, Plugin, SpanContextStorage, SpanFactory, SpanInternal } from '@bugsnag/core-performance'
 import {
   defaultNetworkRequestCallback,
-  type RequestStartCallback,
   type NetworkRequestCallback,
   type NetworkRequestInfo,
   type RequestEndContext,
+  type RequestStartCallback,
   type RequestStartContext,
   type RequestTracker
 } from '@bugsnag/request-tracker-performance'
@@ -84,18 +84,16 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
       return
     }
 
-    const span = this.spanFactory.startSpan(
-      `[HTTP]/${startContext.method.toUpperCase()}`,
-      { startTime: startContext.startTime, makeCurrentContext: false }
-    )
-
-    span.setAttribute('bugsnag.span.category', 'network')
-    span.setAttribute('http.method', startContext.method)
-    span.setAttribute('http.url', networkRequestInfo.url)
+    const span = this.spanFactory.startNetworkSpan({
+      method: startContext.method,
+      startTime: startContext.startTime,
+      url: networkRequestInfo.url
+    })
 
     return {
       onRequestEnd: (endContext: RequestEndContext) => {
         if (endContext.state === 'success') {
+          // TODO: set http.status_code as part of ending a network span
           span.setAttribute('http.status_code', endContext.status)
           this.spanFactory.endSpan(span, endContext.endTime)
         }

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -93,9 +93,7 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
     return {
       onRequestEnd: (endContext: RequestEndContext) => {
         if (endContext.state === 'success') {
-          // TODO: set http.status_code as part of ending a network span
-          span.setAttribute('http.status_code', endContext.status)
-          this.spanFactory.endSpan(span, endContext.endTime)
+          this.spanFactory.endSpan(span, endContext.endTime, { 'http.status_code': endContext.status })
         }
       },
       // propagate trace context using network span

--- a/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -41,11 +41,11 @@ describe('network span plugin', () => {
     }))
 
     const res = fetchTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
 
     const res2 = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
   })
 
@@ -58,16 +58,16 @@ describe('network span plugin', () => {
     }))
 
     const res1 = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res1.extraRequestHeaders).toEqual([])
 
     const res2 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
 
     // traceparent headers are not added to same-origin requests by default
     const res3 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: SAME_ORIGIN_TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res3.extraRequestHeaders).toEqual([])
   })
 
@@ -80,7 +80,7 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
@@ -88,7 +88,7 @@ describe('network span plugin', () => {
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')
@@ -175,7 +175,7 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ endTime: 2, state: 'error' })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -190,7 +190,7 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ state: 'error', error: new Error('woopsy'), endTime: 2 })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -222,7 +222,7 @@ describe('network span plugin', () => {
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
 
     fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
   })
 
   it('prevents creating a span when networkRequestCallback returns { url: null }', () => {
@@ -256,7 +256,7 @@ describe('network span plugin', () => {
     }))
 
     const res = fetchTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 
@@ -270,7 +270,7 @@ describe('network span plugin', () => {
 
     // by default when the origin is different trace propagation headers are not added, unless the networkRequestCallback returns { propagateTraceContext: true }
     const res = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([
       { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
     ])
@@ -288,14 +288,14 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
     expect(spanFactory.endSpan).toHaveBeenCalled()
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')

--- a/packages/platforms/react-native/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/react-native/lib/auto-instrumentation/network-request-plugin.ts
@@ -96,9 +96,7 @@ export class NetworkRequestPlugin implements Plugin<ReactNativeConfiguration> {
     return {
       onRequestEnd: (endContext: RequestEndContext) => {
         if (endContext.state === 'success') {
-          // TODO: set http.status_code as part of ending a network span
-          span.setAttribute('http.status_code', endContext.status)
-          this.spanFactory.endSpan(span, endContext.endTime)
+          this.spanFactory.endSpan(span, endContext.endTime, { 'http.status_code': endContext.status })
         }
       },
       // propagate trace context using network span

--- a/packages/platforms/react-native/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/react-native/lib/auto-instrumentation/network-request-plugin.ts
@@ -8,10 +8,10 @@ import {
 } from '@bugsnag/core-performance'
 import {
   defaultNetworkRequestCallback,
-  type RequestStartCallback,
   type NetworkRequestCallback,
   type NetworkRequestInfo,
   type RequestEndContext,
+  type RequestStartCallback,
   type RequestStartContext,
   type RequestTracker
 } from '@bugsnag/request-tracker-performance'
@@ -87,18 +87,16 @@ export class NetworkRequestPlugin implements Plugin<ReactNativeConfiguration> {
       return
     }
 
-    const span = this.spanFactory.startSpan(
-      `[HTTP]/${startContext.method.toUpperCase()}`,
-      { startTime: startContext.startTime, makeCurrentContext: false }
-    )
-
-    span.setAttribute('bugsnag.span.category', 'network')
-    span.setAttribute('http.method', startContext.method)
-    span.setAttribute('http.url', networkRequestInfo.url)
+    const span = this.spanFactory.startNetworkSpan({
+      method: startContext.method,
+      startTime: startContext.startTime,
+      url: networkRequestInfo.url
+    })
 
     return {
       onRequestEnd: (endContext: RequestEndContext) => {
         if (endContext.state === 'success') {
+          // TODO: set http.status_code as part of ending a network span
           span.setAttribute('http.status_code', endContext.status)
           this.spanFactory.endSpan(span, endContext.endTime)
         }

--- a/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -49,12 +49,12 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
 
     // currently traceparent headers are not added to any requests by default
     const res2 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: SAME_ORIGIN_TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
   })
 
@@ -64,7 +64,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
@@ -72,7 +72,7 @@ describe('network span plugin', () => {
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')
@@ -153,7 +153,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ endTime: 2, state: 'error' })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -165,7 +165,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ state: 'error', error: new Error('woopsy'), endTime: 2 })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -192,7 +192,7 @@ describe('network span plugin', () => {
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
   })
 
   it('uses a modified url from networkRequestCallback', () => {
@@ -205,14 +205,14 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
     expect(spanFactory.endSpan).toHaveBeenCalled()
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')
@@ -228,7 +228,7 @@ describe('network span plugin', () => {
     }))
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([
       { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
     ])
@@ -243,7 +243,7 @@ describe('network span plugin', () => {
     }))
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([
       { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
     ])
@@ -254,7 +254,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 
@@ -268,7 +268,7 @@ describe('network span plugin', () => {
     }))
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 })

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -1,6 +1,7 @@
 import {
   DefaultSpanContextStorage,
   Sampler,
+  type SpanAttribute,
   SpanFactory,
   type Configuration,
   type SpanEnded,
@@ -45,8 +46,8 @@ class MockSpanFactory <C extends Configuration> extends SpanFactory<C> {
     return super.startSpan(name, options)
   })
 
-  endSpan = jest.fn((span: SpanInternal, endTime: number) => {
-    super.endSpan(span, endTime)
+  endSpan = jest.fn((span: SpanInternal, endTime: number, additionalAttributes?: Record<string, SpanAttribute>) => {
+    super.endSpan(span, endTime, additionalAttributes)
   })
 }
 

--- a/test/browser/features/fixtures/packages/manual-span/index.html
+++ b/test/browser/features/fixtures/packages/manual-span/index.html
@@ -4,9 +4,11 @@
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
         <script src="./dist/bundle.js" type="module"></script>
+        <title>Manual spans</title>
     </head>
     <body>
         <h1>manual-span</h1>
         <button id="send-span">send-span</button>
+        <button id="send-network-span">send-network-span</button>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/manual-span/src/index.js
+++ b/test/browser/features/fixtures/packages/manual-span/src/index.js
@@ -3,8 +3,9 @@ import BugsnagPerformance from '@bugsnag/browser-performance'
 const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
+const reflectEndpoint = '/reflect?status=200&delay_ms=0'
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false, autoInstrumentRouteChanges: false })
 
 document.getElementById('send-span').onclick = () => {
   const spanOptions = {}
@@ -16,3 +17,10 @@ document.getElementById('send-span').onclick = () => {
   const span = BugsnagPerformance.startSpan("Custom/ManualSpanScenario", spanOptions)
   span.end()
 }
+
+document.getElementById('send-network-span').addEventListener('click', () => {
+  const span = BugsnagPerformance.startNetworkSpan({ method: "GET", url: reflectEndpoint })
+  fetch(reflectEndpoint).then(({ status }) => {
+    span.end({ status })
+  })
+})

--- a/test/browser/features/network-spans.feature
+++ b/test/browser/features/network-spans.feature
@@ -1,5 +1,18 @@
 Feature: Network spans
 
+    Scenario: Manual network spans
+        Given I navigate to the test URL "/manual-span"
+        When I click the element "send-network-span"
+        And I wait to receive 1 trace
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.title" equals "Manual spans"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.url" equals the stored value "bugsnag.browser.page.url"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "/reflect?status=200&delay_ms=0"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
+
     Scenario: Network spans are automatically instrumented for completed XHR requests
         Given I navigate to the test URL "/network-spans"
         When I click the element "xhr-success"

--- a/test/browser/features/network-spans.feature
+++ b/test/browser/features/network-spans.feature
@@ -5,7 +5,7 @@ Feature: Network spans
         When I click the element "xhr-success"
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.title" equals "Network spans"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.url" equals the stored value "bugsnag.browser.page.url"
@@ -18,7 +18,7 @@ Feature: Network spans
         When I click the element "fetch-success"
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.title" equals "Network spans"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.url" equals the stored value "bugsnag.browser.page.url"
@@ -36,7 +36,7 @@ Feature: Network spans
         When I click the element "fetch-modified-url"
         And I wait to receive 1 trace
         
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
@@ -46,7 +46,7 @@ Feature: Network spans
         When I click the element "xhr-modified-url"
         And I wait to receive 1 trace
         
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200

--- a/test/browser/features/traceparent.feature
+++ b/test/browser/features/traceparent.feature
@@ -11,7 +11,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (simple headers in fetch options)
         Given I navigate to the test URL "/traceparent"
@@ -24,7 +24,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (Headers class in fetch options)   
         Given I navigate to the test URL "/traceparent"
@@ -37,7 +37,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (simple headers in Request object)   
         Given I navigate to the test URL "/traceparent"
@@ -50,7 +50,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (Headers class in Request object)
         Given I navigate to the test URL "/traceparent"
@@ -63,7 +63,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (headers in both request and options)
         Given I navigate to the test URL "/traceparent"
@@ -76,4 +76,4 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
         
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"

--- a/test/react-native/features/network-spans.feature
+++ b/test/react-native/features/network-spans.feature
@@ -5,13 +5,13 @@ Feature: Network spans
         And I wait to receive a sampling request
         And I wait for 2 spans
 
-        Then a span named "[HTTP]/GET" contains the attributes:
+        Then a span named "[HTTP/GET]" contains the attributes:
             | attribute             | type        | value                             |
             | bugsnag.span.category | stringValue | network                           |
             | http.method           | stringValue | GET                               |
             | http.url              | stringValue | https://bugsnag.com?fetch=true    |
             | http.status_code      | intValue    | 200                               |
-        And a span named "[HTTP]/GET" contains the attributes:
+        And a span named "[HTTP/GET]" contains the attributes:
             | attribute             | type        | value                           |
             | bugsnag.span.category | stringValue | network                         |
             | http.method           | stringValue | GET                             |
@@ -28,7 +28,7 @@ Feature: Network spans
         And I wait to receive a sampling request
         And I wait to receive 1 span
 
-        Then a span named "[HTTP]/GET" contains the attributes:
+        Then a span named "[HTTP/GET]" contains the attributes:
             | attribute             | type        | value                                                       |
             | bugsnag.span.category | stringValue | network                                                     |
             | http.method           | stringValue | GET                                                         |


### PR DESCRIPTION
## Goal

add a new `startNetworkSpan` method to the core client
update network span naming convention to `[HTTP/VERB]`

## Testing

Add unit test for `startNetworkSpan` and attributes