### PR TITLE
Add React Native 0.64 support

### DIFF
--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -4,24 +4,32 @@ steps:
       #
       # Test fixtures
       #
-      - label: ':android: Build RN {{matrix}} test fixture APK (Old Arch)'
+      - label: ':android: Build RN {{matrix.reactnative}} test fixture APK (Old Arch)'
         key: "build-react-native-android-fixture-old-arch-full"
         timeout_in_minutes: 30
         agents:
           queue: macos-14
         env:
-          JAVA_VERSION: "17"
+          JAVA_VERSION: "{{matrix.java}}"
           NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
+          RN_VERSION: "{{matrix.reactnative}}"
           BUILD_ANDROID: "true"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/old-arch/**/reactnative.apk"
         commands:
           - ./bin/generate-react-native-fixture
         matrix:
-          - "0.71"
-          - "0.72"
-          - "0.73"
+          setup:
+            reactnative:
+              - "0.71"
+              - "0.72"
+              - "0.73"
+            java:
+              - "17"
+          adjustments:
+            - with:
+                reactnative: "0.64"
+                java: "11"
         retry:
           automatic:
             - exit_status: "*"
@@ -67,6 +75,7 @@ steps:
           - bundle install
           - ./bin/generate-react-native-fixture
         matrix:
+          - "0.64"
           - "0.71"
           - "0.72"
           - "0.73"
@@ -130,6 +139,7 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
+          - "0.64"
           - "0.71"
           - "0.72"
           - "0.73"
@@ -194,6 +204,7 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
+          - "0.64"
           - "0.71"
           - "0.72"
           - "0.73"

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -40,17 +40,24 @@ const PACKAGE_DIRECTORIES = [
   `${ROOT_DIR}/test/react-native/features/fixtures/scenario-launcher`,
 ]
 
+// make sure we install a compatible versions of peer dependencies
+const reactNativeFileAccessVersion = parseFloat(rnVersion) <= 0.64 ? '1.7.1' : '3.1.0'
+const netinfoVersion = parseFloat(rnVersion) <= 0.64 ? '10.0.0' : '11.3.2'
 const DEPENDENCIES = [
-  '@react-native-community/netinfo',
   'react-native-dotenv',
-  'react-native-file-access@3.0.4' // Why this version specifically?
+  `@react-native-community/netinfo@${netinfoVersion}`,
+  `react-native-file-access@${reactNativeFileAccessVersion}`
 ]
 
+const reactNavigationVersion = parseFloat(rnVersion) <= 0.64 ? '6.1.18' : 'latest'
+const reactNavigationNativeStackVersion = parseFloat(rnVersion) <= 0.64 ? '6.11.0' : 'latest'
+const reactNativeScreensVersion = parseFloat(rnVersion) <= 0.64 ? '3.14.0' : 'latest'
+const reactNativeSafeAreaContextVersion = parseFloat(rnVersion) <= 0.64 ? '4.1.0' : 'latest'
 const REACT_NAVIGATION_DEPENDENCIES = [
-  '@react-navigation/native',
-  '@react-navigation/native-stack',
-  'react-native-screens',
-  'react-native-safe-area-context'
+  `@react-navigation/native@${reactNavigationVersion}`,
+  `@react-navigation/native-stack@${reactNavigationNativeStackVersion}`,
+  `react-native-screens@${reactNativeScreensVersion}`,
+  `react-native-safe-area-context@${reactNativeSafeAreaContextVersion}`
 ]
 
 if (!process.env.SKIP_BUILD_PACKAGES) {
@@ -72,8 +79,12 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
   const RNInitArgs = ['react-native@latest', 'init', 'reactnative', '--package-name', 'com.bugsnag.fixtures.reactnative.performance', '--directory', fixtureDir, '--version', rnVersion, '--npm', '--skip-install']
   execFileSync('npx', RNInitArgs, { stdio: 'inherit' })
   
-  // replace the App.tsx file with our own App.js file
-  fs.unlinkSync(resolve(fixtureDir, 'App.tsx'))
+  // replace the App.tsx/App.js file with our own App.js file
+  const appTsFilePath = resolve(fixtureDir, 'App.tsx')
+  const appJsFilePath = resolve(fixtureDir, 'App.js')
+  if (fs.existsSync(appTsFilePath)) fs.unlinkSync(appTsFilePath)
+  if (fs.existsSync(appJsFilePath)) fs.unlinkSync(appJsFilePath)
+
   fs.copyFileSync(
     resolve(ROOT_DIR, 'test/react-native/features/fixtures/app/App.js'),
     resolve(fixtureDir, 'App.js')
@@ -137,14 +148,19 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
   const fixtureDependencyArgs = DEPENDENCIES.join(' ')
 
   // install test fixture dependencies and local packages
-  execSync(`npm install --save ${fixtureDependencyArgs} *.tgz`, { cwd: fixtureDir, stdio: 'inherit' })
+  execSync(`npm install --save --save-exact ${fixtureDependencyArgs} *.tgz`, { cwd: fixtureDir, stdio: 'inherit' })
+
+  // apply additional modifications required for RN 0.64
+  if (parseFloat(rnVersion) === 0.64) {
+    configureRN064Fixture(fixtureDir)
+  }
 }
 
 if (process.env.BUILD_ANDROID === 'true' || process.env.BUILD_ANDROID === '1') {
   // build the android app
   execFileSync('./gradlew', ['assembleRelease'], { cwd: `${fixtureDir}/android`, stdio: 'inherit' })
   fs.copyFileSync(`${fixtureDir}/android/app/build/outputs/apk/release/app-release.apk`, `${fixtureDir}/reactnative.apk`)
-} 
+}
 
 if(process.env.BUILD_IOS === 'true' || process.env.BUILD_IOS === '1') {
   fs.rmSync(`${fixtureDir}/reactnative.xcarchive`, { recursive: true, force: true })
@@ -183,4 +199,50 @@ if(process.env.BUILD_IOS === 'true' || process.env.BUILD_IOS === '1') {
   ]
 
   execFileSync('xcrun', exportArgs, { cwd: fixtureDir, stdio: 'inherit' })
+}
+
+function configureRN064Fixture(fixtureDir) {
+  // Android
+  // Update build.gradle file - enable hermes and set --openssl-legacy-provider node option
+  const moduleGradlePath = resolve(fixtureDir, 'android/app/build.gradle')
+  let moduleGradle = fs.readFileSync(moduleGradlePath, 'utf8')
+
+  const currentReactConfig = `project.ext.react = [
+    enableHermes: false,  // clean and rebuild if changing
+]`
+
+  const updatedReactConfig = `project.ext.react = [
+    enableHermes: true,
+    nodeExecutableAndArgs: ["node", "--openssl-legacy-provider"]
+  ]`
+
+  moduleGradle = moduleGradle.replace(currentReactConfig, updatedReactConfig)
+  fs.writeFileSync(moduleGradlePath, moduleGradle)
+
+  // iOS
+  const podfilePath = resolve(fixtureDir, 'ios/Podfile')
+  let podfile = fs.readFileSync(podfilePath, 'utf8')
+
+  // disable flipper
+  podfile = podfile.replace("use_flipper!", "# use_flipper!")
+
+  // bump the minimum iOS version to 11
+  podfile = podfile.replace("platform :ios, '10.0'", "platform :ios, '11.0'")
+
+  fs.writeFileSync(podfilePath, podfile)
+
+  // set --openssl-legacy-provider node option in pbxproj file
+  const pbxprojPath = resolve(fixtureDir, 'ios/reactnative.xcodeproj/project.pbxproj')
+  let pbxproj = fs.readFileSync(pbxprojPath, 'utf8')
+  pbxproj = pbxproj.replace('export NODE_BINARY=node\\n', 'export NODE_BINARY=node\\nexport NODE_OPTIONS=--openssl-legacy-provider\\n')
+  fs.writeFileSync(pbxprojPath, pbxproj)
+
+  //  set --openssl-legacy-provider node option in .npmrc file (this is only needed for running the test fixture locally)
+  fs.writeFileSync(resolve(fixtureDir, '.npmrc'), 'node-options="--openssl-legacy-provider"\n')
+
+  // fix Yoga.cpp issue with Xcode 14.3+ (see https://github.com/facebook/react-native/issues/36758)
+  const yogaCppPath = resolve(fixtureDir, 'node_modules/react-native/ReactCommon/yoga/yoga/Yoga.cpp')
+  let yogaCpp = fs.readFileSync(yogaCppPath, 'utf8')
+  yogaCpp = yogaCpp.replace('node->getLayout().hadOverflow() |', 'node->getLayout().hadOverflow() ||')
+  fs.writeFileSync(yogaCppPath, yogaCpp)
 }

--- a/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
+++ b/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
@@ -5,7 +5,7 @@ import type {
   SpanFactory
 } from '@bugsnag/core-performance'
 import type { ReactNode } from 'react'
-import { useEffect } from 'react'
+import React from 'react'
 import type { AppRegistry, WrapperComponentProvider } from 'react-native'
 import type { ReactNativeConfiguration } from '../config'
 
@@ -42,7 +42,7 @@ export class AppStartPlugin implements Plugin<ReactNativeConfiguration> {
     appStartSpan.setAttribute('bugsnag.app_start.type', 'ReactNativeInit')
 
     const AppStartWrapper = ({ children }: WrapperProps) => {
-      useEffect(() => {
+      React.useEffect(() => {
         if (appStartSpan.isValid()) {
           this.spanFactory.endSpan(appStartSpan, this.clock.now())
         }

--- a/packages/plugin-react-navigation/lib/complete-navigation.tsx
+++ b/packages/plugin-react-navigation/lib/complete-navigation.tsx
@@ -34,5 +34,5 @@ export const CompleteNavigation: React.FC<Props> = ({ on, children }) => {
     }
   }, [on])
 
-  return children
+  return <>{children}</>
 }

--- a/test/react-native/features/fixtures/app/App.js
+++ b/test/react-native/features/fixtures/app/App.js
@@ -1,11 +1,11 @@
 import React, { useContext, useEffect } from 'react'
-import { SafeAreaView, StyleSheet, View, Text, RootTagContext } from 'react-native'
+import { SafeAreaView, StyleSheet, View, Text, RootTagContext, unstable_RootTagContext } from 'react-native'
 import { launchScenario } from '@bugsnag/react-native-performance-scenarios'
 
 console.reportErrorsAsExceptions = false
 
 const App = () => {
-  const rootTag = useContext(RootTagContext)
+  const rootTag = useContext(RootTagContext || unstable_RootTagContext)
 
   useEffect(() => {
     launchScenario(rootTag)

--- a/test/react-native/features/fixtures/app/android/AndroidManifest.xml
+++ b/test/react-native/features/fixtures/app/android/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.bugsnag.fixtures.reactnative.performance">
 
     <uses-permission android:name="android.permission.INTERNET" />
 		<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/test/react-native/features/fixtures/app/android/MainActivity.0.64.java
+++ b/test/react-native/features/fixtures/app/android/MainActivity.0.64.java
@@ -1,0 +1,25 @@
+package com.bugsnag.fixtures.reactnative.performance;
+
+import android.os.Bundle;
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+
+/**
+   * Required for react-navigation/native implementation
+   * https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project
+   */
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
+  }
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "reactnative";
+  }
+}

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -1,5 +1,6 @@
 import BugsnagPerformance from '@bugsnag/react-native-performance'
 import { REACT_APP_API_KEY, REACT_APP_ENDPOINT, REACT_APP_SCENARIO_NAME } from '@env'
+import React from 'react'
 import { AppRegistry } from 'react-native'
 import * as Scenarios from '../scenarios'
 import { getCurrentCommand } from './CommandRunner'

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/AppStartScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/AppStartScenario.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
 
 export const config = {

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/WrapperComponentProviderScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/WrapperComponentProviderScenario.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
 
 const wrapperComponentProvider = () =>  ({ children }) => {


### PR DESCRIPTION
## Goal

Adds React Native 0.64 tests to CI, and fixes a few minor issues found during testing. 

## Changeset

Changes have been cherry picked from https://github.com/bugsnag/bugsnag-js-performance/pull/483, with a couple of small tweaks:
-  0.64 tests now run as part of the 'full' CI pipeline
- Fixed some versions of react navigation dependencies in the test fixture generation script that were missed

## Testing

Covered by a full CI run