### PR TITLE
[PLAT-12480] Add appium v1.22 to the tests run on Bitbar

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -48,6 +48,7 @@ steps:
             command:
               - --farm=bb
               - --browser={{ matrix.browser }}_{{ matrix.version }}
+              - --appium-version=1.22
               - --aws-public-ip
               - --no-tunnel
           artifacts#v1.5.0:

--- a/.buildkite/react-native-navigation-pipeline.full.yml
+++ b/.buildkite/react-native-navigation-pipeline.full.yml
@@ -1,4 +1,4 @@
-# This pipeline file builds runs the end-to-end tests for 
+# This pipeline file builds runs the end-to-end tests for
 # React Native Navigation on BitBar.
 
 steps:
@@ -116,7 +116,7 @@ steps:
       - label: ":bitbar: :android: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (Old Arch) Android {{matrix.android_version}}"
         depends_on: "build-react-native-navigation-android-fixture-old-arch-full"
         timeout_in_minutes: 60
-        env: 
+        env:
           REACT_NATIVE_NAVIGATION: "true"
         plugins:
           artifacts#v1.9.0:
@@ -133,6 +133,7 @@ steps:
               - --device=ANDROID_{{matrix.android_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -151,7 +152,7 @@ steps:
       - label: ":bitbar: :android: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (New Arch) Android {{matrix.android_version}}"
         depends_on: "build-react-native-navigation-android-fixture-new-arch-full"
         timeout_in_minutes: 60
-        env: 
+        env:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "true"
         plugins:
@@ -169,6 +170,7 @@ steps:
               - --device=ANDROID_{{matrix.android_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -189,7 +191,7 @@ steps:
       - label: ":bitbar: :mac: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (Old Arch) iOS {{matrix.ios_version}}"
         depends_on: "build-react-native-navigation-ios-fixture-old-arch-full"
         timeout_in_minutes: 60
-        env: 
+        env:
           REACT_NATIVE_NAVIGATION: "true"
         plugins:
           artifacts#v1.9.0:
@@ -206,6 +208,7 @@ steps:
               - --device=IOS_{{matrix.ios_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -224,7 +227,7 @@ steps:
       - label: ":bitbar: :mac: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (New Arch) iOS {{matrix.ios_version}}"
         depends_on: "build-react-native-navigation-ios-fixture-new-arch-full"
         timeout_in_minutes: 60
-        env: 
+        env:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "true"
         plugins:
@@ -242,6 +245,7 @@ steps:
               - --device=IOS_{{matrix.ios_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:

--- a/.buildkite/react-native-navigation-pipeline.yml
+++ b/.buildkite/react-native-navigation-pipeline.yml
@@ -132,6 +132,7 @@ steps:
               - --device=ANDROID_{{matrix.android_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -168,6 +169,7 @@ steps:
               - --device=ANDROID_{{matrix.android_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -205,6 +207,7 @@ steps:
               - --device=IOS_{{matrix.ios_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -241,6 +244,7 @@ steps:
               - --device=IOS_{{matrix.ios_version}}
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -120,6 +120,7 @@ steps:
               - --device=ANDROID_12
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -150,6 +151,7 @@ steps:
               - --device=ANDROID_12
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         env:
@@ -182,6 +184,7 @@ steps:
               - --device=IOS_14
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -212,6 +215,7 @@ steps:
               - --device=IOS_14
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         env:

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -114,6 +114,7 @@ steps:
               - --device=ANDROID_12
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -142,6 +143,7 @@ steps:
               - --device=ANDROID_12
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         env:
@@ -172,6 +174,7 @@ steps:
               - --device=IOS_14
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -200,6 +203,7 @@ steps:
               - --device=IOS_14
               - --a11y-locator
               - --fail-fast
+              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
         env:


### PR DESCRIPTION
## Goal

Ensure the Bitbar tests run using appium v1.22

## Testing

Covered by CI