### PR TITLE
[PLAT-12475] Monkey patch notify method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Added
 
-(browser) - Add serviceName config option for browser and ensure service.name attribute is always set [#477](https://github.com/bugsnag/bugsnag-js-performance/pull/477)
+- (browser) - Add serviceName config option for browser and ensure service.name attribute is always set [#477](https://github.com/bugsnag/bugsnag-js-performance/pull/477)
 
 ### Changed
 
-(vue-router) - Use vue router to resolve routes [#476](https://github.com/bugsnag/bugsnag-js-performance/pull/476)
+- (vue-router) - Use vue router to resolve routes [#476](https://github.com/bugsnag/bugsnag-js-performance/pull/476)
+- Update error correlation implementation to monkey patch the error notifier [#474](https://github.com/bugsnag/bugsnag-js-performance/pull/474)
 
 ## [v2.7.1] (2024-07-16)
 

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -1,14 +1,24 @@
 import type { Plugin } from './plugin'
 import { isLogger, isNumber, isObject, isPluginArray, isString, isStringArray, isStringWithLength } from './validation'
 
+type SetTraceCorrelation = (traceId: string, spanId: string) => void
+
 interface BugsnagErrorEvent {
-  setTraceCorrelation?: (traceId: string, spanId: string) => void
+  setTraceCorrelation?: SetTraceCorrelation
 }
 
 type BugsnagErrorCallback = (event: BugsnagErrorEvent) => void
 
 interface BugsnagErrorStatic {
   addOnError: (fn: BugsnagErrorCallback) => void
+  Event: {
+    prototype: {
+      setTraceCorrelation?: SetTraceCorrelation
+    }
+  }
+  _client?: {
+    _notify: (event: BugsnagErrorEvent) => void
+  }
 }
 
 export interface Logger {

--- a/packages/platforms/browser/tests/browser.test.ts
+++ b/packages/platforms/browser/tests/browser.test.ts
@@ -6,7 +6,7 @@
 import { VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
 import type { BrowserConfiguration } from '../lib/config'
 import type { Client } from '@bugsnag/core-performance'
-import type { BrowserBugsnagStatic } from '@bugsnag/browser'
+import type Bugsnag from '@bugsnag/browser'
 
 const emptySamplingRequest = {
   body: '{"resourceSpans":[]}',
@@ -28,7 +28,7 @@ const createSpans = (count: number) => {
 }
 
 let client: Client<BrowserConfiguration>
-let bugsnag: BrowserBugsnagStatic
+let bugsnag: typeof Bugsnag
 
 const response = {
   status: 200,


### PR DESCRIPTION
## Goal

Refactor the error correlation implementation by patching the `_notify` method instead of leveraging `addOnError` to ensure callbacks run before the current span has closed