### PR TITLE
[PLAT-11470] update vite to 4.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23850,9 +23850,10 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
     "semver": "^7.5.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "vite": "^4.5.3"
+    }
   }
 }


### PR DESCRIPTION
## Goal

Resolve CVE-2023-49293, CVE-2024-23331 and CVE-2024-31207 by overriding the version of `vite` used by `@angular-devkit/build-angular`, which is unable to be patched using `npm update` due to strict dependencies in the `@angular-devkit/build-angular` package