### PR TITLE
refactor(react-native): use batch time for filenames in retry queue

### DIFF
--- a/packages/platforms/react-native/lib/retry-queue/directory.ts
+++ b/packages/platforms/react-native/lib/retry-queue/directory.ts
@@ -21,12 +21,18 @@ function filenameSorter (a: string, b: string): number {
     return -1
   }
 
-  if (aTimestamp > bTimestamp) {
-    return -1
+  const delta = bTimestamp - aTimestamp
+  if (delta !== 0) {
+    return delta
   }
 
-  if (aTimestamp < bTimestamp) {
+  // if timestamps are equal fall back to default string sorting
+  if (a > b) {
     return 1
+  }
+
+  if (a < b) {
+    return -1
   }
 
   return 0

--- a/packages/platforms/react-native/lib/retry-queue/file-based.ts
+++ b/packages/platforms/react-native/lib/retry-queue/file-based.ts
@@ -8,25 +8,18 @@ import type {
 import type Directory from './directory'
 import timestampFromFilename from './timestamp-from-filename'
 
-function getLatestSpan (body: DeliveryPayload): DeliverySpan | undefined {
-  let latestSpan: DeliverySpan | undefined
-  let biggestTimestamp: bigint | undefined
+function getLastSpan (body: DeliveryPayload): DeliverySpan | undefined {
+  let lastSpan: DeliverySpan | undefined
 
   for (const resourceSpan of body.resourceSpans) {
     for (const scopeSpan of resourceSpan.scopeSpans) {
       for (const span of scopeSpan.spans) {
-        if (biggestTimestamp === undefined || BigInt(span.endTimeUnixNano) > biggestTimestamp) {
-          latestSpan = span
-
-          // store the biggest timestamp separately as a bigint so we don't need
-          // to parse it on every iteration
-          biggestTimestamp = BigInt(latestSpan.endTimeUnixNano)
-        }
+        lastSpan = span
       }
     }
   }
 
-  return latestSpan
+  return lastSpan
 }
 
 function isValidFilename (filename: string): boolean {
@@ -42,18 +35,18 @@ function isValidFilename (filename: string): boolean {
     return false
   }
 
-  const nowInNanoseconds = BigInt(Date.now()) * NANOSECONDS_IN_MILLISECONDS
+  const now = Date.now()
 
   // files that are older than 24 hours are not valid as the data may not be
   // relevant anymore
-  if (timestamp < nowInNanoseconds - NANOSECONDS_IN_DAY) {
+  if (timestamp < now - MILLISECONDS_IN_DAY) {
     return false
   }
 
   // files that have a timestamp more than 24 hours in the future are not
   // valid as something may have gone wrong with the clock and this is
   // unlikely to be a timezone issue
-  if (timestamp > nowInNanoseconds + NANOSECONDS_IN_DAY) {
+  if (timestamp > now + MILLISECONDS_IN_DAY) {
     return false
   }
 
@@ -63,8 +56,7 @@ function isValidFilename (filename: string): boolean {
 // the minimum possible length of a payload filename (i.e. a 1 character
 // timestamp and span ID)
 const MININUM_FILENAME_LENGTH = 'retry-0-0.json'.length
-const NANOSECONDS_IN_MILLISECONDS = BigInt(1_000_000)
-const NANOSECONDS_IN_DAY = BigInt(24 * 60 * 60_000) * NANOSECONDS_IN_MILLISECONDS
+const MILLISECONDS_IN_DAY = 24 * 60 * 60_000
 
 // the outcome of flushing a single file — either delete it (e.g. success or
 // permanent failure) or leave it alone for the next flush (retryable failure)
@@ -80,18 +72,17 @@ export default class FileBasedRetryQueue implements RetryQueue {
     this.directory = directory
   }
 
-  async add (payload: TracePayload, _time: number): Promise<void> {
-    const span = getLatestSpan(payload.body)
+  async add (payload: TracePayload, time: number): Promise<void> {
+    const span = getLastSpan(payload.body)
 
     if (!span) {
       return
     }
 
-    // we use the latest span's timestamp in the filename so we can decide
-    // whether to keep or discard the span without parsing the payload
-    // as we can't be sure of nanosecond precision in JS environments, we also
-    // append the span ID so file names are unique across batches
-    const filename = `retry-${span.endTimeUnixNano}-${span.spanId}.json`
+    // we use the batch time in the filename so we can decide
+    // whether to keep or discard the file without parsing the payload,
+    // along with the last span's ID so file names are unique across batches
+    const filename = `retry-${time}-${span.spanId}.json`
 
     try {
       const json = JSON.stringify(payload)

--- a/packages/platforms/react-native/lib/retry-queue/file-based.ts
+++ b/packages/platforms/react-native/lib/retry-queue/file-based.ts
@@ -9,17 +9,15 @@ import type Directory from './directory'
 import timestampFromFilename from './timestamp-from-filename'
 
 function getLastSpan (body: DeliveryPayload): DeliverySpan | undefined {
-  let lastSpan: DeliverySpan | undefined
-
-  for (const resourceSpan of body.resourceSpans) {
-    for (const scopeSpan of resourceSpan.scopeSpans) {
-      for (const span of scopeSpan.spans) {
-        lastSpan = span
+  for (let i = body.resourceSpans.length - 1; i >= 0; i--) {
+    const resourceSpan = body.resourceSpans[i]
+    for (let j = resourceSpan.scopeSpans.length - 1; j >= 0; j--) {
+      const scopeSpan = resourceSpan.scopeSpans[j]
+      if (scopeSpan.spans.length > 0) {
+        return scopeSpan.spans[scopeSpan.spans.length - 1]
       }
     }
   }
-
-  return lastSpan
 }
 
 function isValidFilename (filename: string): boolean {

--- a/packages/platforms/react-native/lib/retry-queue/timestamp-from-filename.ts
+++ b/packages/platforms/react-native/lib/retry-queue/timestamp-from-filename.ts
@@ -1,9 +1,9 @@
 const FILENAME_REGEX = /^retry-([0-9]+)-.+\.json$/
 
-export default function timestampFromFilename (filename: string): bigint | undefined {
+export default function timestampFromFilename (filename: string): number | undefined {
   const match = FILENAME_REGEX.exec(filename)
 
   if (match) {
-    return BigInt(match[1])
+    return Number(match[1])
   }
 }

--- a/packages/platforms/react-native/tests/retry-queue/directory.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/directory.test.ts
@@ -11,15 +11,17 @@ describe('RetryQueueDirectory', () => {
 
       await Promise.all([
         fileSystem.writeFile('/a/b/c/retry-1-d.json', ''),
+        fileSystem.writeFile('/a/b/c/retry-3-b.json', ''),
         fileSystem.writeFile('/a/b/c/retry-4-z.json', ''),
-        fileSystem.writeFile('/a/b/c/retry-3-a.json', ''),
+        fileSystem.writeFile('/a/b/c/retry-1-a.json', ''),
         fileSystem.writeFile('/a/b/c/retry-2-x.json', '')
       ])
 
       expect(await directory.files()).toStrictEqual([
         'retry-4-z.json',
-        'retry-3-a.json',
+        'retry-3-b.json',
         'retry-2-x.json',
+        'retry-1-a.json',
         'retry-1-d.json'
       ])
     })

--- a/packages/platforms/react-native/tests/retry-queue/index.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/index.test.ts
@@ -33,11 +33,12 @@ describe('File based retry queue factory', () => {
 
     const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
     const payload = createPayload({ spanId: 'abcd', endTimeUnixNano: validEndTime.toString() })
-    queue.add(payload, 0)
+    const batchTime = Date.now()
+    queue.add(payload, batchTime)
 
     await flushPromises()
 
-    const file = await fileSystem.readFile(`${EXPECTED_PATH}/retry-${validEndTime}-abcd.json`)
+    const file = await fileSystem.readFile(`${EXPECTED_PATH}/retry-${batchTime}-abcd.json`)
     expect(JSON.parse(file)).toStrictEqual(payload)
 
     await queue.flush()
@@ -56,7 +57,7 @@ describe('File based retry queue factory', () => {
     const payload = createPayload({ spanId: 'xyz', endTimeUnixNano: validEndTime.toString() })
 
     await fileSystem.mkdir(EXPECTED_PATH)
-    await fileSystem.writeFile(`${EXPECTED_PATH}/retry-${validEndTime}-xyz.json`, JSON.stringify(payload))
+    await fileSystem.writeFile(`${EXPECTED_PATH}/retry-${Date.now()}-xyz.json`, JSON.stringify(payload))
 
     expect(delivery.requests).toHaveLength(0)
 
@@ -78,7 +79,7 @@ describe('File based retry queue factory', () => {
 
     const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
     const payload = createPayload({ spanId: 'abcd', endTimeUnixNano: validEndTime.toString() })
-    queue.add(payload, 0)
+    queue.add(payload, Date.now())
 
     expect(delivery.requests).toHaveLength(0)
 
@@ -100,7 +101,7 @@ describe('File based retry queue factory', () => {
 
     const validEndTime = BigInt(Date.now()) * BigInt(1_000_000)
     const payload = createPayload({ spanId: 'abcd', endTimeUnixNano: validEndTime.toString() })
-    queue.add(payload, 0)
+    queue.add(payload, Date.now())
 
     expect(delivery.requests).toHaveLength(0)
 

--- a/packages/platforms/react-native/tests/retry-queue/timestamp-from-filename.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/timestamp-from-filename.test.ts
@@ -9,12 +9,9 @@ describe('timestampFromFilename', () => {
     ['retry-00000000000-a.json', '0'],
     ['retry-999999999999999999999999999999999999-a.json', '999999999999999999999999999999999999']
   ])('parses %s into the timestamp %s', (input, expected) => {
-    // ideally we'd want to do something like this:
-    // expect(timestampFromFilename(input)).toBe(BigInt(expected))
-    // but Jest can't serialise BigInts yet so we have to use strings for now
     const actual = timestampFromFilename(input)
-
-    expect(actual?.toString()).toBe(expected)
+    expect(actual).toBe(Number(expected))
+    expect(Number.isNaN(actual)).toBe(false)
   })
 
   it.each([

--- a/packages/platforms/react-native/tests/retry-queue/timestamp-from-filename.test.ts
+++ b/packages/platforms/react-native/tests/retry-queue/timestamp-from-filename.test.ts
@@ -2,16 +2,14 @@ import timestampFromFilename from '../../lib/retry-queue/timestamp-from-filename
 
 describe('timestampFromFilename', () => {
   it.each([
-    ['retry-0-a.json', '0'],
-    ['retry-1-a.json', '1'],
-    ['retry-200000-a.json', '200000'],
-    ['retry-1234567890-a.json', '1234567890'],
-    ['retry-00000000000-a.json', '0'],
-    ['retry-999999999999999999999999999999999999-a.json', '999999999999999999999999999999999999']
+    ['retry-0-a.json', 0],
+    ['retry-1-a.json', 1],
+    ['retry-200000-a.json', 200000],
+    ['retry-1234567890-a.json', 1234567890],
+    ['retry-00000000000-a.json', 0],
+    ['retry-999999999999999999999999999999999999-a.json', 1e+36]
   ])('parses %s into the timestamp %s', (input, expected) => {
-    const actual = timestampFromFilename(input)
-    expect(actual).toBe(Number(expected))
-    expect(Number.isNaN(actual)).toBe(false)
+    expect(timestampFromFilename(input)).toBe(expected)
   })
 
   it.each([


### PR DESCRIPTION
## Goal

Replace usage of BigInt in the react native retry queue as this isn't supported on older versions of React Native (or more specifically on older versions of Hermes).

## Design

Instead of using nanosecond timestamps based on the largest span end time in the payload, the retry queue now uses the time the payload was added to the queue (in ms) for the filename. This is already being passed to `FileBasedRetryQueue#add` by the batch processor, but was previously an unused parameter.

Although it shouldn't really be possible for two files to be created with the same timestamp (as the time is recorded when a batch is flushed and a failed batch is only ever added to the retry queue once), the span ID of the last span in the payload is still used in the filename to ensure filenames are unique.

This also ensures backwards compatibility - the `timestampFromFilename` function used to parse filenames now simply returns a number instead of a bigint, so any existing retry files using nanosecond timestamps will still be parsed.

## Testing

Updated unit tests and relied on existing e2e tests