### PR TITLE
Add React Native 0.75 to test matrix

### DIFF
--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -25,6 +25,7 @@ steps:
               - "0.71"
               - "0.72"
               - "0.73"
+              - "0.74"
             java:
               - "17"
           adjustments:
@@ -56,6 +57,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -82,6 +84,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -108,6 +111,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -147,6 +151,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch-full"
@@ -180,6 +185,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-old-arch-full"
@@ -212,6 +218,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch-full"
@@ -245,3 +252,4 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -25,7 +25,7 @@ steps:
           - bundle install
           - ./bin/generate-react-native-fixture
         matrix:
-          - "0.74"
+          - "0.75"
         retry:
           automatic:
             - exit_status: "*"
@@ -49,7 +49,7 @@ steps:
           - bundle install
           - ./bin/generate-react-native-fixture
         matrix:
-          - "0.74"
+          - "0.75"
         retry:
           automatic:
             - exit_status: "*"
@@ -72,7 +72,7 @@ steps:
           - bundle install
           - ./bin/generate-react-native-fixture
         matrix:
-          - "0.74"
+          - "0.75"
         retry:
           automatic:
             - exit_status: "*"
@@ -96,7 +96,7 @@ steps:
           - bundle install
           - ./bin/generate-react-native-fixture
         matrix:
-          - "0.74"
+          - "0.75"
         retry:
           automatic:
             - exit_status: "*"
@@ -132,7 +132,7 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
+          - "0.75"
 
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
@@ -163,7 +163,7 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
+          - "0.75"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-old-arch"
@@ -192,7 +192,7 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
+          - "0.75"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"
@@ -223,4 +223,4 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
+          - "0.75"

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -109,6 +109,15 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
     configureRN064Fixture(fixtureDir)
   }
 
+  // due to a bug in react-native-file-access, static frameworks is required on 0.75+ othwerwise iOS builds will fail.
+  // there is an open PR to fix this upstream: https://github.com/alpha0010/react-native-file-access/pull/88
+  // TODO: remove this when either the upstream PR is released or PLAT-12626 (replace react-native-file-access with our own File I/O) is implemented
+  if (parseFloat(reactNativeVersion) >= 0.75) {
+    let podfileContents = fs.readFileSync(`${fixtureDir}/ios/Podfile`, 'utf8')
+    podfileContents = podfileContents.replace(/target 'reactnative' do/, 'use_frameworks! :linkage => :static\ntarget \'reactnative\' do')
+    fs.writeFileSync(`${fixtureDir}/ios/Podfile`, podfileContents)
+  }
+
   // link react-native-navigation using rnn-link tool
   if (process.env.REACT_NATIVE_NAVIGATION === 'true' || process.env.REACT_NATIVE_NAVIGATION === '1') {
     execSync('npx rnn-link', { cwd: fixtureDir, stdio: 'inherit' })

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -3,6 +3,7 @@
 const { execFileSync, execSync } = require('child_process')
 const { resolve } = require('path')
 const fs = require('fs')
+const util = require('util')
 
 if (!process.env.RN_VERSION) {
   console.error('Please provide a React Native version')
@@ -286,10 +287,10 @@ function replaceGeneratedFixtureFiles() {
     resolve(fixtureDir, '.env')
   )
 
-  fs.copyFileSync(
-    resolve(ROOT_DIR, 'test/react-native/features/fixtures/app/babel.config.js'),
-    resolve(fixtureDir, 'babel.config.js')
-  )
+  const babelConfig = require(resolve(fixtureDir, 'babel.config.js'))
+  if (!babelConfig.plugins) babelConfig.plugins = []
+  babelConfig.plugins.push('@babel/plugin-transform-export-namespace-from', 'module:react-native-dotenv')
+  fs.writeFileSync(resolve(fixtureDir, 'babel.config.js'), `module.exports = ${util.inspect(babelConfig)}`)
 
   // If we're building with the new architecture, replace the gradle.properties file
   if (process.env.RCT_NEW_ARCH_ENABLED === 'true' || process.env.RCT_NEW_ARCH_ENABLED === '1') {

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -186,20 +186,20 @@ function configureRN064Fixture(fixtureDir) {
     nodeExecutableAndArgs: ["node", "--openssl-legacy-provider"]
   ]`
 
-  // remove flipper dependencies
+  // remove flipper and associated dependencies
+  fs.rmdirSync(resolve(fixtureDir, 'android/app/src/debug/java'), { recursive: true, force: true })
   const flipperDependencies = `debugImplementation("com.facebook.flipper:flipper:\${FLIPPER_VERSION}") {
-    exclude group:'com.facebook.fbjni'
-  }
+      exclude group:'com.facebook.fbjni'
+    }
 
-  debugImplementation("com.facebook.flipper:flipper-network-plugin:\${FLIPPER_VERSION}") {
-      exclude group:'com.facebook.flipper'
-      exclude group:'com.squareup.okhttp3', module:'okhttp'
-  }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:\${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
 
-  debugImplementation("com.facebook.flipper:flipper-fresco-plugin:\${FLIPPER_VERSION}") {
-      exclude group:'com.facebook.flipper'
-  }
-`
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:\${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }`
 
   moduleGradle = moduleGradle.replace(currentReactConfig, updatedReactConfig).replace(flipperDependencies, '')
   fs.writeFileSync(moduleGradlePath, moduleGradle)

--- a/test/react-native/features/error-correlation.feature
+++ b/test/react-native/features/error-correlation.feature
@@ -18,8 +18,8 @@ Feature: Error correlation
     And I wait to receive 1 trace
 
     # Assert on the span, and store the trace id and span id
-    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.id" is stored as the value "spanId"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceid" is stored as the value "traceId"
+    Then the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" is stored as the value "spanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "traceId"
 
     # Check span id is included in the error
     And the error payload field "events.0.correlation.spanId" equals the stored value "spanId"

--- a/test/react-native/features/fixtures/app/android/MainActivity.0.75.kt
+++ b/test/react-native/features/fixtures/app/android/MainActivity.0.75.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.fixtures.reactnative.performance
+
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Required for react-navigation/native implementation
+   * https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project
+   */
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+  }
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "reactnative"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+}

--- a/test/react-native/features/fixtures/app/babel.config.js
+++ b/test/react-native/features/fixtures/app/babel.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['@babel/plugin-transform-export-namespace-from', 'module:react-native-dotenv', ['@babel/plugin-transform-private-methods', { loose: true }]]
-}

--- a/test/react-native/features/fixtures/scenario-launcher/ScenarioLauncher.podspec
+++ b/test/react-native/features/fixtures/scenario-launcher/ScenarioLauncher.podspec
@@ -16,5 +16,9 @@ Pod::Spec.new do |s|
   s.source_files    = "ios/**/*.{h,m,mm}"
   s.dependency "BugsnagReactNative"
   
-  install_modules_dependencies(s)
+  if ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+  end
 end

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.xcodeproj/project.pbxproj
@@ -1,0 +1,313 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		DAB0A55D2C80BF7500085915 /* ScenarioLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB0A55C2C80BF7500085915 /* ScenarioLauncher.m */; };
+		DAB0A55E2C80BF7500085915 /* ScenarioLauncher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DAB0A55B2C80BF7500085915 /* ScenarioLauncher.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		DAB0A5562C80BF7500085915 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				DAB0A55E2C80BF7500085915 /* ScenarioLauncher.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		DAB0A5582C80BF7500085915 /* libScenarioLauncher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libScenarioLauncher.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAB0A55B2C80BF7500085915 /* ScenarioLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScenarioLauncher.h; sourceTree = "<group>"; };
+		DAB0A55C2C80BF7500085915 /* ScenarioLauncher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScenarioLauncher.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		DAB0A5552C80BF7500085915 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		DAB0A5592C80BF7500085915 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DAB0A5582C80BF7500085915 /* libScenarioLauncher.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DAB0A55A2C80BF7500085915 /* ScenarioLauncher */ = {
+			isa = PBXGroup;
+			children = (
+				DAB0A55B2C80BF7500085915 /* ScenarioLauncher.h */,
+				DAB0A55C2C80BF7500085915 /* ScenarioLauncher.m */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		DAB0A5572C80BF7500085915 /* ScenarioLauncher */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAB0A5612C80BF7500085915 /* Build configuration list for PBXNativeTarget "ScenarioLauncher" */;
+			buildPhases = (
+				DAB0A5542C80BF7500085915 /* Sources */,
+				DAB0A5552C80BF7500085915 /* Frameworks */,
+				DAB0A5562C80BF7500085915 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ScenarioLauncher;
+			productName = ScenarioLauncher;
+			productReference = DAB0A5582C80BF7500085915 /* libScenarioLauncher.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		DAB0A5502C80BF7500085915 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1540;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					DAB0A5572C80BF7500085915 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = DAB0A5532C80BF7500085915 /* Build configuration list for PBXProject "ScenarioLauncher" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = DAB0A54F2C80BF7500085915;
+			productRefGroup = DAB0A5592C80BF7500085915 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				DAB0A5572C80BF7500085915 /* ScenarioLauncher */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		DAB0A5542C80BF7500085915 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAB0A55D2C80BF7500085915 /* ScenarioLauncher.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		DAB0A55F2C80BF7500085915 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		DAB0A5602C80BF7500085915 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		DAB0A5622C80BF7500085915 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = ScenarioLauncher;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		DAB0A5632C80BF7500085915 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = ScenarioLauncher;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		DAB0A5532C80BF7500085915 /* Build configuration list for PBXProject "ScenarioLauncher" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAB0A55F2C80BF7500085915 /* Debug */,
+				DAB0A5602C80BF7500085915 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAB0A5612C80BF7500085915 /* Build configuration list for PBXNativeTarget "ScenarioLauncher" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAB0A5622C80BF7500085915 /* Debug */,
+				DAB0A5632C80BF7500085915 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = DAB0A5502C80BF7500085915 /* Project object */;
+}


### PR DESCRIPTION
## Goal

Adds React Native 0.75 tests to the CI pipeline.

Also fixes the following issues with React Native test fixtures and e2e tests:

- Add pbxproj file and fix podspec in scenario launcher package (required for native iOS modules on older versions of React Native)
- Fix Android gradle file replacements for RN 0.64 (Flipper was not being fully removed, causing build issues on some CI machines and in local dev)
- Modify babel.config.js in test fixtures instead of replacing the whole file (Adds the required babel plugins while preserving the existing as this varies between react native versions)
- Fix typos in error correlation feature file


## Testing

Covered by a full CI run