### PR TITLE
Set initial background state to foreground if initial app state is 'inactive'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Update error correlation implementation to monkey patch the error notifier [#474](https://github.com/bugsnag/bugsnag-js-performance/pull/474)
 - (react-native) Ensure native module is fully backwards compatible [#478](https://github.com/bugsnag/bugsnag-js-performance/pull/478)
 
+### Fixed
+
+- (react-native) Set initial background state to foreground if initial app state is 'inactive' [#491](https://github.com/bugsnag/bugsnag-js-performance/pull/491)
+
 ## [v2.7.1] (2024-07-16)
 
 ### Changed

--- a/packages/platforms/react-native/lib/backgrounding-listener.ts
+++ b/packages/platforms/react-native/lib/backgrounding-listener.ts
@@ -8,10 +8,7 @@ import type { AppStateStatic, AppStateStatus } from 'react-native'
 export default function createBrowserBackgroundingListener (appState: AppStateStatic) {
   const callbacks: BackgroundingListenerCallback[] = []
   let state: BackgroundingListenerState =
-  // on iOS the app state may be 'unknown' on launch, so we treat this as 'in-foreground'
-    appState.currentState === 'active' || appState.currentState === 'unknown'
-      ? 'in-foreground'
-      : 'in-background'
+    appState.currentState === 'background' ? 'in-background' : 'in-foreground'
 
   const backgroundingListener: BackgroundingListener = {
     onStateChange (backgroundingListenerCallback: BackgroundingListenerCallback): void {

--- a/packages/platforms/react-native/tests/backgrounding-listener.test.ts
+++ b/packages/platforms/react-native/tests/backgrounding-listener.test.ts
@@ -12,12 +12,12 @@ describe('React Native BackgroundingListener', () => {
     setAppState('active')
   })
 
-  it.each<AppStateStatus>(['background', 'inactive'])('calls the registered callback immediately when app state status is "%s" on registration', (status: AppStateStatus) => {
+  it('calls the registered callback immediately when app state status is "background" on registration', () => {
     const onStateChangeCallback = jest.fn()
 
     const listener = createBrowserBackgroundingListener(AppState)
 
-    setAppState(status)
+    setAppState('background')
 
     expect(onStateChangeCallback).not.toHaveBeenCalled()
 
@@ -27,7 +27,7 @@ describe('React Native BackgroundingListener', () => {
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
   })
 
-  it.each<AppStateStatus>(['active', 'unknown'])('does not call the registered callback immediately when app state status is "%s" on registration', (status: AppStateStatus) => {
+  it.each<AppStateStatus>(['active', 'inactive', 'unknown'])('does not call the registered callback immediately when app state status is "%s" on registration', (status: AppStateStatus) => {
     setAppState(status)
 
     const onStateChangeCallback = jest.fn()
@@ -43,10 +43,12 @@ describe('React Native BackgroundingListener', () => {
   it.each<AppStateStatus>(['background', 'inactive'])('calls the registered callback with "in-foreground" when app state status changes from "%s" to "active"', (status: AppStateStatus) => {
     const onStateChangeCallback = jest.fn()
 
-    setAppState(status)
-
     const listener = createBrowserBackgroundingListener(AppState)
     listener.onStateChange(onStateChangeCallback)
+
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+
+    setAppState(status)
 
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Goal

In React Native 0.74+, when an iOS app launches the initial `AppStateStatus` changed from `unknown` to `inactive`. This wasn't being accounted for in the backgrounding listener, so the initial background state was incorrectly being set to `in-background`. 

This PR updates the React Native backgrounding listener so that the app is considered in foreground on launch unless the initial app state is `background`.

## Design

When the backgrounding listener is created the initial app state is now only set to `in-background` if the initial app state status is explicitly `background` - any other initial state (`active`, `inactive`, or `unknown`) is considered `in-foreground`  until an app state change event occurs.

## Testing

Covered by unit tests and manual testing.

The current structure of the end-to-end test fixture means that we can't test this effectively since the app state status is always 'active' when the scenario runs. This will be addressed in a later PR.