### PR TITLE
React Native: Ensure native module is fully backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Added
 
-- (browser) - Add serviceName config option for browser and ensure service.name attribute is always set [#477](https://github.com/bugsnag/bugsnag-js-performance/pull/477)
+- (browser) Add serviceName config option for browser and ensure service.name attribute is always set [#477](https://github.com/bugsnag/bugsnag-js-performance/pull/477)
 
 ### Changed
 
-- (vue-router) - Use vue router to resolve routes [#476](https://github.com/bugsnag/bugsnag-js-performance/pull/476)
+- (vue-router) Use vue router to resolve routes [#476](https://github.com/bugsnag/bugsnag-js-performance/pull/476)
 - Update error correlation implementation to monkey patch the error notifier [#474](https://github.com/bugsnag/bugsnag-js-performance/pull/474)
+- (react-native) Ensure native module is fully backwards compatible [#478](https://github.com/bugsnag/bugsnag-js-performance/pull/478)
 
 ## [v2.7.1] (2024-07-16)
 

--- a/packages/platforms/react-native/BugsnagReactNativePerformance.podspec
+++ b/packages/platforms/react-native/BugsnagReactNativePerformance.podspec
@@ -15,5 +15,9 @@ Pod::Spec.new do |s|
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
 
-  install_modules_dependencies(s)
+  if ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+  end
 end

--- a/packages/platforms/react-native/BugsnagReactNativePerformance.podspec
+++ b/packages/platforms/react-native/BugsnagReactNativePerformance.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description     = package["description"]
   s.homepage        = package["homepage"]
   s.license         = package["license"]
-  s.platforms       = { :ios => "11.0" }
+  s.platforms       = { :ios => "10.0" }
   s.author          = { "Bugsnag" => "platforms@bugsnag.com" }
   s.source          = { :git => "https://github.com/bugsnag/bugsnag-js-performance.git", :tag => "v#{s.version}" }
 

--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -1,36 +1,32 @@
 def isNewArchitectureEnabled() {
-    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+  return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
-buildscript {
-  ext.safeExtGet = {prop, fallback ->
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-  }
-  repositories {
-    google()
-    gradlePluginPortal()
-  }
-  dependencies {
-    classpath("com.android.tools.build:gradle:7.3.1")
-  }
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.facebook.react'
+if (isNewArchitectureEnabled()) {
+  apply plugin: 'com.facebook.react'
+}
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 33)
-  namespace "com.bugsnag.reactnative.performance"
+  compileSdkVersion safeExtGet('compileSdkVersion', 29)
+
+  if (android.hasProperty('namespace')) {
+    namespace 'com.bugsnag.reactnative.performance'
+  }
 
   sourceSets {
-        main {
-            if (isNewArchitectureEnabled()) {
-                java.srcDirs += ['src/newarch/java']
-            } else {
-                java.srcDirs += ['src/oldarch/java']
-            }
-        }
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += ['src/newarch/java']
+      } else {
+        java.srcDirs += ['src/oldarch/java']
+      }
     }
+  }
 }
 
 repositories {

--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -1,3 +1,7 @@
+def isNewArchitectureEnabled() {
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
 buildscript {
   ext.safeExtGet = {prop, fallback ->
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -17,6 +21,16 @@ apply plugin: 'com.facebook.react'
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 33)
   namespace "com.bugsnag.reactnative.performance"
+
+  sourceSets {
+        main {
+            if (isNewArchitectureEnabled()) {
+                java.srcDirs += ['src/newarch/java']
+            } else {
+                java.srcDirs += ['src/oldarch/java']
+            }
+        }
+    }
 }
 
 repositories {

--- a/packages/platforms/react-native/android/src/main/AndroidManifest.xml
+++ b/packages/platforms/react-native/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.bugsnag.reactnative.performance">
+</manifest>

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
@@ -6,7 +6,6 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.bugsnag.reactnative.performance.NativeBugsnagPerformanceSpec;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -14,30 +13,24 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import java.security.SecureRandom;
 
-public class NativeBugsnagPerformanceImpl extends NativeBugsnagPerformanceSpec {
+class NativeBugsnagPerformanceImpl {
   
-  static final String NAME = "BugsnagReactNativePerformance";
+  static final String MODULE_NAME = "BugsnagReactNativePerformance";
   
+  private final ReactApplicationContext reactContext;
+
   private final SecureRandom random = new SecureRandom();
 
   public NativeBugsnagPerformanceImpl(ReactApplicationContext reactContext) {
-    super(reactContext);
+    this.reactContext = reactContext;
   }
 
-  @NonNull
-  @Override
-  public String getName() {
-    return NAME;
-  }
-
-  @Override
   public WritableMap getDeviceInfo() {
     WritableMap map = Arguments.createMap();
     try {
-      ReactApplicationContext reactContext = getReactApplicationContext();
-      String bundleIdentifier = reactContext.getPackageName();
+      String bundleIdentifier = this.reactContext.getPackageName();
       map.putString("bundleIdentifier", bundleIdentifier);
-      PackageInfo packageInfo = reactContext.getPackageManager().getPackageInfo(bundleIdentifier, 0);
+      PackageInfo packageInfo = this.reactContext.getPackageManager().getPackageInfo(bundleIdentifier, 0);
       map.putString("versionCode", Integer.toString(packageInfo.versionCode));
     } catch (Exception e) {
       // ignore
@@ -62,7 +55,6 @@ public class NativeBugsnagPerformanceImpl extends NativeBugsnagPerformanceSpec {
     return map;
   }
 
-  @Override
   public String requestEntropy() {
     byte[] bytes = new byte[1024];
     random.nextBytes(bytes);
@@ -78,7 +70,6 @@ public class NativeBugsnagPerformanceImpl extends NativeBugsnagPerformanceSpec {
     return hex.toString();
   }
 
-  @Override
   public void requestEntropyAsync(Promise promise) {
     promise.resolve(requestEntropy());
   }

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -1,0 +1,38 @@
+package com.bugsnag.reactnative.performance;
+
+import androidx.annotation.NonNull;
+import com.bugsnag.reactnative.performance.NativeBugsnagPerformanceSpec;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.WritableMap;
+
+public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec {
+  private final NativeBugsnagPerformanceImpl impl;
+
+  public BugsnagReactNativePerformance(ReactApplicationContext reactContext) {
+    super(reactContext);
+    impl = new NativeBugsnagPerformanceImpl(reactContext);
+  }
+
+  @NonNull
+  @Override
+  public String getName() {
+    return NativeBugsnagPerformanceImpl.MODULE_NAME;
+  }
+
+  @Override
+  public WritableMap getDeviceInfo() {
+    return impl.getDeviceInfo();
+  }
+
+  @Override
+  public String requestEntropy() {
+    return impl.requestEntropy();
+  }
+
+  @Override
+  public void requestEntropyAsync(Promise promise) {
+    impl.requestEntropyAsync(promise);
+  }
+}
+

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformancePackage.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformancePackage.java
@@ -16,8 +16,8 @@ public class BugsnagReactNativePerformancePackage extends TurboReactPackage {
   @Nullable
   @Override
   public NativeModule getModule(String name, ReactApplicationContext reactContext) {
-    if(name.equals(NativeBugsnagPerformanceImpl.NAME)) {
-      return new NativeBugsnagPerformanceImpl(reactContext);
+    if(name.equals(NativeBugsnagPerformanceImpl.MODULE_NAME)) {
+      return new BugsnagReactNativePerformance(reactContext);
     } else {
       return null;
     }
@@ -28,10 +28,10 @@ public class BugsnagReactNativePerformancePackage extends TurboReactPackage {
     return new ReactModuleInfoProvider() {
       public Map<String, ReactModuleInfo> getReactModuleInfos() {
         return Collections.singletonMap(
-          NativeBugsnagPerformanceImpl.NAME,
+          NativeBugsnagPerformanceImpl.MODULE_NAME,
           new ReactModuleInfo(
-            NativeBugsnagPerformanceImpl.NAME,
-            NativeBugsnagPerformanceImpl.NAME,
+            NativeBugsnagPerformanceImpl.MODULE_NAME,
+            NativeBugsnagPerformanceImpl.MODULE_NAME,
             false, // canOverrideExistingModule
             true,  // needsEagerInit
             false, // hasConstants

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -1,0 +1,39 @@
+package com.bugsnag.reactnative.performance;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+
+import java.util.Map;
+
+public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
+  
+  private final NativeBugsnagPerformanceImpl impl;
+
+  public BugsnagReactNativePerformance(ReactApplicationContext reactContext) {
+    super(reactContext);
+    this.impl = new NativeBugsnagPerformanceImpl(reactContext);
+  }
+
+  @Override
+  public String getName() {
+    return NativeBugsnagPerformanceImpl.MODULE_NAME;
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableMap getDeviceInfo() {
+    return impl.getDeviceInfo();
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public String requestEntropy() {
+    return impl.requestEntropy();
+  }
+
+  @ReactMethod
+  public void requestEntropyAsync(Promise promise) {
+    impl.requestEntropyAsync(promise);
+  }
+}

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformancePackage.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformancePackage.java
@@ -1,0 +1,22 @@
+package com.bugsnag.reactnative.performance;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class BugsnagReactNativePerformancePackage implements ReactPackage {
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Collections.<NativeModule>singletonList(new BugsnagReactNativePerformance(reactContext));
+    }
+}

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.xcodeproj/project.pbxproj
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.xcodeproj/project.pbxproj
@@ -1,0 +1,292 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		DAE18DD42C58DF2500D52529 /* BugsnagReactNativePerformance.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE18DD32C58DF2500D52529 /* BugsnagReactNativePerformance.m */; };
+		DAE18DD72C58E02C00D52529 /* BugsnagReactNativePerformance.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DAE18DD22C58DF2500D52529 /* BugsnagReactNativePerformance.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				DAE18DD72C58E02C00D52529 /* BugsnagReactNativePerformance.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libBugsnagReactNativePerformance.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugsnagReactNativePerformance.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAE18DD22C58DF2500D52529 /* BugsnagReactNativePerformance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagReactNativePerformance.h; sourceTree = "<group>"; };
+		DAE18DD32C58DF2500D52529 /* BugsnagReactNativePerformance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagReactNativePerformance.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libBugsnagReactNativePerformance.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				DAE18DD22C58DF2500D52529 /* BugsnagReactNativePerformance.h */,
+				DAE18DD32C58DF2500D52529 /* BugsnagReactNativePerformance.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* BugsnagReactNativePerformance */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "BugsnagReactNativePerformance" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BugsnagReactNativePerformance;
+			productName = BugsnagReactNativePerformance;
+			productReference = 134814201AA4EA6300B7C361 /* libBugsnagReactNativePerformance.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "BugsnagReactNativePerformance" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				58B511DA1A9E6C8500147676 /* BugsnagReactNativePerformance */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE18DD42C58DF2500D52529 /* BugsnagReactNativePerformance.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = BugsnagReactNativePerformance;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = BugsnagReactNativePerformance;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "BugsnagReactNativePerformance" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "BugsnagReactNativePerformance" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}

--- a/packages/platforms/react-native/lib/native.ts
+++ b/packages/platforms/react-native/lib/native.ts
@@ -1,6 +1,14 @@
-import { TurboModuleRegistry } from 'react-native'
+import { TurboModuleRegistry, NativeModules } from 'react-native'
 import type { Spec } from './NativeBugsnagPerformance'
 
-const NativeBugsnagPerformance = TurboModuleRegistry.get('BugsnagReactNativePerformance')
+declare const global: {
+  __turboModuleProxy: any
+}
+
+const isTurboModuleEnabled = () => global.__turboModuleProxy != null
+
+export const NativeBugsnagPerformance = isTurboModuleEnabled()
+  ? TurboModuleRegistry.get('BugsnagReactNativePerformance')
+  : NativeModules.BugsnagReactNativePerformance
 
 export default NativeBugsnagPerformance as Spec | null


### PR DESCRIPTION
## Goal

Refactors the native module in the React Native package to ensure full backwards compatibility with the Old Architecture.

## Design

- Android codebase has been updated so that the New Architecture types are not compiled when not available. 
- iOS podspec has been updated to ensure the correct dependencies are installed on Old Architecture.
- `native.ts` has been updated to load the native module from the old NativeModules API if turbo modules are not enabled. 

## Testing

Covered by a full CI run