### PR TITLE
[PLAT-12625] Create new app start span wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - (core) Discard spans open for more than one hour [#494](https://github.com/bugsnag/bugsnag-js-performance/pull/494)
 - (core) use API key subdomain as default endpoint [#500](https://github.com/bugsnag/bugsnag-js-performance/pull/500)
+- (react-native) Add new withInstrumentedAppStarts method to workaround automatically instrumented app start span issues [#497](https://github.com/bugsnag/bugsnag-js-performance/pull/497)
 
 ## [v2.8.0] (2024-08-20)
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "2.8.0"
+  "version": "2.8.1-alpha.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30341,7 +30341,7 @@
     },
     "packages/core": {
       "name": "@bugsnag/core-performance",
-      "version": "2.8.0",
+      "version": "2.8.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/cuid": "^3.1.1"
@@ -30349,21 +30349,21 @@
     },
     "packages/delivery-fetch": {
       "name": "@bugsnag/delivery-fetch-performance",
-      "version": "2.8.0",
+      "version": "2.8.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^2.8.0"
+        "@bugsnag/core-performance": "^2.8.1-alpha.0"
       }
     },
     "packages/platforms/browser": {
       "name": "@bugsnag/browser-performance",
-      "version": "2.8.0",
+      "version": "2.8.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^2.8.0",
+        "@bugsnag/core-performance": "^2.8.1-alpha.0",
         "@bugsnag/cuid": "^3.1.1",
-        "@bugsnag/delivery-fetch-performance": "^2.8.0",
-        "@bugsnag/request-tracker-performance": "^2.8.0"
+        "@bugsnag/delivery-fetch-performance": "^2.8.1-alpha.0",
+        "@bugsnag/request-tracker-performance": "^2.8.1-alpha.0"
       },
       "devDependencies": {
         "@bugsnag/browser": "^8.0.0"
@@ -30393,13 +30393,13 @@
     },
     "packages/platforms/react-native": {
       "name": "@bugsnag/react-native-performance",
-      "version": "2.8.0",
+      "version": "2.8.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^2.8.0",
+        "@bugsnag/core-performance": "^2.8.1-alpha.0",
         "@bugsnag/cuid": "^3.1.1",
-        "@bugsnag/delivery-fetch-performance": "^2.8.0",
-        "@bugsnag/request-tracker-performance": "^2.8.0"
+        "@bugsnag/delivery-fetch-performance": "^2.8.1-alpha.0",
+        "@bugsnag/request-tracker-performance": "^2.8.1-alpha.0"
       },
       "devDependencies": {
         "@react-native-community/netinfo": "^9.4.1",
@@ -30416,11 +30416,11 @@
     },
     "packages/plugin-react-native-navigation": {
       "name": "@bugsnag/plugin-react-native-navigation-performance",
-      "version": "2.8.0",
+      "version": "2.8.1-alpha.0",
       "license": "MIT",
       "devDependencies": {
-        "@bugsnag/core-performance": "^2.8.0",
-        "@bugsnag/react-native-performance": "^2.8.0",
+        "@bugsnag/core-performance": "^2.8.1-alpha.0",
+        "@bugsnag/react-native-performance": "^2.8.1-alpha.0",
         "@react-native/babel-preset": "^0.74.0",
         "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^12.4.1",
@@ -30434,11 +30434,11 @@
     },
     "packages/plugin-react-navigation": {
       "name": "@bugsnag/plugin-react-navigation-performance",
-      "version": "2.8.0",
+      "version": "2.8.1-alpha.0",
       "license": "MIT",
       "devDependencies": {
-        "@bugsnag/core-performance": "^2.8.0",
-        "@bugsnag/react-native-performance": "^2.8.0",
+        "@bugsnag/core-performance": "^2.8.1-alpha.0",
+        "@bugsnag/react-native-performance": "^2.8.1-alpha.0",
         "@react-native/babel-preset": "^0.74.0",
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.17",
@@ -30465,10 +30465,10 @@
     },
     "packages/request-tracker": {
       "name": "@bugsnag/request-tracker-performance",
-      "version": "2.8.0",
+      "version": "2.8.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/core-performance": "^2.8.0"
+        "@bugsnag/core-performance": "^2.8.1-alpha.0"
       }
     },
     "packages/test-utilities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30427,8 +30427,8 @@
         "react-native-navigation": "7.37.2"
       },
       "peerDependencies": {
-        "@bugsnag/core-performance": "^2.3.0",
-        "@bugsnag/react-native-performance": "^2.3.0",
+        "@bugsnag/core-performance": "*",
+        "@bugsnag/react-native-performance": "*",
         "react-native-navigation": "*"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/core-performance",
-  "version": "2.8.0",
+  "version": "2.8.1-alpha.0",
   "description": "Core performance client",
   "keywords": [
     "bugsnag",

--- a/packages/delivery-fetch/package.json
+++ b/packages/delivery-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/delivery-fetch-performance",
-  "version": "2.8.0",
+  "version": "2.8.1-alpha.0",
   "description": "BugSnag performance monitoring delivery mechanism using the fetch API",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^2.8.0"
+    "@bugsnag/core-performance": "^2.8.1-alpha.0"
   },
   "type": "module",
   "main": "dist/delivery.js",

--- a/packages/platforms/browser/package.json
+++ b/packages/platforms/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/browser-performance",
-  "version": "2.8.0",
+  "version": "2.8.1-alpha.0",
   "description": "BugSnag performance monitoring for browsers",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -21,10 +21,10 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^2.8.0",
+    "@bugsnag/core-performance": "^2.8.1-alpha.0",
     "@bugsnag/cuid": "^3.1.1",
-    "@bugsnag/delivery-fetch-performance": "^2.8.0",
-    "@bugsnag/request-tracker-performance": "^2.8.0"
+    "@bugsnag/delivery-fetch-performance": "^2.8.1-alpha.0",
+    "@bugsnag/request-tracker-performance": "^2.8.1-alpha.0"
   },
   "devDependencies": {
     "@bugsnag/browser": "^8.0.0"

--- a/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
+++ b/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
@@ -42,7 +42,7 @@ export class AppStartPlugin implements Plugin<ReactNativeConfiguration> {
     const appStartSpan = createAppStartSpan(this.spanFactory, this.appStartTime)
 
     const AppStartWrapper = ({ children }: WrapperProps) => {
-      useEndSpanOnMount(appStartSpan, this.spanFactory, this.clock)
+      useEndSpanOnMount(this.spanFactory, this.clock, appStartSpan)
 
       return children
     }

--- a/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
+++ b/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
@@ -8,6 +8,8 @@ import type { ReactNode } from 'react'
 import React from 'react'
 import type { AppRegistry, WrapperComponentProvider } from 'react-native'
 import type { ReactNativeConfiguration } from '../config'
+import { createAppStartSpan } from '../create-app-start-span'
+import { useEndSpanOnMount } from '../use-end-span-on-mount'
 
 interface WrapperProps {
   children: ReactNode
@@ -37,16 +39,10 @@ export class AppStartPlugin implements Plugin<ReactNativeConfiguration> {
   configure (configuration: InternalConfiguration<ReactNativeConfiguration>) {
     if (!configuration.autoInstrumentAppStarts) return
 
-    const appStartSpan = this.spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: this.appStartTime, parentContext: null })
-    appStartSpan.setAttribute('bugsnag.span.category', 'app_start')
-    appStartSpan.setAttribute('bugsnag.app_start.type', 'ReactNativeInit')
+    const appStartSpan = createAppStartSpan(this.spanFactory, this.appStartTime)
 
     const AppStartWrapper = ({ children }: WrapperProps) => {
-      React.useEffect(() => {
-        if (appStartSpan.isValid()) {
-          this.spanFactory.endSpan(appStartSpan, this.clock.now())
-        }
-      }, [])
+      useEndSpanOnMount(appStartSpan, this.spanFactory, this.clock)
 
       return children
     }

--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -51,7 +51,7 @@ const BugsnagPerformance = createClient({
   schema: createSchema(),
   spanAttributesSource,
   retryQueueFactory: createRetryQueueFactory(FileSystem),
-  platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(appStartTime, spanFactory, spanContextStorage)
+  platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(appStartTime, clock, spanFactory, spanContextStorage)
 })
 
 export default BugsnagPerformance

--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -51,7 +51,7 @@ const BugsnagPerformance = createClient({
   schema: createSchema(),
   spanAttributesSource,
   retryQueueFactory: createRetryQueueFactory(FileSystem),
-  platformExtensions
+  platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(appStartTime, spanFactory, spanContextStorage)
 })
 
 export default BugsnagPerformance

--- a/packages/platforms/react-native/lib/create-app-start-span.ts
+++ b/packages/platforms/react-native/lib/create-app-start-span.ts
@@ -1,8 +1,12 @@
-import type { SpanFactory } from '@bugsnag/core-performance'
+import type { SpanFactory, SpanInternal } from '@bugsnag/core-performance'
 import type { ReactNativeConfiguration } from './config'
 
+let appStartSpan: SpanInternal
+
 export function createAppStartSpan (spanFactory: SpanFactory<ReactNativeConfiguration>, appStartTime: number) {
-  const appStartSpan = spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
+  if (appStartSpan) return appStartSpan
+
+  appStartSpan = spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
 
   spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
   appStartSpan.setAttribute('bugsnag.span.category', 'app_start')

--- a/packages/platforms/react-native/lib/create-app-start-span.ts
+++ b/packages/platforms/react-native/lib/create-app-start-span.ts
@@ -1,0 +1,12 @@
+import type { SpanFactory } from '@bugsnag/core-performance'
+import type { ReactNativeConfiguration } from './config'
+
+export function createAppStartSpan (spanFactory: SpanFactory<ReactNativeConfiguration>, appStartTime: number) {
+  const appStartSpan = spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
+
+  spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
+  appStartSpan.setAttribute('bugsnag.span.category', 'app_start')
+  appStartSpan.setAttribute('bugsnag.app_start.type', 'ReactNativeInit')
+
+  return appStartSpan
+}

--- a/packages/platforms/react-native/lib/platform-extensions.tsx
+++ b/packages/platforms/react-native/lib/platform-extensions.tsx
@@ -20,7 +20,7 @@ export const platformExtensions = (appStartTime: number, clock: Clock, spanFacto
     const appStartSpan = createAppStartSpan(spanFactory, appStartTime)
 
     return () => {
-      useEndSpanOnMount(appStartSpan, spanFactory, clock)
+      useEndSpanOnMount(spanFactory, clock, appStartSpan)
 
       return <App />
     }

--- a/packages/platforms/react-native/lib/platform-extensions.tsx
+++ b/packages/platforms/react-native/lib/platform-extensions.tsx
@@ -1,9 +1,10 @@
 import type { SpanContextStorage, SpanFactory, SpanOptions } from '@bugsnag/core-performance'
 import type { ReactNativeConfiguration } from './config'
+import React, { useEffect } from 'react'
 
 type NavigationSpanOptions = Omit<SpanOptions, 'isFirstClass'>
 
-export const platformExtensions = (spanFactory: SpanFactory<ReactNativeConfiguration>, spanContextStorage: SpanContextStorage) => ({
+export const platformExtensions = (appStartTime: number, spanFactory: SpanFactory<ReactNativeConfiguration>, spanContextStorage: SpanContextStorage) => ({
   startNavigationSpan: (routeName: string, spanOptions?: NavigationSpanOptions) => {
     const cleanOptions = spanFactory.validateSpanOptions(routeName, spanOptions)
     cleanOptions.options.isFirstClass = true
@@ -12,6 +13,21 @@ export const platformExtensions = (spanFactory: SpanFactory<ReactNativeConfigura
     span.setAttribute('bugsnag.span.category', 'navigation')
     span.setAttribute('bugsnag.navigation.route', cleanOptions.name)
     return spanFactory.toPublicApi(span)
+  },
+  wrapApp: (App: React.FC) => {
+    const appStartSpan = spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
+    appStartSpan.setAttribute('bugsnag.span.category', 'app_start')
+    appStartSpan.setAttribute('bugsnag.app_start.type', 'ReactNativeInit')
+
+    return () => {
+      useEffect(() => {
+        if (appStartSpan.isValid()) {
+          spanFactory.endSpan(appStartSpan, performance.now())
+        }
+      }, [])
+
+      return <App />
+    }
   }
 })
 

--- a/packages/platforms/react-native/lib/use-end-span-on-mount.ts
+++ b/packages/platforms/react-native/lib/use-end-span-on-mount.ts
@@ -2,7 +2,7 @@ import type { Clock, SpanFactory, SpanInternal } from '@bugsnag/core-performance
 import { useEffect } from 'react'
 import type { ReactNativeConfiguration } from './config'
 
-export const useEndSpanOnMount = (span: SpanInternal, spanFactory: SpanFactory<ReactNativeConfiguration>, clock: Clock) => {
+export const useEndSpanOnMount = (spanFactory: SpanFactory<ReactNativeConfiguration>, clock: Clock, span: SpanInternal) => {
   useEffect(() => {
     if (span.isValid()) {
       spanFactory.endSpan(span, clock.now())

--- a/packages/platforms/react-native/lib/use-end-span-on-mount.ts
+++ b/packages/platforms/react-native/lib/use-end-span-on-mount.ts
@@ -1,0 +1,11 @@
+import type { Clock, SpanFactory, SpanInternal } from '@bugsnag/core-performance'
+import { useEffect } from 'react'
+import type { ReactNativeConfiguration } from './config'
+
+export const useEndSpanOnMount = (span: SpanInternal, spanFactory: SpanFactory<ReactNativeConfiguration>, clock: Clock) => {
+  useEffect(() => {
+    if (span.isValid()) {
+      spanFactory.endSpan(span, clock.now())
+    }
+  }, [])
+}

--- a/packages/platforms/react-native/package.json
+++ b/packages/platforms/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/react-native-performance",
-  "version": "2.8.0",
+  "version": "2.8.1-alpha.0",
   "description": "BugSnag performance monitoring for React Native",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -15,10 +15,10 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^2.8.0",
+    "@bugsnag/core-performance": "^2.8.1-alpha.0",
     "@bugsnag/cuid": "^3.1.1",
-    "@bugsnag/delivery-fetch-performance": "^2.8.0",
-    "@bugsnag/request-tracker-performance": "^2.8.0"
+    "@bugsnag/delivery-fetch-performance": "^2.8.1-alpha.0",
+    "@bugsnag/request-tracker-performance": "^2.8.1-alpha.0"
   },
   "devDependencies": {
     "@react-native-community/netinfo": "^9.4.1",

--- a/packages/platforms/react-native/tests/platform-extensions.test.ts
+++ b/packages/platforms/react-native/tests/platform-extensions.test.ts
@@ -1,12 +1,13 @@
 import { platformExtensions } from '../lib/platform-extensions'
-import { createTestClient, InMemoryDelivery, VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
+import { createTestClient, IncrementingClock, InMemoryDelivery, VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
 
 jest.useFakeTimers()
 
 describe('startNavigationSpan', () => {
   it('creates a navigation span', async () => {
     const delivery = new InMemoryDelivery()
-    const testClient = createTestClient({ deliveryFactory: () => delivery, platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(0, spanFactory, spanContextStorage) })
+    const clock = new IncrementingClock()
+    const testClient = createTestClient({ deliveryFactory: () => delivery, platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(0, clock, spanFactory, spanContextStorage) })
     testClient.start({ apiKey: VALID_API_KEY })
     await jest.runOnlyPendingTimersAsync()
 

--- a/packages/platforms/react-native/tests/platform-extensions.test.ts
+++ b/packages/platforms/react-native/tests/platform-extensions.test.ts
@@ -6,7 +6,7 @@ jest.useFakeTimers()
 describe('startNavigationSpan', () => {
   it('creates a navigation span', async () => {
     const delivery = new InMemoryDelivery()
-    const testClient = createTestClient({ deliveryFactory: () => delivery, platformExtensions })
+    const testClient = createTestClient({ deliveryFactory: () => delivery, platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(0, spanFactory, spanContextStorage) })
     testClient.start({ apiKey: VALID_API_KEY })
     await jest.runOnlyPendingTimersAsync()
 

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -19,8 +19,8 @@
         "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
     },
     "peerDependencies": {
-        "@bugsnag/core-performance": "^2.3.0",
-        "@bugsnag/react-native-performance": "^2.3.0",
+        "@bugsnag/core-performance": "*",
+        "@bugsnag/react-native-performance": "*",
         "react-native-navigation": "*"
     },
     "devDependencies": {

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bugsnag/plugin-react-native-navigation-performance",
-    "version": "2.8.0",
+    "version": "2.8.1-alpha.0",
     "description": "BugSnag performance monitoring for react-native-navigation",
     "homepage": "https://www.bugsnag.com/",
     "license": "MIT",
@@ -24,8 +24,8 @@
         "react-native-navigation": "*"
     },
     "devDependencies": {
-        "@bugsnag/core-performance": "^2.8.0",
-        "@bugsnag/react-native-performance": "^2.8.0",
+        "@bugsnag/core-performance": "^2.8.1-alpha.0",
+        "@bugsnag/react-native-performance": "^2.8.1-alpha.0",
         "@react-native/babel-preset": "^0.74.0",
         "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^12.4.1",

--- a/packages/plugin-react-navigation/package.json
+++ b/packages/plugin-react-navigation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bugsnag/plugin-react-navigation-performance",
-    "version": "2.8.0",
+    "version": "2.8.1-alpha.0",
     "description": "BugSnag performance monitoring for @react-navigation/native",
     "homepage": "https://www.bugsnag.com/",
     "license": "MIT",
@@ -19,8 +19,8 @@
         "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
     },
     "devDependencies": {
-        "@bugsnag/core-performance": "^2.8.0",
-        "@bugsnag/react-native-performance": "^2.8.0",
+        "@bugsnag/core-performance": "^2.8.1-alpha.0",
+        "@bugsnag/react-native-performance": "^2.8.1-alpha.0",
         "@react-native/babel-preset": "^0.74.0",
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.17",

--- a/packages/request-tracker/package.json
+++ b/packages/request-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/request-tracker-performance",
-  "version": "2.8.0",
+  "version": "2.8.1-alpha.0",
   "description": "BugSnag performance request tracker for monitoring XHR and fetch requests",
   "homepage": "https://www.bugsnag.com/",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "url": "https://github.com/bugsnag/bugsnag-js-performance/issues"
   },
   "dependencies": {
-    "@bugsnag/core-performance": "^2.8.0"
+    "@bugsnag/core-performance": "^2.8.1-alpha.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/test/react-native/features/app-start-spans.feature
+++ b/test/react-native/features/app-start-spans.feature
@@ -39,3 +39,22 @@ Feature: App Start spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "app_start"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.app_start.type" equals "ReactNativeInit"
+
+  Scenario: App start span is created when using the wrapApp method
+    When I run 'AppStartWrapperScenario'
+    And I wait to receive a sampling request
+    And I wait for 1 span
+
+    # Check the initial probability request
+    Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
+
+    And the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[AppStart/ReactNativeInit]"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "app_start"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.app_start.type" equals "ReactNativeInit"
+    

--- a/test/react-native/features/fixtures/scenario-launcher/package.json
+++ b/test/react-native/features/fixtures/scenario-launcher/package.json
@@ -12,7 +12,6 @@
     "react-native-navigation": "*"
   },
   "peerDependencies": {
-    "@bugsnag/react-native-cli": "*",
     "@react-navigation/native": "*",
     "@react-navigation/native-stack": "*",
     "react": "*",

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/AppStartWrapperScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/AppStartWrapperScenario.js
@@ -7,7 +7,7 @@ export const config = {
   autoInstrumentAppStarts: false
 }
 
-export const App = BugsnagPerformance.wrapApp(() => {
+export const App = BugsnagPerformance.withInstrumentedAppStarts(() => {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.scenario}>

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/AppStartWrapperScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/AppStartWrapperScenario.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+
+export const config = {
+  maximumBatchSize: 1,
+  autoInstrumentAppStarts: false
+}
+
+export const App = BugsnagPerformance.wrapApp(() => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>AppStartScenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+})
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -1,4 +1,5 @@
 export * as AppStartScenario from './AppStartScenario'
+export * as AppStartWrapperScenario from './AppStartWrapperScenario'
 export * as BackgroundSpanScenario from './BackgroundSpanScenario'
 export * as ErrorCorrelationScenario from './ErrorCorrelationScenario'
 export * as ManualSpanScenario from './ManualSpanScenario'


### PR DESCRIPTION
## Goal

Provide an alternative method to instrument app start spans aside from `setWrapperComponentProvider`

## Design

Using a higher order component (HOC) will prevent the app from re-rendering when root props are updated from the native side

## Changeset

- Expose new `withInstrumentedAppStarts` wrapper method from the performance client
- This PR also includes an alpha release for testing purposes

## Testing

- Add new end to end test to validate spans are still created using the new method
- Manual testing that the root app does not re-render when properties update from native iOS code