### PR TITLE
Release v2.5.0

### DIFF
--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -10,6 +10,7 @@ steps:
         agents:
           queue: macos-12-arm
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           BUILD_ANDROID: "true"
         artifact_paths:
@@ -30,6 +31,7 @@ steps:
         agents:
           queue: macos-12-arm
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "true"
           BUILD_ANDROID: "true"
@@ -51,6 +53,7 @@ steps:
         agents:
           queue: "macos-12-arm"
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           BUILD_IOS: "true"
           DEVELOPER_DIR: "/Applications/Xcode14.app"
@@ -73,6 +76,7 @@ steps:
         agents:
           queue: "macos-12-arm"
         env:
+          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_IOS: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v2.5.0] (2024-05-02)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@
 
 - (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
 
+
+### Fixed
+
+- (core) Fix import of `@bugsnag/cuid` not working in node ESM environment [#445](https://github.com/bugsnag/bugsnag-js-performance/pull/445)
+
 ## v2.4.1 (2024-04-18)
 
 ### Fixed
 
-- (core) Delay span batching while inital sampling request is in flight [#433](https://github.com/bugsnag/bugsnag-js-performance/pull/433)
+- (core) Delay span batching while initial sampling request is in flight [#433](https://github.com/bugsnag/bugsnag-js-performance/pull/433)
 - (core) Refactor span batching to ensure correct sampling values for subsequent spans [#435](https://github.com/bugsnag/bugsnag-js-performance/pull/435)
 - (request-tracker) Ensure existing headers are preserved for fetch requests [#436](https://github.com/bugsnag/bugsnag-js-performance/pull/436)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## TBD
+## [Unreleased]
 
 ### Added
 
 - (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
-
+- Add new `startNetworkSpan` method to `BugsnagPerformance` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)
+- Change network span naming convention to `[HTTP/VERB]` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Added
+
+- (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
+
 ## v2.4.1 (2024-04-18)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -3449,9 +3449,9 @@
       "link": true
     },
     "node_modules/@bugsnag/cuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.1.0.tgz",
-      "integrity": "sha512-U6vPVhFPLWLXQIGnmk/uPbyidB5xLVFfEdZDmmLbv41Be67re4mNsjMukHdUv669RXOWTDQNJ+bMODhuWpshkw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.1.1.tgz",
+      "integrity": "sha512-d2z4b0rEo3chI07FNN1Xds8v25CNeekecU6FC/2Fs9MxY2EipkZTThVcV2YinMn8dvRUlViKOyC50evoUxg8tw=="
     },
     "node_modules/@bugsnag/delivery-fetch-performance": {
       "resolved": "packages/delivery-fetch",
@@ -24680,7 +24680,7 @@
       "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/cuid": "^3.1.0"
+        "@bugsnag/cuid": "^3.1.1"
       }
     },
     "packages/delivery-fetch": {
@@ -24697,7 +24697,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/core-performance": "^2.4.1",
-        "@bugsnag/cuid": "^3.1.0",
+        "@bugsnag/cuid": "^3.1.1",
         "@bugsnag/delivery-fetch-performance": "^2.4.1",
         "@bugsnag/request-tracker-performance": "^2.4.1"
       }
@@ -24708,7 +24708,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/core-performance": "^2.4.1",
-        "@bugsnag/cuid": "^3.1.0",
+        "@bugsnag/cuid": "^3.1.1",
         "@bugsnag/delivery-fetch-performance": "^2.4.1",
         "@bugsnag/request-tracker-performance": "^2.4.1"
       },

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -4,8 +4,9 @@ import { type BackgroundingListener } from './backgrounding-listener'
 import { BatchProcessor } from './batch-processor'
 import { type Clock } from './clock'
 import { validateConfig, type Configuration, type CoreSchema } from './config'
-import { type DeliveryFactory, TracePayloadEncoder } from './delivery'
+import { TracePayloadEncoder, type DeliveryFactory } from './delivery'
 import { type IdGenerator } from './id-generator'
+import { type NetworkSpan, type NetworkSpanEndOptions, type NetworkSpanOptions } from './network-span'
 import { type Persistence } from './persistence'
 import { type Plugin } from './plugin'
 import ProbabilityFetcher from './probability-fetcher'
@@ -16,12 +17,14 @@ import Sampler from './sampler'
 import { type Span, type SpanOptions } from './span'
 import { DefaultSpanContextStorage, type SpanContext, type SpanContextStorage } from './span-context'
 import { SpanFactory } from './span-factory'
+import { timeToNumber } from './time'
 
 interface Constructor<T> { new(): T, prototype: T }
 
 export interface Client<C extends Configuration> {
   start: (config: C | string) => void
   startSpan: (name: string, options?: SpanOptions) => Span
+  startNetworkSpan: (options: NetworkSpanOptions) => NetworkSpan
   readonly currentSpanContext: SpanContext | undefined
   getPlugin: <T extends Plugin<C>> (Constructor: Constructor<T>) => T | undefined
 }
@@ -113,6 +116,25 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
       const span = spanFactory.startSpan(cleanOptions.name, cleanOptions.options)
       span.setAttribute('bugsnag.span.category', 'custom')
       return spanFactory.toPublicApi(span)
+    },
+    startNetworkSpan: (networkSpanOptions: NetworkSpanOptions) => {
+      const spanInternal = spanFactory.startNetworkSpan(networkSpanOptions)
+      const span = spanFactory.toPublicApi(spanInternal)
+
+      // Overwrite end method to set status code attribute
+      // once we release the setAttribute API we can simply return the span
+      const networkSpan: NetworkSpan = {
+        ...span,
+        end: (endOptions: NetworkSpanEndOptions) => {
+          spanFactory.endSpan(
+            spanInternal,
+            timeToNumber(options.clock, endOptions.endTime),
+            { 'http.status_code': endOptions.status }
+          )
+        }
+      }
+
+      return networkSpan
     },
     getPlugin: (Constructor) => {
       for (const plugin of plugins) {

--- a/packages/core/lib/network-span.ts
+++ b/packages/core/lib/network-span.ts
@@ -1,0 +1,37 @@
+import { coreSpanOptionSchema, type SpanOptionSchema, type SpanOptions } from './span'
+import { type SpanContext } from './span-context'
+import { type Time } from './time'
+import { isStringWithLength } from './validation'
+
+export interface NetworkSpanOptions extends Omit<SpanOptions, 'makeCurrentContext'> {
+  method: string
+  url: string
+}
+
+export interface NetworkSpanEndOptions {
+  status: number
+  endTime?: Time
+}
+
+export interface NetworkSpan extends SpanContext {
+  end: (endOptions: NetworkSpanEndOptions) => void
+}
+
+// Clone core schema and remove makeCurrentContext
+// which should always be false for network spans
+const baseSchema = { ...coreSpanOptionSchema }
+delete baseSchema.makeCurrentContext
+
+export const networkSpanOptionsSchema: SpanOptionSchema = {
+  ...baseSchema,
+  method: {
+    message: 'should be a string',
+    getDefaultValue: () => undefined,
+    validate: isStringWithLength
+  },
+  url: {
+    message: 'should be a string',
+    getDefaultValue: () => undefined,
+    validate: isStringWithLength
+  }
+}

--- a/packages/core/lib/persistence.ts
+++ b/packages/core/lib/persistence.ts
@@ -1,5 +1,7 @@
-import { isCuid } from '@bugsnag/cuid'
+import cuid from '@bugsnag/cuid'
 import { isPersistedProbability } from './validation'
+
+const { isCuid } = cuid
 
 export interface PersistedProbability {
   value: number

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -1,11 +1,12 @@
-import { SpanAttributes, type SpanAttributesSource } from './attributes'
+import { type SpanAttribute, SpanAttributes, type SpanAttributesSource } from './attributes'
 import { type BackgroundingListener, type BackgroundingListenerState } from './backgrounding-listener'
 import { type Clock } from './clock'
 import { type Configuration, type Logger } from './config'
 import { type IdGenerator } from './id-generator'
+import { type NetworkSpanOptions } from './network-span'
 import { type Processor } from './processor'
 import { type ReadonlySampler } from './sampler'
-import { SpanInternal, type Span, type SpanOptions, type SpanOptionSchema, type InternalSpanOptions, coreSpanOptionSchema } from './span'
+import { SpanInternal, coreSpanOptionSchema, type InternalSpanOptions, type Span, type SpanOptionSchema, type SpanOptions } from './span'
 import { type SpanContextStorage } from './span-context'
 import { timeToNumber } from './time'
 import { isObject, isSpanContext } from './validation'
@@ -87,6 +88,18 @@ export class SpanFactory <C extends Configuration> {
     return span
   }
 
+  startNetworkSpan (options: NetworkSpanOptions) {
+    const spanName = `[HTTP/${options.method.toUpperCase()}]`
+    const cleanOptions = this.validateSpanOptions<NetworkSpanOptions>(spanName, options)
+    const spanInternal = this.startSpan(cleanOptions.name, { ...cleanOptions.options, makeCurrentContext: false })
+
+    spanInternal.setAttribute('bugsnag.span.category', 'network')
+    spanInternal.setAttribute('http.method', options.method)
+    spanInternal.setAttribute('http.url', options.url)
+
+    return spanInternal
+  }
+
   configure (processor: Processor, logger: Logger) {
     this.processor = processor
     this.logger = logger
@@ -94,7 +107,8 @@ export class SpanFactory <C extends Configuration> {
 
   endSpan (
     span: SpanInternal,
-    endTime: number
+    endTime: number,
+    additionalAttributes?: Record<string, SpanAttribute>
   ) {
     // if the span doesn't exist here it shouldn't be processed
     if (!this.openSpans.delete(span)) {
@@ -109,6 +123,11 @@ export class SpanFactory <C extends Configuration> {
 
     // Discard marked spans
     if (endTime === DISCARD_END_TIME) return
+
+    // Set any additional attributes
+    for (const [key, value] of Object.entries(additionalAttributes || {})) {
+      span.setAttribute(key, value)
+    }
 
     this.spanAttributesSource.requestAttributes(span)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,6 @@
     "dist"
   ],
   "dependencies": {
-    "@bugsnag/cuid": "^3.1.0"
+    "@bugsnag/cuid": "^3.1.1"
   }
 }

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -2,6 +2,7 @@ import fs from 'fs'
 import createRollupConfig from '../../.rollup/index.mjs'
 
 export default createRollupConfig({
+  external: ['@bugsnag/cuid'],
   additionalReplacements: {
     __ENABLE_BUGSNAG_TEST_CONFIGURATION__: !!process.env.ENABLE_TEST_CONFIGURATION
   }

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -1,10 +1,10 @@
-import type { SpanInternal, InternalConfiguration, Logger, Plugin, SpanFactory, SpanContextStorage } from '@bugsnag/core-performance'
+import type { InternalConfiguration, Logger, Plugin, SpanContextStorage, SpanFactory, SpanInternal } from '@bugsnag/core-performance'
 import {
   defaultNetworkRequestCallback,
-  type RequestStartCallback,
   type NetworkRequestCallback,
   type NetworkRequestInfo,
   type RequestEndContext,
+  type RequestStartCallback,
   type RequestStartContext,
   type RequestTracker
 } from '@bugsnag/request-tracker-performance'
@@ -84,20 +84,16 @@ export class NetworkRequestPlugin implements Plugin<BrowserConfiguration> {
       return
     }
 
-    const span = this.spanFactory.startSpan(
-      `[HTTP]/${startContext.method.toUpperCase()}`,
-      { startTime: startContext.startTime, makeCurrentContext: false }
-    )
-
-    span.setAttribute('bugsnag.span.category', 'network')
-    span.setAttribute('http.method', startContext.method)
-    span.setAttribute('http.url', networkRequestInfo.url)
+    const span = this.spanFactory.startNetworkSpan({
+      method: startContext.method,
+      startTime: startContext.startTime,
+      url: networkRequestInfo.url
+    })
 
     return {
       onRequestEnd: (endContext: RequestEndContext) => {
         if (endContext.state === 'success') {
-          span.setAttribute('http.status_code', endContext.status)
-          this.spanFactory.endSpan(span, endContext.endTime)
+          this.spanFactory.endSpan(span, endContext.endTime, { 'http.status_code': endContext.status })
         }
       },
       // propagate trace context using network span

--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -12,6 +12,11 @@ import { type BrowserConfiguration } from '../config'
 
 export interface BrowserNetworkRequestInfo extends NetworkRequestInfo {
   readonly type: PerformanceResourceTiming['initiatorType']
+
+  /**
+   * Experimental. Whether to propagate trace context by adding a `traceparent` header to the request.
+   */
+  propagateTraceContext?: boolean
 }
 
 const permittedPrefixes = ['http://', 'https://', '/', './', '../']

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@bugsnag/core-performance": "^2.4.1",
-    "@bugsnag/cuid": "^3.1.0",
+    "@bugsnag/cuid": "^3.1.1",
     "@bugsnag/delivery-fetch-performance": "^2.4.1",
     "@bugsnag/request-tracker-performance": "^2.4.1"
   },

--- a/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -41,11 +41,11 @@ describe('network span plugin', () => {
     }))
 
     const res = fetchTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
 
     const res2 = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
   })
 
@@ -58,16 +58,16 @@ describe('network span plugin', () => {
     }))
 
     const res1 = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res1.extraRequestHeaders).toEqual([])
 
     const res2 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
 
     // traceparent headers are not added to same-origin requests by default
     const res3 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: SAME_ORIGIN_TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res3.extraRequestHeaders).toEqual([])
   })
 
@@ -80,7 +80,7 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
@@ -88,7 +88,7 @@ describe('network span plugin', () => {
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')
@@ -175,7 +175,7 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ endTime: 2, state: 'error' })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -190,7 +190,7 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ state: 'error', error: new Error('woopsy'), endTime: 2 })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -222,7 +222,7 @@ describe('network span plugin', () => {
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
 
     fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
   })
 
   it('prevents creating a span when networkRequestCallback returns { url: null }', () => {
@@ -256,7 +256,7 @@ describe('network span plugin', () => {
     }))
 
     const res = fetchTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 
@@ -270,7 +270,7 @@ describe('network span plugin', () => {
 
     // by default when the origin is different trace propagation headers are not added, unless the networkRequestCallback returns { propagateTraceContext: true }
     const res = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([
       { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
     ])
@@ -288,14 +288,14 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = fetchTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
     expect(spanFactory.endSpan).toHaveBeenCalled()
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')

--- a/packages/platforms/browser/tests/browser.test.ts
+++ b/packages/platforms/browser/tests/browser.test.ts
@@ -90,8 +90,6 @@ describe('Browser client integration tests', () => {
       const fullBatch = JSON.parse(mockFetch.mock.calls[1][1].body)
       expect(fullBatch.resourceSpans[0].scopeSpans[0].spans).toHaveLength(100)
 
-      console.log(mockFetch.mock.calls[1][1].headers)
-
       // Header should be updated
       expect(mockFetch).toHaveBeenLastCalledWith('/test', expect.objectContaining({
         headers: expect.objectContaining({

--- a/packages/platforms/react-native/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/react-native/lib/auto-instrumentation/network-request-plugin.ts
@@ -8,10 +8,10 @@ import {
 } from '@bugsnag/core-performance'
 import {
   defaultNetworkRequestCallback,
-  type RequestStartCallback,
   type NetworkRequestCallback,
   type NetworkRequestInfo,
   type RequestEndContext,
+  type RequestStartCallback,
   type RequestStartContext,
   type RequestTracker
 } from '@bugsnag/request-tracker-performance'
@@ -87,20 +87,16 @@ export class NetworkRequestPlugin implements Plugin<ReactNativeConfiguration> {
       return
     }
 
-    const span = this.spanFactory.startSpan(
-      `[HTTP]/${startContext.method.toUpperCase()}`,
-      { startTime: startContext.startTime, makeCurrentContext: false }
-    )
-
-    span.setAttribute('bugsnag.span.category', 'network')
-    span.setAttribute('http.method', startContext.method)
-    span.setAttribute('http.url', networkRequestInfo.url)
+    const span = this.spanFactory.startNetworkSpan({
+      method: startContext.method,
+      startTime: startContext.startTime,
+      url: networkRequestInfo.url
+    })
 
     return {
       onRequestEnd: (endContext: RequestEndContext) => {
         if (endContext.state === 'success') {
-          span.setAttribute('http.status_code', endContext.status)
-          this.spanFactory.endSpan(span, endContext.endTime)
+          this.spanFactory.endSpan(span, endContext.endTime, { 'http.status_code': endContext.status })
         }
       },
       // propagate trace context using network span

--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -37,7 +37,7 @@ const BugsnagPerformance = createClient({
   persistence,
   plugins: (spanFactory, spanContextStorage) => [
     new AppStartPlugin(appStartTime, spanFactory, clock, AppRegistry),
-    new NetworkRequestPlugin(spanFactory, xhrRequestTracker)
+    new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrRequestTracker)
   ],
   resourceAttributesSource,
   schema: createSchema(),

--- a/packages/platforms/react-native/lib/config.ts
+++ b/packages/platforms/react-native/lib/config.ts
@@ -1,5 +1,6 @@
 import {
   isBoolean,
+  isStringOrRegExpArray,
   isStringWithLength,
   schema,
   type ConfigOption,
@@ -18,6 +19,7 @@ export interface ReactNativeSchema extends CoreSchema {
   wrapperComponentProvider: ConfigOption<WrapperComponentProvider | null>
   autoInstrumentNetworkRequests: ConfigOption<boolean>
   networkRequestCallback: ConfigOption<NetworkRequestCallback<ReactNativeNetworkRequestInfo>>
+  tracePropagationUrls: ConfigOption<Array<string | RegExp>>
 }
 
 export interface ReactNativeConfiguration extends Configuration {
@@ -27,6 +29,7 @@ export interface ReactNativeConfiguration extends Configuration {
   generateAnonymousId?: boolean
   networkRequestCallback?: NetworkRequestCallback<ReactNativeNetworkRequestInfo>
   wrapperComponentProvider?: WrapperComponentProvider | null
+  tracePropagationUrls?: Array<string | RegExp>
 }
 
 function createSchema (): ReactNativeSchema {
@@ -61,6 +64,11 @@ function createSchema (): ReactNativeSchema {
       defaultValue: defaultNetworkRequestCallback,
       message: 'should be a function',
       validate: isNetworkRequestCallback
+    },
+    tracePropagationUrls: {
+      defaultValue: [],
+      message: 'should be an array of string|RegExp',
+      validate: isStringOrRegExpArray
     }
   }
 }

--- a/packages/platforms/react-native/lib/persistence/file-based.ts
+++ b/packages/platforms/react-native/lib/persistence/file-based.ts
@@ -7,7 +7,9 @@ import {
 } from '@bugsnag/core-performance'
 import { type ReadWriteFile, type ReadableFile } from './file'
 import { Platform } from 'react-native'
-import { isCuid } from '@bugsnag/cuid'
+import cuid from '@bugsnag/cuid'
+
+const { isCuid } = cuid
 
 // this is intentionally very loose as the persisted file could contain anything
 type PersistedData = Record<string, unknown>

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bugsnag/core-performance": "^2.4.1",
-    "@bugsnag/cuid": "^3.1.0",
+    "@bugsnag/cuid": "^3.1.1",
     "@bugsnag/delivery-fetch-performance": "^2.4.1",
     "@bugsnag/request-tracker-performance": "^2.4.1"
   },

--- a/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -49,12 +49,12 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
 
     // currently traceparent headers are not added to any requests by default
     const res2 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: SAME_ORIGIN_TEST_URL, startTime: 2 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/POST]', { startTime: 2, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
   })
 
@@ -64,7 +64,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
@@ -72,7 +72,7 @@ describe('network span plugin', () => {
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')
@@ -153,7 +153,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ endTime: 2, state: 'error' })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -165,7 +165,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ state: 'error', error: new Error('woopsy'), endTime: 2 })
     expect(spanFactory.endSpan).not.toHaveBeenCalled()
@@ -192,7 +192,7 @@ describe('network span plugin', () => {
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
   })
 
   it('uses a modified url from networkRequestCallback', () => {
@@ -205,14 +205,14 @@ describe('network span plugin', () => {
     }))
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
 
     endRequest({ status: 200, endTime: 2, state: 'success' })
     expect(spanFactory.endSpan).toHaveBeenCalled()
     expect(spanFactory.createdSpans.length).toEqual(1)
 
     const span = spanFactory.createdSpans[0]
-    expect(span.name).toEqual('[HTTP]/GET')
+    expect(span.name).toEqual('[HTTP/GET]')
     expect(span.startTime).toEqual(1)
     expect(span.endTime).toEqual(2)
     expect(span).toHaveAttribute('bugsnag.span.category', 'network')
@@ -228,7 +228,7 @@ describe('network span plugin', () => {
     }))
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([
       { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
     ])
@@ -243,7 +243,7 @@ describe('network span plugin', () => {
     }))
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([
       { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
     ])
@@ -254,7 +254,7 @@ describe('network span plugin', () => {
     plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 
@@ -268,7 +268,7 @@ describe('network span plugin', () => {
     }))
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP/GET]', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 })

--- a/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/react-native/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -14,6 +14,15 @@ class MockRequestTracker extends RequestTracker {
   })
 }
 
+const createConfig = (overrides: Partial<ReactNativeConfiguration> = {}) => {
+  return createConfiguration<ReactNativeConfiguration>({
+    endpoint: ENDPOINT,
+    autoInstrumentNetworkRequests: true,
+    tracePropagationUrls: [],
+    ...overrides
+  })
+}
+
 describe('network span plugin', () => {
   let xhrTracker: MockRequestTracker
   let spanFactory: MockSpanFactory<ReactNativeConfiguration>
@@ -29,10 +38,7 @@ describe('network span plugin', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
     expect(xhrTracker.onStart).not.toHaveBeenCalled()
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     expect(xhrTracker.onStart).toHaveBeenCalled()
   })
@@ -40,16 +46,13 @@ describe('network span plugin', () => {
   it('starts a span on request start', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: TEST_URL, startTime: 2 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
 
-    // traceparent headers are not added to same-origin requests by default
+    // currently traceparent headers are not added to any requests by default
     const res2 = xhrTracker.start({ type: 'xmlhttprequest', method: 'POST', url: SAME_ORIGIN_TEST_URL, startTime: 2 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/POST', { startTime: 2, makeCurrentContext: false })
     expect(res2.extraRequestHeaders).toEqual([])
@@ -58,10 +61,7 @@ describe('network span plugin', () => {
   it('ends a span on request end', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
@@ -84,10 +84,7 @@ describe('network span plugin', () => {
   it('does not track requests when autoInstrumentNetworkRequests = false', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: false
-    }))
+    plugin.configure(createConfig({ autoInstrumentNetworkRequests: false }))
 
     expect(xhrTracker.onStart).not.toHaveBeenCalled()
   })
@@ -95,10 +92,7 @@ describe('network span plugin', () => {
   it('does not track requests to the configured traces endpoint', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: `${ENDPOINT}`, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
@@ -108,10 +102,7 @@ describe('network span plugin', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
     const NET_INFO_REACHABILITY_URL = 'https://clients3.google.com/generate_204?_=1701691583660'
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: NET_INFO_REACHABILITY_URL, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
@@ -129,10 +120,7 @@ describe('network span plugin', () => {
   it.each(expectedProtocols)('tracks requests over all expected protocols', (url) => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalled()
@@ -153,10 +141,7 @@ describe('network span plugin', () => {
   it.each(unexpectedProtocols)('does not track requests over unexpected protocols', (url) => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url, startTime: 1 })
     expect(spanFactory.startSpan).not.toHaveBeenCalled()
@@ -165,10 +150,7 @@ describe('network span plugin', () => {
   it('discards the span if the status is 0', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
@@ -180,10 +162,7 @@ describe('network span plugin', () => {
   it('discards the span if there is an error', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
 
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true
-    }))
+    plugin.configure(createConfig())
 
     const { onRequestEnd: endRequest } = xhrTracker.start({ type: 'xmlhttprequest', method: 'GET', url: TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
@@ -205,9 +184,7 @@ describe('network span plugin', () => {
 
   it('prevents creating a span when networkRequestCallback returns null', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
+    plugin.configure(createConfig({
       networkRequestCallback: (networkRequestInfo) => networkRequestInfo.url === 'no-delivery' ? null : networkRequestInfo
     }))
 
@@ -220,9 +197,7 @@ describe('network span plugin', () => {
 
   it('uses a modified url from networkRequestCallback', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
+    plugin.configure(createConfig({
       networkRequestCallback: (networkRequestInfo) => ({
         type: networkRequestInfo.type,
         url: 'modified-url'
@@ -246,32 +221,54 @@ describe('network span plugin', () => {
     expect(span).toHaveAttribute('http.status_code', 200)
   })
 
-  it('prevents adding trace propagation headers when networkRequestCallback returns { propagateTraceContext: false }', () => {
+  it('adds trace propagation headers when url matches tracePropagationUrls (string)', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
-      networkRequestCallback: (networkRequestInfo) => ({ ...networkRequestInfo, propagateTraceContext: false })
+    plugin.configure(createConfig({
+      tracePropagationUrls: [TEST_URL]
     }))
+
+    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(res.extraRequestHeaders).toEqual([
+      { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
+    ])
+  })
+
+  it('adds trace propagation headers when url matches tracePropagationUrls (RegExp)', () => {
+    const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
+    plugin.configure(createConfig({
+      tracePropagationUrls: [
+        /^(http(s)?(:\/\/))?(www\.)?test-url\.com(\/.*)?$/
+      ]
+    }))
+
+    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
+    expect(res.extraRequestHeaders).toEqual([
+      { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
+    ])
+  })
+
+  it('does not add trace propagation headers when tracePropagationUrls is empty', () => {
+    const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
+    plugin.configure(createConfig())
 
     const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
     expect(res.extraRequestHeaders).toEqual([])
   })
 
-  it('adds trace propagation headers when networkRequestCallback returns { propagateTraceContext: true }', () => {
+  it('does not add trace propagation headers when url does not match tracePropagationUrls', () => {
     const plugin = new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrTracker)
-    plugin.configure(createConfiguration<ReactNativeConfiguration>({
-      endpoint: ENDPOINT,
-      autoInstrumentNetworkRequests: true,
-      networkRequestCallback: (networkRequestInfo) => ({ ...networkRequestInfo, propagateTraceContext: true })
+    plugin.configure(createConfig({
+      tracePropagationUrls: [
+        'http://noheader.com/',
+        /^(http(s)?(:\/\/))?(www\.)?noheader\.com(\/.*)?$/
+      ]
     }))
 
-    // by default when the origin is different trace propagation headers are not added, unless the networkRequestCallback returns { propagateTraceContext: true }
-    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: TEST_URL, startTime: 1 })
+    const res = xhrTracker.start({ type: 'fetch', method: 'GET', url: SAME_ORIGIN_TEST_URL, startTime: 1 })
     expect(spanFactory.startSpan).toHaveBeenCalledWith('[HTTP]/GET', { startTime: 1, makeCurrentContext: false })
-    expect(res.extraRequestHeaders).toEqual([
-      { traceparent: '00-a random 128 bit string-a random 64 bit string-01' }
-    ])
+    expect(res.extraRequestHeaders).toEqual([])
   })
 })

--- a/packages/platforms/react-native/tests/config.test.ts
+++ b/packages/platforms/react-native/tests/config.test.ts
@@ -104,4 +104,39 @@ describe('ReactNativeSchema', () => {
       })
     })
   })
+
+  describe('tracePropagationUrls', () => {
+    it('defaults to an empty array', () => {
+      const schema = createSchema()
+
+      expect(schema.tracePropagationUrls.defaultValue).toStrictEqual([])
+    })
+
+    it.each([
+      [false, 123],
+      [false, false],
+      [false, null],
+      [false, undefined],
+      [false, ''],
+      [false, 'a'],
+      [false, /a/],
+      [false, {}],
+      [false, { a: 1, b: 2 }],
+      [false, [[]]],
+      [false, [['a']]],
+      [false, ['a', /b/, 1]],
+
+      [true, []],
+      [true, ['a']],
+      [true, [/a/]],
+      [true, ['a', 'b', 'c']],
+      [true, [/a/, /b/, /c/]],
+      [true, ['a', /b/, 'c']]
+    ])('returns %s from validation for the value %p', (expected, value) => {
+      const schema = createSchema()
+      const validate = schema.tracePropagationUrls.validate
+
+      expect(validate(value)).toBe(expected)
+    })
+  })
 })

--- a/packages/request-tracker/lib/network-request-callback.ts
+++ b/packages/request-tracker/lib/network-request-callback.ts
@@ -1,9 +1,5 @@
 export interface NetworkRequestInfo {
   url: string | null
-  /**
-   * Experimental. Whether to propagate trace context by adding a `traceparent` header to the request.
-   */
-  propagateTraceContext?: boolean
 }
 
 export type NetworkRequestCallback <T extends NetworkRequestInfo> = (networkRequestInfo: T) => T | null

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -1,6 +1,7 @@
 import {
   DefaultSpanContextStorage,
   Sampler,
+  type SpanAttribute,
   SpanFactory,
   type Configuration,
   type SpanEnded,
@@ -45,8 +46,8 @@ class MockSpanFactory <C extends Configuration> extends SpanFactory<C> {
     return super.startSpan(name, options)
   })
 
-  endSpan = jest.fn((span: SpanInternal, endTime: number) => {
-    super.endSpan(span, endTime)
+  endSpan = jest.fn((span: SpanInternal, endTime: number, additionalAttributes?: Record<string, SpanAttribute>) => {
+    super.endSpan(span, endTime, additionalAttributes)
   })
 }
 

--- a/test/browser/features/fixtures/packages/manual-span/index.html
+++ b/test/browser/features/fixtures/packages/manual-span/index.html
@@ -4,9 +4,11 @@
         <meta charset="utf-8" />
         <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
         <script src="./dist/bundle.js" type="module"></script>
+        <title>Manual spans</title>
     </head>
     <body>
         <h1>manual-span</h1>
         <button id="send-span">send-span</button>
+        <button id="send-network-span">send-network-span</button>
     </body>
 </html>

--- a/test/browser/features/fixtures/packages/manual-span/src/index.js
+++ b/test/browser/features/fixtures/packages/manual-span/src/index.js
@@ -3,8 +3,9 @@ import BugsnagPerformance from '@bugsnag/browser-performance'
 const parameters = new URLSearchParams(window.location.search)
 const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
+const reflectEndpoint = '/reflect?status=200&delay_ms=0'
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false })
+BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false, autoInstrumentRouteChanges: false })
 
 document.getElementById('send-span').onclick = () => {
   const spanOptions = {}
@@ -16,3 +17,10 @@ document.getElementById('send-span').onclick = () => {
   const span = BugsnagPerformance.startSpan("Custom/ManualSpanScenario", spanOptions)
   span.end()
 }
+
+document.getElementById('send-network-span').addEventListener('click', () => {
+  const span = BugsnagPerformance.startNetworkSpan({ method: "GET", url: reflectEndpoint })
+  fetch(reflectEndpoint).then(({ status }) => {
+    span.end({ status })
+  })
+})

--- a/test/browser/features/fixtures/packages/oldest-batch-removed/src/index.js
+++ b/test/browser/features/fixtures/packages/oldest-batch-removed/src/index.js
@@ -6,18 +6,14 @@ const endpoint = parameters.get('endpoint')
 
 const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time))
 
-BugsnagPerformance.start({ apiKey, endpoint, retryQueueMaxSize: 3, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false, appVersion: '1.2.3' })
+BugsnagPerformance.start({ apiKey, endpoint, retryQueueMaxSize: 1, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false, appVersion: '1.2.3' })
 
 document.getElementById("send-first-span").addEventListener("click", () => {
   BugsnagPerformance.startSpan("Custom/Span to discard").end()
 })
 
 document.getElementById("send-retry-spans").addEventListener("click", async () => {
-  BugsnagPerformance.startSpan("Custom/Span to retry 1").end()
-  await sleep(100)
-  BugsnagPerformance.startSpan("Custom/Span to retry 2").end()
-  await sleep(100)
-  BugsnagPerformance.startSpan("Custom/Span to retry 3").end()
+  BugsnagPerformance.startSpan("Custom/Span to retry").end()
 })
 
 document.getElementById("send-final-span").addEventListener("click", () => {

--- a/test/browser/features/network-spans.feature
+++ b/test/browser/features/network-spans.feature
@@ -1,11 +1,24 @@
 Feature: Network spans
 
+    Scenario: Manual network spans
+        Given I navigate to the test URL "/manual-span"
+        When I click the element "send-network-span"
+        And I wait to receive 1 trace
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.title" equals "Manual spans"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.url" equals the stored value "bugsnag.browser.page.url"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "/reflect?status=200&delay_ms=0"
+        And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
+
     Scenario: Network spans are automatically instrumented for completed XHR requests
         Given I navigate to the test URL "/network-spans"
         When I click the element "xhr-success"
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.title" equals "Network spans"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.url" equals the stored value "bugsnag.browser.page.url"
@@ -18,7 +31,7 @@ Feature: Network spans
         When I click the element "fetch-success"
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.title" equals "Network spans"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.browser.page.url" equals the stored value "bugsnag.browser.page.url"
@@ -36,7 +49,7 @@ Feature: Network spans
         When I click the element "fetch-modified-url"
         And I wait to receive 1 trace
         
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200
@@ -46,7 +59,7 @@ Feature: Network spans
         When I click the element "xhr-modified-url"
         And I wait to receive 1 trace
         
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect\?status=200\&delay_ms=0&not-your-ordinary-url=true$"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" equals 200

--- a/test/browser/features/retries.feature
+++ b/test/browser/features/retries.feature
@@ -68,29 +68,27 @@ Feature: Retries
     Scenario Outline: Oldest batch is removed when max retry queue size is exceeded
         Given I navigate to the test URL "/oldest-batch-removed"
         And I wait to receive a sampling request
-        And I set the HTTP status code for the next 4 "POST" requests to <status>
+        And I set the HTTP status code for the next 2 "POST" requests to <status>
 
         When I click the element "send-first-span"
         And I wait to receive 1 trace
         And I discard the oldest trace
 
         Then I click the element "send-retry-spans"
-        And I wait to receive 3 traces
+        And I wait to receive 1 trace
 
         # Remove failed requests
-        And I discard the oldest 3 traces
+        And I discard the oldest trace
 
         Then I click the element "send-final-span"
         And I wait for 5 seconds
-        And I wait to receive 4 traces
+        And I wait to receive 2 traces
 
         # First successful batch
         Then a span name equals "Custom/Span to deliver"
 
-        # Retried batches
-        And a span name equals "Custom/Span to retry 1"
-        And a span name equals "Custom/Span to retry 2"
-        And a span name equals "Custom/Span to retry 3"
+        # Retried batch
+        And a span name equals "Custom/Span to retry"
 
         Examples:
             | status | definition                    |

--- a/test/browser/features/traceparent.feature
+++ b/test/browser/features/traceparent.feature
@@ -11,7 +11,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (simple headers in fetch options)
         Given I navigate to the test URL "/traceparent"
@@ -24,7 +24,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (Headers class in fetch options)   
         Given I navigate to the test URL "/traceparent"
@@ -37,7 +37,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (simple headers in Request object)   
         Given I navigate to the test URL "/traceparent"
@@ -50,7 +50,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (Headers class in Request object)
         Given I navigate to the test URL "/traceparent"
@@ -63,7 +63,7 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
 
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"
 
     Scenario: traceparent header is added to fetch requests (headers in both request and options)
         Given I navigate to the test URL "/traceparent"
@@ -76,4 +76,4 @@ Feature: Trace propagation headers
 
         And I wait to receive 1 trace
         
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP/GET]"

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioContext.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const ScenarioContext = React.createContext({
+  reflectEndpoint: '',
+})

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -4,6 +4,7 @@ import { AppRegistry } from 'react-native'
 import * as Scenarios from '../scenarios'
 import { getCurrentCommand } from './CommandRunner'
 import { clearPersistedState, setDeviceId, setSamplingProbability } from './Persistence'
+import { ScenarioContext } from './ScenarioContext' 
 
 const isTurboModuleEnabled = () => global.__turboModuleProxy != null
 
@@ -51,8 +52,17 @@ async function runScenario (rootTag, scenarioName, apiKey, endpoint) {
       appParams.fabric = true
       appParams.initialProps = { concurrentRoot: true }
     }
+
+    const reflectEndpoint = endpoint.replace('traces', 'reflect')
+
+    console.error(`[BugsnagPerformance] Reflect endpoint: ${reflectEndpoint}`)
+
+    const Scenario = () => 
+    <ScenarioContext.Provider value={{ reflectEndpoint }}>
+      <scenario.App />
+    </ScenarioContext.Provider>
   
-    AppRegistry.registerComponent(scenarioName, () => scenario.App)
+    AppRegistry.registerComponent(scenarioName, () => Scenario)
     AppRegistry.runApplication(scenarioName, appParams)
   }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
@@ -3,7 +3,7 @@ import React, { useContext, useEffect } from 'react'
 import { ScenarioContext } from '../lib/ScenarioContext'
 
 export const config = {
-  maximumBatchSize: 1,
+  maximumBatchSize: 5,
   autoInstrumentAppStarts: false,
   networkRequestCallback: (requestInfo) => {
     if (requestInfo.url.endsWith('/command')) return null

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
@@ -5,12 +5,11 @@ import { ScenarioContext } from '../lib/ScenarioContext'
 export const config = {
   maximumBatchSize: 5,
   autoInstrumentAppStarts: false,
+  tracePropagationUrls: [/^http:\/\/.+:\d{4}\/reflect$/],
   networkRequestCallback: (requestInfo) => {
     if (requestInfo.url.endsWith('/command')) return null
-
-    requestInfo.propagateTraceContext = true
-    return requestInfo;
-  },
+    return requestInfo
+  }
 }
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/TracePropagationScenario.js
@@ -1,0 +1,106 @@
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import React, { useContext, useEffect } from 'react'
+import { ScenarioContext } from '../lib/ScenarioContext'
+
+export const config = {
+  maximumBatchSize: 1,
+  autoInstrumentAppStarts: false,
+  networkRequestCallback: (requestInfo) => {
+    if (requestInfo.url.endsWith('/command')) return null
+
+    requestInfo.propagateTraceContext = true
+    return requestInfo;
+  },
+}
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+const fetchWithObjectLiteralHeadersInOptions = async (endpoint) => {
+  try {
+    await fetch(endpoint, { headers: { 'X-Test-Header': 'test' } })
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const fetchWithHeadersClassInOptions = async (endpoint) => {
+  try {
+    await fetch(endpoint, { headers: new Headers({ 'X-Test-Header': 'test' }) })
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const fetchWithObjectLiteralHeadersInRequest = async (endpoint) => {
+  try {
+    const request = new Request(endpoint, { headers: { 'X-Test-Header': 'test' }})
+    await fetch(request)
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const fetchWithHeadersClassInRequest = async (endpoint) => {
+  try {
+    const request = new Request(endpoint, { headers: new Headers({ 'X-Test-Header': 'test' }) })
+    await fetch(request)
+  } catch (e) {
+    console.error('[BugsnagPerformance] error sending fetch request', e)
+  }
+}
+
+const xhrWithHeaders = async (endpoint) => {
+  return new Promise((resolve, reject) => {
+    const xhrSuccess = new XMLHttpRequest()
+   
+    xhrSuccess.onload = () => {
+      if (xhrSuccess.readyState === 4) {
+        resolve() 
+      }
+    }
+
+    xhrSuccess.onerror = () => {
+      console.error('[BugsnagPerformance] error sending xhr request', xhr)
+      reject()
+    }
+
+    xhrSuccess.open('GET', endpoint)
+    xhrSuccess.setRequestHeader('X-Test-Header', 'test')
+    xhrSuccess.send()
+  })
+}
+
+export const App = () => {
+  const { reflectEndpoint } = useContext(ScenarioContext)
+
+  useEffect(() => {
+    (async () => {
+        await delay(250)
+
+        await fetchWithObjectLiteralHeadersInOptions(reflectEndpoint)
+        await fetchWithHeadersClassInOptions(reflectEndpoint)
+
+        await fetchWithObjectLiteralHeadersInRequest(reflectEndpoint)
+        await fetchWithHeadersClassInRequest(reflectEndpoint)
+
+        await xhrWithHeaders(reflectEndpoint)
+    })()
+}, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>TracePropagationScenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -8,6 +8,7 @@ export * as NetworkRequestFailedScenario from './NetworkRequestFailedScenario'
 export * as NetworkRequestScenario from './NetworkRequestScenario'
 export * as SpanTriggeredByCommandScenario from './SpanTriggeredByCommandScenario'
 export * as WrapperComponentProviderScenario from './WrapperComponentProviderScenario'
+export * as TracePropagationScenario from './TracePropagationScenario'
 
 // React Native Navigation Scenarios
 export * as ReactNativeNavigationScenario from './ReactNativeNavigationScenario'

--- a/test/react-native/features/network-spans.feature
+++ b/test/react-native/features/network-spans.feature
@@ -5,13 +5,13 @@ Feature: Network spans
         And I wait to receive a sampling request
         And I wait for 2 spans
 
-        Then a span named "[HTTP]/GET" contains the attributes:
+        Then a span named "[HTTP/GET]" contains the attributes:
             | attribute             | type        | value                             |
             | bugsnag.span.category | stringValue | network                           |
             | http.method           | stringValue | GET                               |
             | http.url              | stringValue | https://bugsnag.com?fetch=true    |
             | http.status_code      | intValue    | 200                               |
-        And a span named "[HTTP]/GET" contains the attributes:
+        And a span named "[HTTP/GET]" contains the attributes:
             | attribute             | type        | value                           |
             | bugsnag.span.category | stringValue | network                         |
             | http.method           | stringValue | GET                             |
@@ -28,7 +28,7 @@ Feature: Network spans
         And I wait to receive a sampling request
         And I wait to receive 1 span
 
-        Then a span named "[HTTP]/GET" contains the attributes:
+        Then a span named "[HTTP/GET]" contains the attributes:
             | attribute             | type        | value                                                       |
             | bugsnag.span.category | stringValue | network                                                     |
             | http.method           | stringValue | GET                                                         |

--- a/test/react-native/features/traceparent.feature
+++ b/test/react-native/features/traceparent.feature
@@ -1,0 +1,49 @@
+Feature: Trace propagation headers
+
+    Scenario: traceparent headers are added to requests
+        When I run 'TracePropagationScenario'
+
+        And I wait to receive 5 reflections
+        And I wait to receive 5 traces
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
+
+        And I discard the oldest reflection
+        And I discard the oldest trace
+
+        Then the reflection request method equals "GET"
+        And the reflection "X-Test-Header" header equals "test"
+        And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
+
+        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"

--- a/test/react-native/features/traceparent.feature
+++ b/test/react-native/features/traceparent.feature
@@ -4,46 +4,34 @@ Feature: Trace propagation headers
         When I run 'TracePropagationScenario'
 
         And I wait to receive 5 reflections
-        And I wait to receive 5 traces
+        
+        And I wait for 5 spans
+        Then every span string attribute "http.url" matches the regex "^http:\/\/.+:\d{4}\/reflect$"
 
-        Then the reflection request method equals "GET"
+        And the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"
 
         And I discard the oldest reflection
-        And I discard the oldest trace
 
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-
-        Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[HTTP]/GET"


### PR DESCRIPTION
### Added

- (react-native) Add trace propagation headers for React Native [#437](https://github.com/bugsnag/bugsnag-js-performance/pull/437) [#444](https://github.com/bugsnag/bugsnag-js-performance/pull/444)
- Add new `startNetworkSpan` method to `BugsnagPerformance` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)
- Change network span naming convention to `[HTTP/VERB]` [#448](https://github.com/bugsnag/bugsnag-js-performance/pull/448)

### Fixed

- (core) Fix import of `@bugsnag/cuid` not working in node ESM environment [#445](https://github.com/bugsnag/bugsnag-js-performance/pull/445)