### PR TITLE
[PLAT-12231] Browser error correlation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3410,9 +3410,31 @@
       "resolved": "packages/angular",
       "link": true
     },
+    "node_modules/@bugsnag/browser": {
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.7.tgz",
+      "integrity": "sha512-70jFkWKscK2osm7bnFbPLevrzHClrygM3UcKetKs/l81Xuzlxnu1SS3onN5OUl9kd9RN4XMFr46Pv5jSqWqImQ==",
+      "dev": true,
+      "dependencies": {
+        "@bugsnag/core": "^7.22.7"
+      }
+    },
     "node_modules/@bugsnag/browser-performance": {
       "resolved": "packages/platforms/browser",
       "link": true
+    },
+    "node_modules/@bugsnag/core": {
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.22.7.tgz",
+      "integrity": "sha512-9DPWBkkBjhFJc5dCFy/wVC3HE0Aw3ZiLJKjyAxgywSKbILgtpD+qT1Xe8sacWyxU92znamlZ8H8ziQOe7jhhbA==",
+      "dev": true,
+      "dependencies": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
     },
     "node_modules/@bugsnag/core-performance": {
       "resolved": "packages/core",
@@ -3449,6 +3471,12 @@
     "node_modules/@bugsnag/request-tracker-performance": {
       "resolved": "packages/request-tracker",
       "link": true
+    },
+    "node_modules/@bugsnag/safe-json-stringify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
+      "dev": true
     },
     "node_modules/@bugsnag/vue-router-performance": {
       "resolved": "packages/vue-router",
@@ -11462,7 +11490,6 @@
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "stackframe": "^1.3.4"
       }
@@ -14494,6 +14521,12 @@
       "version": "2.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -21921,6 +21954,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dev": true,
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "license": "MIT",
@@ -21940,8 +21982,7 @@
     },
     "node_modules/stackframe": {
       "version": "1.3.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.10",
@@ -24197,6 +24238,9 @@
         "@bugsnag/cuid": "^3.1.1",
         "@bugsnag/delivery-fetch-performance": "^2.6.0",
         "@bugsnag/request-tracker-performance": "^2.6.0"
+      },
+      "devDependencies": {
+        "@bugsnag/browser": "^7.0.0"
       }
     },
     "packages/platforms/react-native": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3410,31 +3410,9 @@
       "resolved": "packages/angular",
       "link": true
     },
-    "node_modules/@bugsnag/browser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.7.tgz",
-      "integrity": "sha512-70jFkWKscK2osm7bnFbPLevrzHClrygM3UcKetKs/l81Xuzlxnu1SS3onN5OUl9kd9RN4XMFr46Pv5jSqWqImQ==",
-      "dev": true,
-      "dependencies": {
-        "@bugsnag/core": "^7.22.7"
-      }
-    },
     "node_modules/@bugsnag/browser-performance": {
       "resolved": "packages/platforms/browser",
       "link": true
-    },
-    "node_modules/@bugsnag/core": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.22.7.tgz",
-      "integrity": "sha512-9DPWBkkBjhFJc5dCFy/wVC3HE0Aw3ZiLJKjyAxgywSKbILgtpD+qT1Xe8sacWyxU92znamlZ8H8ziQOe7jhhbA==",
-      "dev": true,
-      "dependencies": {
-        "@bugsnag/cuid": "^3.0.0",
-        "@bugsnag/safe-json-stringify": "^6.0.0",
-        "error-stack-parser": "^2.0.3",
-        "iserror": "0.0.2",
-        "stack-generator": "^2.0.3"
-      }
     },
     "node_modules/@bugsnag/core-performance": {
       "resolved": "packages/core",
@@ -24240,7 +24218,29 @@
         "@bugsnag/request-tracker-performance": "^2.6.0"
       },
       "devDependencies": {
-        "@bugsnag/browser": "^7.0.0"
+        "@bugsnag/browser": "^7.25.0-alpha.0"
+      }
+    },
+    "packages/platforms/browser/node_modules/@bugsnag/browser": {
+      "version": "7.25.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.25.0-alpha.0.tgz",
+      "integrity": "sha512-mfPn5/q03+Jg84GfyUCs0wQSNTslaKQHamzeROWKkZjO6vW12H3ckAi5I45jGULvUymo6CVVnfswhDLyzzw55Q==",
+      "dev": true,
+      "dependencies": {
+        "@bugsnag/core": "^7.25.0-alpha.0"
+      }
+    },
+    "packages/platforms/browser/node_modules/@bugsnag/core": {
+      "version": "7.25.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.25.0-alpha.0.tgz",
+      "integrity": "sha512-qHrt70QtHXklayOsUTKXv9I7akht7G0uaZr7KYJ3NvQZhEBROF2A5NgGOO5naWtSsb1pjAfKKihYKcZFLtuUDA==",
+      "dev": true,
+      "dependencies": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
       }
     },
     "packages/platforms/react-native": {

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -1,6 +1,16 @@
 import { type Plugin } from './plugin'
 import { isLogger, isNumber, isObject, isPluginArray, isString, isStringArray, isStringWithLength } from './validation'
 
+interface BugsnagErrorEvent {
+  addMetadata: (tabName: string, data: Record<string, any>) => void
+}
+
+type BugsnagErrorCallback = (event: BugsnagErrorEvent) => void
+
+interface BugsnagErrorStatic {
+  addOnError: (fn: BugsnagErrorCallback) => void
+}
+
 export interface Logger {
   debug: (message: string) => void
   info: (message: string) => void
@@ -16,6 +26,7 @@ export interface Configuration {
   appVersion?: string
   enabledReleaseStages?: string[] | null
   plugins?: Array<Plugin<Configuration>>
+  bugsnag?: BugsnagErrorStatic
 }
 
 export interface TestConfiguration {
@@ -42,6 +53,7 @@ export interface CoreSchema extends Schema {
   appVersion: ConfigOption<string>
   enabledReleaseStages: ConfigOption<string[] | null>
   plugins: ConfigOption<Array<Plugin<Configuration>>>
+  bugsnag: ConfigOption<BugsnagErrorStatic | undefined>
 }
 
 export const schema: CoreSchema = {
@@ -84,6 +96,11 @@ export const schema: CoreSchema = {
     defaultValue: [],
     message: 'should be an array of plugin objects',
     validate: isPluginArray
+  },
+  bugsnag: {
+    defaultValue: undefined,
+    message: 'should be an instance of Bugsnag',
+    validate: (value: unknown): value is BugsnagErrorStatic => isObject(value) && typeof value.addOnError === 'function'
   }
 }
 

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -2,7 +2,7 @@ import { type Plugin } from './plugin'
 import { isLogger, isNumber, isObject, isPluginArray, isString, isStringArray, isStringWithLength } from './validation'
 
 interface BugsnagErrorEvent {
-  setTraceCorrelation: (traceId: string, spanId: string) => void
+  setTraceCorrelation?: (traceId: string, spanId: string) => void
 }
 
 type BugsnagErrorCallback = (event: BugsnagErrorEvent) => void

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -2,7 +2,7 @@ import { type Plugin } from './plugin'
 import { isLogger, isNumber, isObject, isPluginArray, isString, isStringArray, isStringWithLength } from './validation'
 
 interface BugsnagErrorEvent {
-  addMetadata: (tabName: string, data: Record<string, any>) => void
+  setTraceCorrelation: (traceId: string, spanId: string) => void
 }
 
 type BugsnagErrorCallback = (event: BugsnagErrorEvent) => void

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -68,6 +68,19 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
     start: (config: C | string) => {
       const configuration = validateConfig<S, C>(config, options.schema)
 
+      if (configuration.bugsnag) {
+        configuration.bugsnag.addOnError((event) => {
+          const currentSpanContext = spanContextStorage.current
+
+          if (currentSpanContext) {
+            event.addMetadata('correlation', {
+              traceid: currentSpanContext.traceId,
+              spanid: currentSpanContext.id
+            })
+          }
+        })
+      }
+
       const delivery = options.deliveryFactory(configuration.endpoint)
 
       options.spanAttributesSource.configure(configuration)

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -72,11 +72,8 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
         configuration.bugsnag.addOnError((event) => {
           const currentSpanContext = spanContextStorage.current
 
-          if (currentSpanContext) {
-            event.addMetadata('correlation', {
-              traceid: currentSpanContext.traceId,
-              spanid: currentSpanContext.id
-            })
+          if (currentSpanContext && event.setTraceCorrelation) {
+            event.setTraceCorrelation(currentSpanContext.traceId, currentSpanContext.id)
           }
         })
       }

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -6,8 +6,8 @@ import {
   type Configuration,
   type CoreSchema
 } from '@bugsnag/core-performance'
-import { type NetworkRequestCallback, defaultNetworkRequestCallback, isNetworkRequestCallback } from '@bugsnag/request-tracker-performance'
-import { type BrowserNetworkRequestInfo } from './auto-instrumentation'
+import { defaultNetworkRequestCallback, isNetworkRequestCallback, type NetworkRequestCallback } from '@bugsnag/request-tracker-performance'
+import type { BrowserNetworkRequestInfo } from './auto-instrumentation'
 import { isRoutingProvider, type RoutingProvider } from './routing-provider'
 import { defaultSendPageAttributes, isSendPageAttributes, type SendPageAttributes } from './send-page-attributes'
 

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -26,6 +26,9 @@
     "@bugsnag/delivery-fetch-performance": "^2.6.0",
     "@bugsnag/request-tracker-performance": "^2.6.0"
   },
+  "devDependencies": {
+    "@bugsnag/browser": "^7.0.0"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/request-tracker-performance": "^2.6.0"
   },
   "devDependencies": {
-    "@bugsnag/browser": "^7.0.0"
+    "@bugsnag/browser": "^7.25.0-alpha.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/platforms/browser/tests/browser.test.ts
+++ b/packages/platforms/browser/tests/browser.test.ts
@@ -188,11 +188,9 @@ describe('Browser client integration tests', () => {
       Bugsnag.notify(new Error('test error'))
 
       expect(sendEvent).toHaveBeenCalledTimes(1)
-      expect(sendEvent.mock.calls[0][0].events[0]._metadata).toEqual({
-        correlation: {
-          traceid: span.traceId,
-          spanid: span.id
-        }
+      expect(sendEvent.mock.calls[0][0].events[0]._correlation).toEqual({
+        traceId: span.traceId,
+        spanId: span.id
       })
 
       span.end()

--- a/packages/plugin-react-navigation/lib/create-navigation-container.tsx
+++ b/packages/plugin-react-navigation/lib/create-navigation-container.tsx
@@ -27,7 +27,7 @@ export const createNavigationContainer: CreateNavigationContainer = (NavigationC
       }
 
       if (typeof onStateChange === 'function') {
-        onStateChange.apply(undefined, args)
+        onStateChange.apply(this, args)
       }
     }
 

--- a/packages/plugin-react-navigation/lib/create-navigation-container.tsx
+++ b/packages/plugin-react-navigation/lib/create-navigation-container.tsx
@@ -27,7 +27,7 @@ export const createNavigationContainer: CreateNavigationContainer = (NavigationC
       }
 
       if (typeof onStateChange === 'function') {
-        onStateChange.apply(this, args)
+        onStateChange.apply(undefined, args)
       }
     }
 


### PR DESCRIPTION
## Goal

Implement error correlation for browser performance

## Design

Call `addOnError` from bugsnag notifier when provided as a configuration option

## Changeset

Added new `bugsnag` configuration option to core client

## Testing

Added unit tests for adding span and trace id to a reported error