### PR TITLE
feat(react-native): support react-native-file-access v1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19407,19 +19407,6 @@
         "node": "14 || >=16.14"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "dev": true,
@@ -24257,13 +24244,13 @@
         "@react-native-community/netinfo": "^9.4.1",
         "@types/react": "^18.2.24",
         "metro-react-native-babel-preset": "^0.77.0",
-        "react-native-file-access": "^3.0.4"
+        "react-native-file-access": ">=1.7.1"
       },
       "peerDependencies": {
         "@react-native-community/netinfo": ">= 9.4.1",
         "react": "*",
         "react-native": "*",
-        "react-native-file-access": "^3.0.4"
+        "react-native-file-access": ">=1.7.1"
       }
     },
     "packages/platforms/react-native/node_modules/metro-react-native-babel-preset": {
@@ -24388,7 +24375,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@bugsnag/browser-performance": "*",
-        "path-to-regexp": "^1.8.0",
         "vue-router": "^4.2.4"
       }
     }

--- a/packages/platforms/react-native/lib/persistence/file-utils.ts
+++ b/packages/platforms/react-native/lib/persistence/file-utils.ts
@@ -1,0 +1,96 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 alpha0010
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * https://github.com/alpha0010/react-native-file-access/blob/7179426e701fa6e54bda6c2a753cfe31a4a08293/LICENSE
+ */
+
+// Copied from v3.1.0:
+// https://github.com/alpha0010/react-native-file-access/blob/v3.1.0/src/util.ts
+
+/**
+ * Escape for use as literal string in a regex.
+ */
+function regexEscape (literal: string) {
+  return literal.replace(/[\^$\\.*+?()[\]{}|]/g, '\\$&')
+}
+
+/**
+ * Condense consecutive separators.
+ */
+function normalizeSeparator (path: string, separator: string) {
+  const sepRe = new RegExp(`(${regexEscape(separator)}){2,}`, 'g')
+  return path.replace(sepRe, separator.replace(/\$/g, '$$$$'))
+}
+
+/**
+ * Split path on last separator.
+ */
+function splitPath (path: string, separator: string) {
+  let norm = normalizeSeparator(path, separator)
+  if (norm === separator) {
+    return { dir: separator, base: '' }
+  }
+  if (norm.endsWith(separator)) {
+    norm = norm.substring(0, norm.length - separator.length)
+  }
+  const idx = norm.lastIndexOf(separator)
+  if (idx === -1) {
+    return { dir: '.', base: norm }
+  }
+  return {
+    dir: norm.substring(0, idx),
+    base: norm.substring(idx + separator.length)
+  }
+}
+
+export const Util = {
+  /**
+   * Get the file/folder name from the end of the path.
+   */
+  basename (path: string, separator = '/') {
+    return splitPath(path, separator).base
+  },
+
+  /**
+   * Get the path containing the file/folder.
+   */
+  dirname (path: string, separator = '/') {
+    return splitPath(path, separator).dir
+  },
+
+  /**
+   * Get the file extension.
+   */
+  extname (path: string, separator = '/') {
+    const extIdx = path.lastIndexOf('.')
+    if (extIdx <= 0) {
+      return ''
+    }
+
+    const sepIdx = path.lastIndexOf(separator)
+    if (sepIdx === -1 || extIdx > sepIdx + separator.length) {
+      return path.substring(extIdx + 1)
+    }
+    return ''
+  }
+}

--- a/packages/platforms/react-native/lib/persistence/file.ts
+++ b/packages/platforms/react-native/lib/persistence/file.ts
@@ -1,6 +1,6 @@
 import { isObject } from '@bugsnag/core-performance'
 import type { FileSystem } from 'react-native-file-access'
-import { Util } from 'react-native-file-access'
+import { Util } from './file-utils'
 
 export interface ReadableFile {
   read: () => Promise<string>

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -24,13 +24,13 @@
     "@react-native-community/netinfo": "^9.4.1",
     "@types/react": "^18.2.24",
     "metro-react-native-babel-preset": "^0.77.0",
-    "react-native-file-access": "^3.0.4"
+    "react-native-file-access": ">=1.7.1"
   },
   "peerDependencies": {
     "@react-native-community/netinfo": ">= 9.4.1",
     "react": "*",
     "react-native": "*",
-    "react-native-file-access": "^3.0.4"
+    "react-native-file-access": ">=1.7.1"
   },
   "scripts": {
     "build": "rollup --config",


### PR DESCRIPTION
## Goal

Adds support for older versions of react-native-file-access:

- Loosens the peer dependency version requirements to <=1.7.1 (latest version that supports RN 0.64)
- Vendor the file utility functions that were added in v2.3.0 of react-native-file-access to ensure backwards compatibility

## Testing

Relied on existing tests