### PR TITLE
[PLAT-12196] Clear lastRenderTime after ending navigation span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
 - (browser) Set parent span context for full page load spans based on traceparent meta tag, if present [#446](https://github.com/bugsnag/bugsnag-js-performance/pull/446)
+
+### Fixed
+
+- (plugin-react-navigation) Fix an issue where a navigation span could inherit the end time of the last span [#457](https://github.com/bugsnag/bugsnag-js-performance/pull/457)
 
 ## [v2.5.0] (2024-05-02)
 

--- a/packages/plugin-react-navigation/test/create-navigation-container.test.tsx
+++ b/packages/plugin-react-navigation/test/create-navigation-container.test.tsx
@@ -8,6 +8,14 @@ import React from 'react'
 import { Button, Text, View } from 'react-native'
 import { createNavigationContainer } from '../lib/create-navigation-container'
 
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
 describe('createNavigationContainer', () => {
   it('creates a navigation span when the route changes', () => {
     const spanFactory = new MockSpanFactory<ReactNativeConfiguration>()
@@ -23,13 +31,13 @@ describe('createNavigationContainer', () => {
     expect(screen.getByText('Route 2')).toBeOnTheScreen()
 
     expect(spanFactory.startSpan).toHaveBeenCalledTimes(1)
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[Navigation]Route 2', { isFirstClass: true })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[Navigation]Route 2', { isFirstClass: true, startTime: 0 })
 
     fireEvent.press(screen.getByText('Go back'))
     expect(screen.getByText('Route 1')).toBeOnTheScreen()
 
     expect(spanFactory.startSpan).toHaveBeenCalledTimes(2)
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[Navigation]Route 1', { isFirstClass: true })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[Navigation]Route 1', { isFirstClass: true, startTime: 0 })
   })
 
   it('forwards the provided ref to the NavigationContainer', () => {
@@ -49,7 +57,7 @@ describe('createNavigationContainer', () => {
     })
 
     expect(spanFactory.startSpan).toHaveBeenCalledTimes(1)
-    expect(spanFactory.startSpan).toHaveBeenCalledWith('[Navigation]Route 2', { isFirstClass: true })
+    expect(spanFactory.startSpan).toHaveBeenCalledWith('[Navigation]Route 2', { isFirstClass: true, startTime: 0 })
   })
 })
 


### PR DESCRIPTION
## Goal

Fix an issue where a span ended without a NavigationComplete component would inherit the end time of the last span ended via the NavigationComplete component

As an aside, the plugin now directly uses `performance.now` for start time, as per end time. 

## Testing

Added unit test to ensure navigation spans do not inherit the last render time from the `NavigationComplete` component