### PR TITLE
Fix missing ruby packages from the license-finder docker image

### DIFF
--- a/dockerfiles/Dockerfile.license-finder
+++ b/dockerfiles/Dockerfile.license-finder
@@ -1,6 +1,6 @@
 FROM node:18-alpine as license-finder
 
-RUN apk update && apk add ruby
+RUN apk update && apk add ruby ruby-dev build-base
 
 RUN gem install license_finder
 


### PR DESCRIPTION
## Goal

Ensure that the license-finder docker image has the required packages needed to work on CI.


## Testing

covered by CI