### PR TITLE
use API key subdomain as default endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - (core) Discard spans open for more than one hour [#494](https://github.com/bugsnag/bugsnag-js-performance/pull/494)
+- (core) use API key subdomain as default endpoint [#500](https://github.com/bugsnag/bugsnag-js-performance/pull/500)
 
 ## [v2.8.0] (2024-08-20)
 

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -330,6 +330,36 @@ describe('Core', () => {
             expect(span).toHaveAttribute('bugsnag.sampling.p', 0.9)
           })
         })
+
+        describe('endpoint', () => {
+          describe('when the endpoint is the default value', () => {
+            it('modifies the endpoint to include the API key', async () => {
+              const delivery = new InMemoryDelivery()
+              const deliveryFactory = jest.fn(() => delivery)
+              const client = createTestClient({ deliveryFactory })
+
+              client.start(VALID_API_KEY)
+
+              await jest.runOnlyPendingTimersAsync()
+
+              expect(deliveryFactory).toHaveBeenCalledWith('https://a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6.otlp.bugsnag.com/v1/traces')
+            })
+          })
+
+          describe('when the endpoint is not the default value', () => {
+            it('does not modify the endpoint', async () => {
+              const delivery = new InMemoryDelivery()
+              const deliveryFactory = jest.fn(() => delivery)
+              const client = createTestClient({ deliveryFactory })
+
+              client.start({ apiKey: VALID_API_KEY, endpoint: 'https://my-custom-otel-repeater.com' })
+
+              await jest.runOnlyPendingTimersAsync()
+
+              expect(deliveryFactory).toHaveBeenCalledWith('https://my-custom-otel-repeater.com')
+            })
+          })
+        })
       })
 
       describe('currentSpanContext', () => {

--- a/packages/platforms/browser/tests/on-settle/index.test.ts
+++ b/packages/platforms/browser/tests/on-settle/index.test.ts
@@ -357,7 +357,7 @@ describe('onSettle', () => {
     expect(settleCallback).not.toHaveBeenCalled()
 
     // request should be ignored, so advancing by 100ms will settle
-    fetchRequestTracker.start({ ...START_CONTEXT, url: 'https://otlp.bugsnag.com/v1/traces' })
+    fetchRequestTracker.start({ ...START_CONTEXT, url: `https://${VALID_API_KEY}.otlp.bugsnag.com/v1/traces` })
 
     await jest.advanceTimersByTimeAsync(100)
     expect(settleCallback).toHaveBeenCalled()


### PR DESCRIPTION
## Goal

> The SaaS span endpoint now supports the format <project_api_key>.otlp.bugsnag.com
> This should just be the default value for the endpoint – if the developer passes their own URL we just use that value directly (don’t attempt to inject the API key into the provided URL).

## Design

Mutate the configuration so that the actual value used is available to all consumers of the configuration, such as request instrumentations which use the value to determine which requests should be tracked or not, and what URLs to ignore in request settling.

## Changeset

- use API key subdomain as default endpoint

## Testing

- [x] unit test
- [ ] manual test

Note: e2e tests not added the depend on using a custom endpoint, which prevents us from testing this functionality at the e2e level