### PR TITLE
Discard spans open for more than one hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- (core) Discard spans open for more than one hour [#494](https://github.com/bugsnag/bugsnag-js-performance/pull/494)
+
 ## [v2.8.0] (2024-08-20)
 
 ### Added

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -112,19 +112,26 @@ export class SpanFactory <C extends Configuration> {
     endTime: number,
     additionalAttributes?: Record<string, SpanAttribute>
   ) {
-    // if the span doesn't exist here it shouldn't be processed
-    if (!this.openSpans.delete(span)) {
-      // only warn if the span has already been ended explicitly rather than
-      // discarded by us
-      if (!span.isValid()) {
-        this.logger.warn('Attempted to end a Span which is no longer valid.')
-      }
+    // remove the span from the context stack (this will also remove any invalid spans)
+    this.spanContextStorage.pop(span)
 
-      return
+    const untracked = !this.openSpans.delete(span)
+    const isValidSpan = span.isValid()
+
+    // log a warning if the span is already invalid and is not being tracked
+    if (untracked && !isValidSpan) {
+      this.logger.warn('Attempted to end a Span which is no longer valid.')
     }
 
-    // Discard marked spans
-    if (endTime === DISCARD_END_TIME) return
+    // spans should be discarded if:
+    // - they are not tracked (i.e. discarded due to backgrounding)
+    // - they are already invalid
+    // - they have an explicit discard end time
+    if (untracked || !isValidSpan || endTime === DISCARD_END_TIME) {
+      // we still call end on the span so that it is no longer considered valid
+      span.end(endTime, this.sampler.spanProbability)
+      return
+    }
 
     // Set any additional attributes
     for (const [key, value] of Object.entries(additionalAttributes || {})) {
@@ -134,7 +141,6 @@ export class SpanFactory <C extends Configuration> {
     this.spanAttributesSource.requestAttributes(span)
 
     const spanEnded = span.end(endTime, this.sampler.spanProbability)
-    this.spanContextStorage.pop(span)
 
     if (this.sampler.sample(spanEnded)) {
       this.processor.add(spanEnded)

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -76,7 +76,7 @@ export class SpanFactory <C extends Configuration> {
       attributes.set('bugsnag.span.first_class', options.isFirstClass)
     }
 
-    const span = new SpanInternal(spanId, traceId, name, safeStartTime, attributes, parentSpanId)
+    const span = new SpanInternal(spanId, traceId, name, safeStartTime, attributes, this.clock, parentSpanId)
 
     // don't track spans that are started while the app is backgrounded
     if (this.isInForeground) {
@@ -117,7 +117,7 @@ export class SpanFactory <C extends Configuration> {
       // only warn if the span has already been ended explicitly rather than
       // discarded by us
       if (!span.isValid()) {
-        this.logger.warn('Attempted to end a Span which has already ended.')
+        this.logger.warn('Attempted to end a Span which is no longer valid.')
       }
 
       return

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -7,6 +7,8 @@ import type { Time } from './time'
 import traceIdToSamplingRate from './trace-id-to-sampling-rate'
 import { isBoolean, isSpanContext, isTime } from './validation'
 
+const HOUR_IN_MILLISECONDS = 60 * 60 * 1000
+
 export interface Span extends SpanContext {
   end: (endTime?: Time) => void
 }
@@ -70,10 +72,11 @@ export class SpanInternal implements SpanContext {
   private readonly kind = Kind.Client // TODO: How do we define the initial Kind?
   private readonly events = new SpanEvents()
   private readonly attributes: SpanAttributes
+  private readonly clock: Clock
   name: string
   private endTime?: number
 
-  constructor (id: string, traceId: string, name: string, startTime: number, attributes: SpanAttributes, parentSpanId?: string) {
+  constructor (id: string, traceId: string, name: string, startTime: number, attributes: SpanAttributes, clock: Clock, parentSpanId?: string) {
     this.id = id
     this.traceId = traceId
     this.parentSpanId = parentSpanId
@@ -81,6 +84,7 @@ export class SpanInternal implements SpanContext {
     this.startTime = startTime
     this.attributes = attributes
     this.samplingRate = traceIdToSamplingRate(this.traceId)
+    this.clock = clock
   }
 
   addEvent (name: string, time: number) {
@@ -119,7 +123,7 @@ export class SpanInternal implements SpanContext {
   }
 
   isValid () {
-    return this.endTime === undefined
+    return this.endTime === undefined && this.startTime > (this.clock.now() - HOUR_IN_MILLISECONDS)
   }
 }
 

--- a/packages/core/tests/span-context.test.ts
+++ b/packages/core/tests/span-context.test.ts
@@ -24,6 +24,17 @@ describe('SpanContext', () => {
       span.end()
       expect(span.isValid()).toEqual(false)
     })
+
+    it('returns false if the span start time is more than one hour in the past', () => {
+      const delivery = new InMemoryDelivery()
+      const clock = new IncrementingClock({ currentTime: Date.now() })
+      const client = createTestClient({ deliveryFactory: () => delivery, clock })
+      client.start({ apiKey: VALID_API_KEY })
+
+      const HOUR_IN_MILLISECONDS = 60 * 60 * 1000
+      const span = client.startSpan('test span', { startTime: Date.now() - HOUR_IN_MILLISECONDS })
+      expect(span.isValid()).toEqual(false)
+    })
   })
 })
 

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -109,12 +109,14 @@ describe('SpanInternal', () => {
 
   describe('bugsnag.sampling.p', () => {
     it.each([0.25, 0.5, 0.1, 1, 0, 0.4, 0.3])('is set to the correct value on "end"', (probability) => {
+      const clock = new IncrementingClock()
       const span = new SpanInternal(
         'span id',
         'trace id',
         'name',
         1234,
-        new SpanAttributes(new Map<string, SpanAttribute>())
+        new SpanAttributes(new Map<string, SpanAttribute>()),
+        clock
       )
 
       const endedSpan = span.end(5678, createSamplingProbability(probability))
@@ -124,12 +126,14 @@ describe('SpanInternal', () => {
     })
 
     it.each([0.25, 0.5, 0.1, 1, 0, 0.4, 0.3])('is updated when samplingProbability is changed', (probability) => {
+      const clock = new IncrementingClock()
       const span = new SpanInternal(
         'span id',
         'trace id',
         'name',
         1234,
-        new SpanAttributes(new Map<string, SpanAttribute>())
+        new SpanAttributes(new Map<string, SpanAttribute>()),
+        clock
       )
 
       const endedSpan = span.end(5678, createSamplingProbability(probability))
@@ -386,7 +390,7 @@ describe('Span', () => {
         kind: Kind.Client,
         name: 'test span',
         startTimeUnixNano: '1000000',
-        endTimeUnixNano: '2000000',
+        endTimeUnixNano: '3000000',
         attributes: expect.any(Object),
         events: expect.any(Array)
       })
@@ -656,7 +660,7 @@ describe('Span', () => {
 
       await jest.runOnlyPendingTimersAsync()
 
-      expect(logger.warn).toHaveBeenCalledWith('Attempted to end a Span which has already ended.')
+      expect(logger.warn).toHaveBeenCalledWith('Attempted to end a Span which is no longer valid.')
       expect(delivery.requests).toHaveLength(1)
     })
 

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -102,7 +102,7 @@ describe('RouteChangePlugin', () => {
 
     const secondSpan = expect.objectContaining({
       name: '[RouteChange]/second-route',
-      startTimeUnixNano: '2000000',
+      startTimeUnixNano: '3000000',
       endTimeUnixNano: '32000000'
     })
 

--- a/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/route-change-plugin.test.ts
@@ -102,7 +102,7 @@ describe('RouteChangePlugin', () => {
 
     const secondSpan = expect.objectContaining({
       name: '[RouteChange]/second-route',
-      startTimeUnixNano: '3000000',
+      startTimeUnixNano: '5000000',
       endTimeUnixNano: '32000000'
     })
 

--- a/packages/platforms/browser/tests/span-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/span-attributes-source.test.ts
@@ -1,5 +1,5 @@
 import { SpanAttributes, SpanInternal } from '@bugsnag/core-performance'
-import { createConfiguration } from '@bugsnag/js-performance-test-utilities'
+import { createConfiguration, IncrementingClock } from '@bugsnag/js-performance-test-utilities'
 import type { BrowserConfiguration } from '../lib'
 import createSpanAttributesSource from '../lib/span-attributes-source'
 
@@ -16,7 +16,8 @@ describe('spanAttributesSource', () => {
   it('adds permitted attributes to a span', () => {
     const browserConfiguration = createConfiguration<BrowserConfiguration>({ sendPageAttributes: { url: true, title: true } })
     const spanAttributes = new SpanAttributes(new Map())
-    const span = new SpanInternal('id', 'traceId', 'test span', 1234, spanAttributes)
+    const clock = new IncrementingClock()
+    const span = new SpanInternal('id', 'traceId', 'test span', 1234, spanAttributes, clock)
 
     spanAttributesSource.requestAttributes(span)
 


### PR DESCRIPTION
## Goal

Mitigates the potential for memory leaks caused by failing to end a span.

Currently if a span on the context stack is not ended for any reason (e.g. a developer has a problem with their logic for closing spans), then the span will remain open and there will be a reference to the span in the context stack until the thread / process / document (depending on platform) is killed.

## Design

Ideally we would use `WeakRef`s in the context stack to allow spans on the context stack to be garbage collected, however as `WeakRef` isn't supported on older browser versions we need an alternative approach.

So to avoid holding references indefinitely, any spans with a start time older than 1 hour are considered 'invalid', allowing them to be removed from the context stack naturally (since invalid spans are popped off the stack whenever a span is added or removed).

If/when an invalid span is ended, it will be discarded. As part of this, also fixed a bug where spans that were explicitly discarded using the special discard end time (-1) would still be considered valid and remain on the context stack.

## Testing

Added new unit tests