### PR TITLE
feat(vue-router): use vue router to resolve routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 (browser) - Add serviceName config option for browser and ensure service.name attribute is always set [#477](https://github.com/bugsnag/bugsnag-js-performance/pull/477)
 
+### Changed
+
+(vue-router) - Use vue router to resolve routes [#476](https://github.com/bugsnag/bugsnag-js-performance/pull/476)
+
 ## [v2.7.1] (2024-07-16)
 
 ### Changed

--- a/packages/vue-router/lib/vue-router-routing-provider.ts
+++ b/packages/vue-router/lib/vue-router-routing-provider.ts
@@ -1,21 +1,6 @@
-import {
-  onSettle
-
-} from '@bugsnag/browser-performance'
+import { onSettle } from '@bugsnag/browser-performance'
 import type { RouteResolver, RoutingProvider, StartRouteChangeCallback } from '@bugsnag/browser-performance'
-import pathToRegexp from 'path-to-regexp'
-import type { RouteRecordRaw, Router } from 'vue-router'
-
-function flattenRoutes (routes: RouteRecordRaw[], _prefix: string = ''): string[] {
-  const prefix = `${!_prefix || _prefix === '/' ? _prefix : `${_prefix}/`}`
-  return [
-    ...routes.map(route => `${prefix}${route.path || ''}`),
-    ...routes.reduce<string[]>(
-      (accum, route) => [...accum, ...(route.children ? flattenRoutes(route.children, `${prefix}${route.path}`) : [])],
-      []
-    )
-  ]
-}
+import type { Router } from 'vue-router'
 
 export class VueRouterRoutingProvider implements RoutingProvider {
   router: Router
@@ -27,7 +12,8 @@ export class VueRouterRoutingProvider implements RoutingProvider {
     const normalizedBasename = !basename || basename === '/' ? '' : basename
 
     function resolveRoute (url: URL): string {
-      return flattenRoutes(router.getRoutes()).find((fullRoutePath) => url.pathname.replace(normalizedBasename ?? '', '').match(pathToRegexp(fullRoutePath))) || 'no-route-found'
+      const location = router.resolve({ path: url.pathname.replace(normalizedBasename ?? '', '') })
+      return location.matched.length > 0 ? location.matched[location.matched.length - 1].path : 'no-route-found'
     }
     this.resolveRoute = resolveRoute
   }

--- a/packages/vue-router/lib/vue-router-routing-provider.ts
+++ b/packages/vue-router/lib/vue-router-routing-provider.ts
@@ -13,7 +13,7 @@ export class VueRouterRoutingProvider implements RoutingProvider {
 
     function resolveRoute (url: URL): string {
       const location = router.resolve({ path: url.pathname.replace(normalizedBasename ?? '', '') })
-      return location.matched.length > 0 ? location.matched[location.matched.length - 1].path : 'no-route-found'
+      return location.matched.pop()?.path || 'no-route-found'
     }
     this.resolveRoute = resolveRoute
   }

--- a/packages/vue-router/package.json
+++ b/packages/vue-router/package.json
@@ -21,7 +21,6 @@
   },
   "peerDependencies": {
     "@bugsnag/browser-performance": "*",
-    "path-to-regexp": "^1.8.0",
     "vue-router": "^4.2.4"
   },
   "type": "module",

--- a/packages/vue-router/tests/vue-router-routing-provider.test.ts
+++ b/packages/vue-router/tests/vue-router-routing-provider.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import type { Router } from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
 import { VueRouterRoutingProvider } from '../lib/vue-router-routing-provider'
 import { MockSpanFactory } from '@bugsnag/js-performance-test-utilities'
 import type { RouteChangeSpan, StartRouteChangeCallback } from '@bugsnag/browser-performance'
@@ -15,15 +15,15 @@ describe('VueRouterRoutingProvider', () => {
   const routes = [
     {
       path: '/',
-      element: '<Root />',
+      component: { template: '<Root />' },
       children: [
         {
           path: 'contacts/:contactId',
-          element: '<Contact />',
+          component: { template: '<Contact />' },
           children: [
             {
               path: 'edit',
-              element: '<EditContact />'
+              component: { template: '<EditContact />' }
             }
           ]
         }
@@ -31,12 +31,14 @@ describe('VueRouterRoutingProvider', () => {
     }
   ]
 
-  const router = {
-    getRoutes () {
-      return routes
-    },
-    beforeResolve: jest.fn()
-  } as unknown as Router
+  const router = createRouter({
+    history: createWebHistory(),
+    routes
+  })
+
+  beforeEach(() => {
+    router.beforeResolve = jest.fn()
+  })
 
   describe('listenForRouteChanges', () => {
     it('attaches a handler to the beforeResolve event and calls startRouteChangeSpan when fired', () => {
@@ -128,7 +130,7 @@ describe('VueRouterRoutingProvider', () => {
   })
 
   describe('resolveRoute', () => {
-    it('uses the provided routes when resolving routes', () => {
+    it('resolves a URL to the expected route', () => {
       const routingProvider = new VueRouterRoutingProvider(router)
 
       expect(routingProvider.resolveRoute(new URL('/contacts/2', window.origin))).toBe('/contacts/:contactId')

--- a/test/browser/features/fixtures/packages/vue-router/src/App.vue
+++ b/test/browser/features/fixtures/packages/vue-router/src/App.vue
@@ -6,7 +6,8 @@ import { RouterLink, RouterView } from 'vue-router'
   <header>
     <nav>
       <RouterLink to="/">Home</RouterLink>
-      <RouterLink id="change-route" to="/contacts/1">change-route</RouterLink>
+      <br />
+      <RouterLink id="contact" to="/contacts/1">Contact</RouterLink>
     </nav>
   </header>
 

--- a/test/browser/features/fixtures/packages/vue-router/src/main.js
+++ b/test/browser/features/fixtures/packages/vue-router/src/main.js
@@ -20,9 +20,16 @@ const router = createRouter({
       component: HomeView
     },
     {
-      path: '/contacts/:contactId',
+      path: '/contacts/:contactId()',
       name: 'contact',
-      component: () => import('./views/ContactView.vue')
+      component: () => import('./views/ContactView.vue'),
+      children: [
+        {
+          path: 'profile',
+          name: 'profile', 
+          component: () => import('./views/ContactProfile.vue')
+        }
+      ]
     }
   ]
 })
@@ -31,7 +38,7 @@ const router = createRouter({
 BugsnagPerformance.start({
     apiKey,
     endpoint,
-    maximumBatchSize: 13,
+    maximumBatchSize: 14,
     batchInactivityTimeoutMs: 5000,
     autoInstrumentNetworkRequests: false,
     routingProvider: new VueRouterRoutingProvider(router, base)

--- a/test/browser/features/fixtures/packages/vue-router/src/views/ContactProfile.vue
+++ b/test/browser/features/fixtures/packages/vue-router/src/views/ContactProfile.vue
@@ -1,0 +1,12 @@
+<script setup>
+import { onMounted } from 'vue'
+
+onMounted(() => { document.title = 'Contact Profile'; })
+</script>
+
+<template>
+  <div>
+    <h1>Contact {{ $route.params.contactId }} Profile</h1>
+  </div>
+</template>
+

--- a/test/browser/features/fixtures/packages/vue-router/src/views/ContactView.vue
+++ b/test/browser/features/fixtures/packages/vue-router/src/views/ContactView.vue
@@ -1,12 +1,15 @@
 <script setup>
 import { onMounted } from 'vue'
+import { RouterLink, RouterView } from 'vue-router'
 
 onMounted(() => { document.title = 'Contact 1'; })
 </script>
 
 <template>
   <div>
-    <h1>Contact 1</h1>
+    <h1>Contact {{ $route.params.contactId }}</h1>
   </div>
+  <RouterLink id="profile" :to="{ name: 'profile' }">Profile</RouterLink>
+  <RouterView />
 </template>
 

--- a/test/browser/features/vue-router.feature
+++ b/test/browser/features/vue-router.feature
@@ -2,19 +2,28 @@ Feature: Vue router
 
     Scenario: Route change spans are automatically instrumented
         Given I navigate to the test URL "/vue-router"
-        And I click the element "change-route"
+        And I click the element "contact"
+        And I click the element "profile"
         When I wait to receive 1 trace
 
         Then a span named "[FullPageLoad]/" contains the attributes:
-            | attribute                         | type             | value                    |
-            | bugsnag.span.category             | stringValue      | full_page_load           |
-            | bugsnag.browser.page.title        | stringValue      | Vue router             |
-            | bugsnag.browser.page.route        | stringValue      | /                        |
+            | attribute                         | type             | value                              |
+            | bugsnag.span.category             | stringValue      | full_page_load                     |
+            | bugsnag.browser.page.title        | stringValue      | Vue router                         |
+            | bugsnag.browser.page.route        | stringValue      | /                                  |
 
-        And a span named "[RouteChange]/contacts/:contactId" contains the attributes: 
-            | attribute                                 | type         | value                | 
-            | bugsnag.span.category                     | stringValue  | route_change         |
-            | bugsnag.browser.page.title                | stringValue  | Contact 1            |
-            | bugsnag.browser.page.route                | stringValue  | /contacts/:contactId |
-            | bugsnag.browser.page.previous_route       | stringValue  | /                    |
-            | bugsnag.browser.page.route_change.trigger | stringValue  | beforeResolve        |
+        And a span named "[RouteChange]/contacts/:contactId()" contains the attributes: 
+            | attribute                                 | type         | value                          | 
+            | bugsnag.span.category                     | stringValue  | route_change                   |
+            | bugsnag.browser.page.title                | stringValue  | Contact 1                      |
+            | bugsnag.browser.page.route                | stringValue  | /contacts/:contactId()         |
+            | bugsnag.browser.page.previous_route       | stringValue  | /                              |
+            | bugsnag.browser.page.route_change.trigger | stringValue  | beforeResolve                  |
+
+        And a span named "[RouteChange]/contacts/:contactId()/profile" contains the attributes: 
+            | attribute                                 | type         | value                          | 
+            | bugsnag.span.category                     | stringValue  | route_change                   |
+            | bugsnag.browser.page.title                | stringValue  | Contact Profile                |
+            | bugsnag.browser.page.route                | stringValue  | /contacts/:contactId()/profile |
+            | bugsnag.browser.page.previous_route       | stringValue  | /contacts/:contactId()         |
+            | bugsnag.browser.page.route_change.trigger | stringValue  | beforeResolve                  |


### PR DESCRIPTION
## Goal

Replace the usage of `path-to-regexp` and use Vue's `router.resolve` to resolve routes in `VueRoutingProvider`.

Fixes an issue where routes with parantheses (generated by nuxt) were failing to resolve (see #460)

## Design

v4 of `vue-router` (which we depend on) no longer uses `path-to-regexp` internally to parse routes, and now uses its own parsing system that supports dynamic routing. 

The router object has a `resolve` method that seems to do what we need (find a corresponding route from a given URL) - and also removes the need to flatten routes when resolving.

## Changeset

- Removed path-to-regexp dependency
- Updated resolveRoute to use Vue's router.resolve
- Updated e2e tests to test nested routes and routes with parentheses

## Testing

Updated the e2e tests to include a nested route and a route with parentheses