### PR TITLE
Move 'full' React Native pipeline to MacOS 14 / Java 17

### DIFF
--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -8,8 +8,9 @@ steps:
         key: "build-react-native-android-fixture-old-arch-full"
         timeout_in_minutes: 30
         agents:
-          queue: macos-12-arm
+          queue: macos-14
         env:
+          JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           BUILD_ANDROID: "true"
@@ -30,8 +31,9 @@ steps:
         key: "build-react-native-android-fixture-new-arch-full"
         timeout_in_minutes: 30
         agents:
-          queue: macos-12-arm
+          queue: macos-14
         env:
+          JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "true"
@@ -53,12 +55,12 @@ steps:
         key: "build-react-native-ios-fixture-old-arch-full"
         timeout_in_minutes: 30
         agents:
-          queue: "macos-12-arm"
+          queue: "macos-14"
         env:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           BUILD_IOS: "true"
-          DEVELOPER_DIR: "/Applications/Xcode14.app"
+          XCODE_VERSION: "15.3.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/old-arch/**/output/reactnative.ipa"
         commands:
@@ -77,13 +79,13 @@ steps:
         key: "build-react-native-ios-fixture-new-arch-full"
         timeout_in_minutes: 30
         agents:
-          queue: "macos-12-arm"
+          queue: "macos-14"
         env:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_IOS: "true"
-          DEVELOPER_DIR: "/Applications/Xcode14.app"
+          XCODE_VERSION: "15.3.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/new-arch/**/output/reactnative.ipa"
         commands:


### PR DESCRIPTION
## Goal

Move the 'full' react native CI pipeline to MacOS 14/Java 17 (required for React Native 0.73) - this was missed in #464 when 0.73 tests were moved from the basic to full pipeline.

## Testing

covered by a full CI run