### PR TITLE
feat(react-native): support remote debugging in chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- (react-native) Support remote debugging in Chrome [#468](https://github.com/bugsnag/bugsnag-js-performance/pull/468)
+
 ## [v2.6.0] (2024-06-06)
 
 ### Added

--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -15,11 +15,19 @@ import createRetryQueueFactory from './retry-queue'
 import { createSpanAttributesSource } from './span-attributes-source'
 import createBrowserBackgroundingListener from './backgrounding-listener'
 
+// this is how some internal react native code detects whether the app is running
+// in the remote debugger:
+// https://github.com/facebook/react-native/blob/e320ab47cf855f2e5de74ea448ec292cf0bbb29a/packages/react-native/Libraries/Utilities/DebugEnvironment.js#L15
+// there's no public api for this so we use the same approach
+
+// @ts-expect-error Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+const isDebuggingRemotely = !global.nativeCallSyncHook && !global.RN$Bridgeless
+
 const clock = createClock(performance)
 const appStartTime = clock.now()
 const deliveryFactory = createFetchDeliveryFactory(fetch, clock)
 const spanAttributesSource = createSpanAttributesSource()
-const deviceInfo = NativeBugsnagPerformance ? NativeBugsnagPerformance.getDeviceInfo() : undefined
+const deviceInfo = NativeBugsnagPerformance && !isDebuggingRemotely ? NativeBugsnagPerformance.getDeviceInfo() : undefined
 const persistence = persistenceFactory(FileSystem, deviceInfo)
 const resourceAttributesSource = resourceAttributesSourceFactory(persistence, deviceInfo)
 const backgroundingListener = createBrowserBackgroundingListener(AppState)
@@ -27,7 +35,7 @@ const backgroundingListener = createBrowserBackgroundingListener(AppState)
 // React Native's fetch polyfill uses xhr under the hood, so we only track xhr requests
 const xhrRequestTracker = createXmlHttpRequestTracker(XMLHttpRequest, clock)
 
-const idGenerator = createIdGenerator(NativeBugsnagPerformance)
+const idGenerator = createIdGenerator(NativeBugsnagPerformance, isDebuggingRemotely)
 
 const BugsnagPerformance = createClient({
   backgroundingListener,

--- a/packages/platforms/react-native/lib/clock.ts
+++ b/packages/platforms/react-native/lib/clock.ts
@@ -12,7 +12,7 @@ const createClock = (performance: Performance): Clock => {
   const startWallTime = Date.now()
 
   return {
-    now: performance.now,
+    now: () => performance.now(),
     date: () => new Date(performance.now() - startPerfTime + startWallTime),
     convert: (date: Date) => date.getTime() - startWallTime + startPerfTime,
     // convert milliseconds since timeOrigin to full timestamp

--- a/packages/platforms/react-native/lib/id-generator.ts
+++ b/packages/platforms/react-native/lib/id-generator.ts
@@ -32,9 +32,11 @@ export function createRandomString (): string {
   return random
 }
 
-function createIdGenerator (NativeBugsnagPerformance: NativeBugsnag | null): IdGenerator {
-  // If the native module is not available for any reason, fall back to a JS implementation
-  const requestEntropy = isNativeModuleEnabled(NativeBugsnagPerformance) ? NativeBugsnagPerformance.requestEntropy : createRandomString
+function createIdGenerator (NativeBugsnagPerformance: NativeBugsnag | null, isDebuggingRemotely = false): IdGenerator {
+  // If the native module is not available or remote debugging is enabled, fall back to a JS implementation
+  const requestEntropy = isNativeModuleEnabled(NativeBugsnagPerformance) && !isDebuggingRemotely
+    ? NativeBugsnagPerformance.requestEntropy
+    : createRandomString
   const requestEntropyAsync = isNativeModuleEnabled(NativeBugsnagPerformance) ? NativeBugsnagPerformance.requestEntropyAsync : async () => createRandomString()
 
   // initialise the pool synchronously

--- a/packages/platforms/react-native/tests/id-generator.test.ts
+++ b/packages/platforms/react-native/tests/id-generator.test.ts
@@ -104,5 +104,12 @@ describe('React Native ID generator', () => {
       const id = idGenerator.generate(64)
       expect(id).toMatch(/^[a-f0-9]{16}$/)
     })
+
+    it('falls back to JS entropy source if remote debugging is enabled', () => {
+      const idGenerator = createIdGenerator(NativeBugsnagPerformance, true)
+      expect(requestEntropy).not.toHaveBeenCalled()
+      const id = idGenerator.generate(64)
+      expect(id).toMatch(/^[a-f0-9]{16}$/)
+    })
   })
 })


### PR DESCRIPTION
## Goal

Support remote debugging via Chrome for React Native apps. 

Updates the React Native client to avoid making synchronous native calls if we detect that remote debugging is enabled (see #370).

## Design

Currently there are only two synchronous native calls made, both during initialisation, to `getDeviceInfo` (to get native device metadata( and `requestEntropy` to (initialise the entropy source for the id generator).

If remote debugging is detected we simply don't make these calls - this means that when running in the debugger some device-related resource attributes will be missing from resource spans, and the id generator will fall back to using a JS entropy source, but the client should otherwise work as expected.

## Testing

Tested manually with the remote debugger