### PR TITLE
[PLAT-12634] Make setAttribute public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- (core) Add `setAttribute` method to spans to enable setting custom attributes [#499](https://github.com/bugsnag/bugsnag-js-performance/pull/499)
+
 ### Changed
 
 - (core) Discard spans open for more than one hour [#494](https://github.com/bugsnag/bugsnag-js-performance/pull/494)

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -159,6 +159,9 @@ export class SpanFactory <C extends Configuration> {
         return span.samplingRate
       },
       isValid: () => span.isValid(),
+      setAttribute: (name, value) => {
+        span.setAttribute(name, value)
+      },
       end: (endTime) => {
         const safeEndTime = timeToNumber(this.clock, endTime)
         this.endSpan(span, safeEndTime)

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -160,7 +160,11 @@ export class SpanFactory <C extends Configuration> {
       },
       isValid: () => span.isValid(),
       setAttribute: (name, value) => {
-        span.setAttribute(name, value)
+        if (typeof name !== 'string') {
+          this.logger.warn(`Invalid attribute name, expected string, got ${typeof name}`)
+        } else {
+          span.setAttribute(name, value)
+        }
       },
       end: (endTime) => {
         const safeEndTime = timeToNumber(this.clock, endTime)

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -11,6 +11,7 @@ const HOUR_IN_MILLISECONDS = 60 * 60 * 1000
 
 export interface Span extends SpanContext {
   end: (endTime?: Time) => void
+  setAttribute: (name: string, value: SpanAttribute) => void
 }
 
 export const enum Kind {

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -55,6 +55,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
             traceId: '',
             samplingRate: 0,
             isValid: () => false,
+            setAttribute: () => {},
             end: () => {}
           }
         }
@@ -91,6 +92,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
         traceId: span.traceId,
         isValid: span.isValid,
         samplingRate: span.samplingRate,
+        setAttribute: span.setAttribute,
         end: (endTimeOrOptions?: Time | RouteChangeSpanEndOptions): void => {
           const options: RouteChangeSpanEndOptions = isObject(endTimeOrOptions) ? endTimeOrOptions : { endTime: endTimeOrOptions }
 


### PR DESCRIPTION
## Goal

Support custom attributes

## Changeset

- Expose setAttribute method in the public span API
- Add span name validation

## Testing

Add unit test to ensure setAttribute adds attributes as necessary