### PR TITLE
Fix crash when navigation ref is created with useRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (plugin-react-navigation) Fix a crash when navigation ref is created using useRef [#469](https://github.com/bugsnag/bugsnag-js-performance/pull/469)
+
 ## [v2.6.0] (2024-06-06)
 
 ### Added

--- a/packages/plugin-react-navigation/lib/create-navigation-container.tsx
+++ b/packages/plugin-react-navigation/lib/create-navigation-container.tsx
@@ -19,9 +19,9 @@ export const createNavigationContainer: CreateNavigationContainer = (NavigationC
     const routeNameRef = useRef<string>()
 
     const wrappedOnStateChange: typeof onStateChange = (...args) => {
-      const currentRoute = navigationContainerRef && navigationContainerRef.current
+      const currentRoute = navigationContainerRef ? navigationContainerRef.current
         ? navigationContainerRef.current.getCurrentRoute()
-        : navigationContainerRef ? navigationContainerRef.getCurrentRoute() : null
+        : navigationContainerRef.getCurrentRoute() : null
 
       if (currentRoute) {
         routeNameRef.current = currentRoute.name

--- a/packages/plugin-react-navigation/lib/create-navigation-container.tsx
+++ b/packages/plugin-react-navigation/lib/create-navigation-container.tsx
@@ -19,7 +19,9 @@ export const createNavigationContainer: CreateNavigationContainer = (NavigationC
     const routeNameRef = useRef<string>()
 
     const wrappedOnStateChange: typeof onStateChange = (...args) => {
-      const currentRoute = navigationContainerRef ? navigationContainerRef.getCurrentRoute() : null
+      const currentRoute = navigationContainerRef && navigationContainerRef.current
+        ? navigationContainerRef.current.getCurrentRoute()
+        : navigationContainerRef ? navigationContainerRef.getCurrentRoute() : null
 
       if (currentRoute) {
         routeNameRef.current = currentRoute.name

--- a/packages/plugin-react-navigation/lib/create-navigation-container.tsx
+++ b/packages/plugin-react-navigation/lib/create-navigation-container.tsx
@@ -19,9 +19,11 @@ export const createNavigationContainer: CreateNavigationContainer = (NavigationC
     const routeNameRef = useRef<string>()
 
     const wrappedOnStateChange: typeof onStateChange = (...args) => {
-      const currentRoute = navigationContainerRef ? navigationContainerRef.current
-        ? navigationContainerRef.current.getCurrentRoute()
-        : navigationContainerRef.getCurrentRoute() : null
+      const currentRoute = navigationContainerRef
+        ? navigationContainerRef.current
+          ? navigationContainerRef.current.getCurrentRoute()
+          : navigationContainerRef.getCurrentRoute()
+        : null
 
       if (currentRoute) {
         routeNameRef.current = currentRoute.name


### PR DESCRIPTION
## Goal

Support navigation refs created using `useRef`.

Currently the React Navigation plugin expects the passed in navigation ref to be created with `useNavigationContainerRef`, and crashes if the ref was created with `useRef`, since in that case `getCurrentRoute` should be accessed via `ref.current`.

## Design

the code now first checks if `ref.current` exists and then falls back to calling `getCurrentRoute` on the ref directly.