### PR TITLE
Use 'r32' as the r value key in tracestate

### DIFF
--- a/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/network-request-plugin.ts
@@ -134,5 +134,5 @@ function buildTraceparentHeader (traceId: string, parentSpanId: string, sampled:
 }
 
 function buildTracestateHeader (traceId: string): string {
-  return `sb=v:1;r:${traceIdToSamplingRate(traceId)}`
+  return `sb=v:1;r32:${traceIdToSamplingRate(traceId)}`
 }

--- a/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
+++ b/packages/platforms/browser/tests/auto-instrumentation/network-request-plugin.test.ts
@@ -276,7 +276,7 @@ describe('network span plugin', () => {
     expect(res.extraRequestHeaders).toEqual([
       {
         traceparent: '00-a random 128 bit string-a random 64 bit string-01',
-        tracestate: 'sb=v:1;r:290'
+        tracestate: 'sb=v:1;r32:290'
       }
     ])
   })
@@ -334,7 +334,7 @@ describe('network span plugin', () => {
         expect(res.extraRequestHeaders).toEqual([
           {
             traceparent: '00-a random 128 bit string-a random 64 bit string-01',
-            tracestate: 'sb=v:1;r:290'
+            tracestate: 'sb=v:1;r32:290'
           }
         ])
 
@@ -343,7 +343,7 @@ describe('network span plugin', () => {
         expect(res2.extraRequestHeaders).toEqual([
           {
             traceparent: '00-a random 128 bit string-a random 64 bit string-01',
-            tracestate: 'sb=v:1;r:290'
+            tracestate: 'sb=v:1;r32:290'
 
           }
         ])
@@ -398,7 +398,7 @@ describe('network span plugin', () => {
         expect(res.extraRequestHeaders).toEqual([
           {
             traceparent: '00-xyz456-abc123-01',
-            tracestate: 'sb=v:1;r:0'
+            tracestate: 'sb=v:1;r32:0'
           }
         ])
       })

--- a/test/browser/features/trace-propagation.feature
+++ b/test/browser/features/trace-propagation.feature
@@ -8,7 +8,7 @@ Feature: Trace propagation headers
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-        And the reflection "tracestate" header matches the regex "^sb=v:1;r:[0-9]{1,32}"
+        And the reflection "tracestate" header matches the regex "^sb=v:1;r32:[0-9]{1,32}"
 
         And I wait to receive 1 trace
 
@@ -22,7 +22,7 @@ Feature: Trace propagation headers
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-        And the reflection "tracestate" header matches the regex "^sb=v:1;r:[0-9]{1,32}"
+        And the reflection "tracestate" header matches the regex "^sb=v:1;r32:[0-9]{1,32}"
 
         And I wait to receive 1 trace
 
@@ -36,7 +36,7 @@ Feature: Trace propagation headers
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-        And the reflection "tracestate" header matches the regex "^sb=v:1;r:[0-9]{1,32}"
+        And the reflection "tracestate" header matches the regex "^sb=v:1;r32:[0-9]{1,32}"
 
         And I wait to receive 1 trace
 
@@ -50,7 +50,7 @@ Feature: Trace propagation headers
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-        And the reflection "tracestate" header matches the regex "^sb=v:1;r:[0-9]{1,32}"
+        And the reflection "tracestate" header matches the regex "^sb=v:1;r32:[0-9]{1,32}"
 
         And I wait to receive 1 trace
 
@@ -64,7 +64,7 @@ Feature: Trace propagation headers
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-        And the reflection "tracestate" header matches the regex "^sb=v:1;r:[0-9]{1,32}"
+        And the reflection "tracestate" header matches the regex "^sb=v:1;r32:[0-9]{1,32}"
 
         And I wait to receive 1 trace
 
@@ -78,7 +78,7 @@ Feature: Trace propagation headers
         Then the reflection request method equals "GET"
         And the reflection "X-Test-Header" header equals "test"
         And the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
-        And the reflection "tracestate" header matches the regex "^sb=v:1;r:[0-9]{1,32}"
+        And the reflection "tracestate" header matches the regex "^sb=v:1;r32:[0-9]{1,32}"
 
         And I wait to receive 1 trace
         


### PR DESCRIPTION
## Goal

The JS SDK uses 32 bit values for p & r because JS numbers cannot hold 64 bit integers

We need to be able to determine if an r value is 32 or 64 bit in order to consume the tracestate correctly, so we're now using explicit bit sizes in the r value key (i.e. r32 & r64)