### PR TITLE
Add serviceName config option for browser and ensure service.name attribute is always set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+(browser) - Add serviceName config option for browser and ensure service.name attribute is always set [#477](https://github.com/bugsnag/bugsnag-js-performance/pull/477)
+
 ## [v2.7.1] (2024-07-16)
 
 ### Changed

--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -32,11 +32,12 @@ export class SpanAttributes {
 }
 
 export class ResourceAttributes extends SpanAttributes {
-  constructor (releaseStage: string, appVersion: string, sdkName: string, sdkVersion: string) {
+  constructor (releaseStage: string, appVersion: string, serviceName: string, sdkName: string, sdkVersion: string) {
     const initialValues = new Map([
       ['deployment.environment', releaseStage],
       ['telemetry.sdk.name', sdkName],
-      ['telemetry.sdk.version', sdkVersion]
+      ['telemetry.sdk.version', sdkVersion],
+      ['service.name', serviceName]
     ])
 
     if (appVersion.length > 0) {

--- a/packages/core/tests/delivery.test.ts
+++ b/packages/core/tests/delivery.test.ts
@@ -56,6 +56,7 @@ describe('TracePayloadEncoder', () => {
                 { key: 'deployment.environment', value: { stringValue: 'test' } },
                 { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.core' } },
                 { key: 'telemetry.sdk.version', value: { stringValue: '1.2.3' } },
+                { key: 'service.name', value: { stringValue: 'unknown_service' } },
                 { key: 'service.version', value: { stringValue: '3.4.5' } }
               ]
             },

--- a/packages/platforms/browser/lib/config.ts
+++ b/packages/platforms/browser/lib/config.ts
@@ -1,8 +1,8 @@
 import {
   isBoolean,
+  isStringWithLength,
   isStringOrRegExpArray,
   schema
-
 } from '@bugsnag/core-performance'
 import type { ConfigOption, Configuration, CoreSchema } from '@bugsnag/core-performance'
 import { defaultNetworkRequestCallback, isNetworkRequestCallback } from '@bugsnag/request-tracker-performance'
@@ -22,6 +22,7 @@ export interface BrowserSchema extends CoreSchema {
   settleIgnoreUrls: ConfigOption<Array<string | RegExp>>
   networkRequestCallback: ConfigOption<NetworkRequestCallback<BrowserNetworkRequestInfo>>
   sendPageAttributes: ConfigOption<SendPageAttributes>
+  serviceName: ConfigOption<string>
 }
 
 export interface BrowserConfiguration extends Configuration {
@@ -33,6 +34,7 @@ export interface BrowserConfiguration extends Configuration {
   settleIgnoreUrls?: Array<string | RegExp>
   networkRequestCallback?: NetworkRequestCallback<BrowserNetworkRequestInfo>
   sendPageAttributes?: SendPageAttributes
+  serviceName?: string
 }
 
 export function createSchema (hostname: string, defaultRoutingProvider: RoutingProvider): BrowserSchema {
@@ -81,6 +83,11 @@ export function createSchema (hostname: string, defaultRoutingProvider: RoutingP
       defaultValue: defaultSendPageAttributes,
       message: 'should be an object',
       validate: isSendPageAttributes
+    },
+    serviceName: {
+      defaultValue: 'unknown_service',
+      message: 'should be a string',
+      validate: isStringWithLength
     }
   }
 }

--- a/packages/platforms/browser/lib/resource-attributes-source.ts
+++ b/packages/platforms/browser/lib/resource-attributes-source.ts
@@ -14,6 +14,7 @@ function createResourceAttributesSource (
     const attributes = new ResourceAttributes(
       config.releaseStage,
       config.appVersion,
+      config.serviceName,
       'bugsnag.performance.browser',
       '__VERSION__'
     )

--- a/packages/platforms/browser/tests/config.test.ts
+++ b/packages/platforms/browser/tests/config.test.ts
@@ -50,4 +50,11 @@ describe('createSchema', () => {
       expect(validate(value)).toBe(expected)
     })
   })
+
+  describe('serviceName', () => {
+    it('defaults to unknown_service', () => {
+      const schema = createSchema('', new MockRoutingProvider())
+      expect(schema.serviceName.defaultValue).toBe('unknown_service')
+    })
+  })
 })

--- a/packages/platforms/browser/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/resource-attributes-source.test.ts
@@ -21,7 +21,7 @@ describe('resourceAttributesSource', () => {
 
     const resourceAttributesSource = createResourceAttributesSource(navigator, persistence)
     const resourceAttributes = await resourceAttributesSource(
-      createConfiguration<BrowserConfiguration>({ releaseStage: 'test', appVersion: '1.0.0' })
+      createConfiguration<BrowserConfiguration>({ releaseStage: 'test', appVersion: '1.0.0', serviceName: 'test' })
     )
 
     // ensure the anyonmous ID hasn't changed
@@ -31,6 +31,7 @@ describe('resourceAttributesSource', () => {
       { key: 'deployment.environment', value: { stringValue: 'test' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'service.name', value: { stringValue: 'test' } },
       { key: 'service.version', value: { stringValue: '1.0.0' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
       { key: 'device.id', value: { stringValue: 'c1234567890abcdefghijklmnop' } }
@@ -51,6 +52,7 @@ describe('resourceAttributesSource', () => {
       { key: 'deployment.environment', value: { stringValue: 'production' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'service.name', value: { stringValue: 'unknown_service' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
       { key: 'device.id', value: { stringValue: expect.stringMatching(/^c[0-9a-z]{20,32}$/) } }
     ])
@@ -73,6 +75,7 @@ describe('resourceAttributesSource', () => {
       { key: 'deployment.environment', value: { stringValue: 'production' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'service.name', value: { stringValue: 'unknown_service' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
       { key: 'browser.platform', value: { stringValue: 'macOS' } },
       { key: 'browser.mobile', value: { boolValue: false } },
@@ -100,6 +103,7 @@ describe('resourceAttributesSource', () => {
       { key: 'deployment.environment', value: { stringValue: 'production' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'service.name', value: { stringValue: 'unknown_service' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
       { key: 'device.id', value: { stringValue: deviceId } }
     ])
@@ -139,6 +143,7 @@ describe('resourceAttributesSource', () => {
       { key: 'deployment.environment', value: { stringValue: 'production' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'service.name', value: { stringValue: 'unknown_service' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } },
       { key: 'device.id', value: { stringValue: deviceId } }
     ])
@@ -179,6 +184,7 @@ describe('resourceAttributesSource', () => {
       { key: 'deployment.environment', value: { stringValue: 'production' } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'bugsnag.performance.browser' } },
       { key: 'telemetry.sdk.version', value: { stringValue: '__VERSION__' } },
+      { key: 'service.name', value: { stringValue: 'unknown_service' } },
       { key: 'browser.user_agent', value: { stringValue: navigator.userAgent } }
       // the device.id attribute should not exist
     ])

--- a/packages/platforms/react-native/lib/resource-attributes-source.ts
+++ b/packages/platforms/react-native/lib/resource-attributes-source.ts
@@ -13,6 +13,7 @@ export default function resourceAttributesSourceFactory (persistence: Persistenc
     const attributes = new ResourceAttributes(
       config.releaseStage,
       config.appVersion,
+      deviceInfo?.bundleIdentifier || 'unknown_service',
       'bugsnag.performance.reactnative',
       '__VERSION__'
     )
@@ -43,10 +44,6 @@ export default function resourceAttributesSourceFactory (persistence: Persistenc
 
       if (deviceInfo.model) {
         attributes.set('device.model.identifier', deviceInfo.model)
-      }
-
-      if (deviceInfo.bundleIdentifier) {
-        attributes.set('service.name', deviceInfo.bundleIdentifier)
       }
     }
 

--- a/packages/test-utilities/lib/create-configuration.ts
+++ b/packages/test-utilities/lib/create-configuration.ts
@@ -20,6 +20,7 @@ function createConfiguration<C extends Configuration> (overrides: Partial<C> = {
     },
     appVersion: '',
     networkRequestCallback: (networkRequestInfo: unknown) => networkRequestInfo,
+    serviceName: 'unknown_service',
     ...overrides
   } as unknown as InternalConfiguration<C>
 }

--- a/packages/test-utilities/lib/resource-attributes-source.ts
+++ b/packages/test-utilities/lib/resource-attributes-source.ts
@@ -2,7 +2,7 @@ import { ResourceAttributes } from '@bugsnag/core-performance'
 import type { Configuration, ResourceAttributeSource } from '@bugsnag/core-performance'
 
 const resourceAttributesSource: ResourceAttributeSource<Configuration> = async () => {
-  return new ResourceAttributes('test', '3.4.5', 'bugsnag.performance.core', '1.2.3')
+  return new ResourceAttributes('test', '3.4.5', 'unknown_service', 'bugsnag.performance.core', '1.2.3')
 }
 
 export default resourceAttributesSource

--- a/test/browser/features/fixtures/packages/manual-span/src/index.js
+++ b/test/browser/features/fixtures/packages/manual-span/src/index.js
@@ -5,7 +5,15 @@ const apiKey = parameters.get('api_key')
 const endpoint = parameters.get('endpoint')
 const reflectEndpoint = '/reflect?status=200&delay_ms=0'
 
-BugsnagPerformance.start({ apiKey, endpoint, maximumBatchSize: 1, autoInstrumentFullPageLoads: false, autoInstrumentNetworkRequests: false, autoInstrumentRouteChanges: false })
+BugsnagPerformance.start({
+  apiKey,
+  endpoint,
+  maximumBatchSize: 1,
+  autoInstrumentFullPageLoads: false,
+  autoInstrumentNetworkRequests: false,
+  autoInstrumentRouteChanges: false,
+  serviceName: 'manual-span'
+})
 
 document.getElementById('send-span').onclick = () => {
   const spanOptions = {}

--- a/test/browser/features/manual-spans.feature
+++ b/test/browser/features/manual-spans.feature
@@ -20,6 +20,7 @@ Feature: Manual creation of spans
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals the stored value "telemetry.sdk.version"
     And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals the stored value "environment"
     And the trace payload field "resourceSpans.0.resource" string attribute "device.id" matches the regex "^c[0-9a-z]{20,32}$"
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "manual-span"
 
   Scenario: isFirstClass span option can be set to false
     Given I navigate to the test URL "/manual-span?isFirstClass=false"
@@ -41,6 +42,7 @@ Feature: Manual creation of spans
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.browser"
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" equals the stored value "telemetry.sdk.version"
     And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals the stored value "environment"
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "manual-span"
 
   @chromium_only @local_only
   Scenario: userAgentData is included in custom span


### PR DESCRIPTION
## Goal

- Adds `service.name` as a core resource attribute
- Adds a new `serviceName` config option for the browser to allow users to configure this
- Ensures the `service.name` attribute is always set on all platforms

## Design

Added `service.name` to the core resource attribute class to ensure that it is set on all platforms (as it's a required attribute in the OTEL spec)

Previously this attribute was not being set on the browser package, so a new config option has been added for browser with a default value of `unknown_service`.

On React Native, service.name is set from the bundle identifier - this has been updated to fall back to `unknown_service` if native device info is unavailable for any reason.