### PR TITLE
Custom attribute limits

### DIFF
--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -1,4 +1,5 @@
-import type { Configuration, InternalConfiguration } from './config'
+import type { Configuration, InternalConfiguration, Logger } from './config'
+import { defaultResourceAttributeLimits } from './custom-attribute-limits'
 import type { SpanInternal } from './span'
 import { isNumber } from './validation'
 
@@ -34,11 +35,21 @@ export interface SpanAttributesSource <C extends Configuration> {
   requestAttributes: (span: SpanInternal) => void
 }
 
+export interface SpanAttributesLimits {
+  attributeStringValueLimit: number
+  attributeArrayLengthLimit: number
+  attributeCountLimit: number
+}
+
 export class SpanAttributes {
   private readonly attributes: Map<string, SpanAttribute>
+  private readonly logger: Logger
+  private readonly spanAttributeLimits: SpanAttributesLimits
 
-  constructor (initialValues: Map<string, SpanAttribute>) {
+  constructor (initialValues: Map<string, SpanAttribute>, spanAttributeLimits: SpanAttributesLimits, logger: Logger) {
     this.attributes = initialValues
+    this.spanAttributeLimits = spanAttributeLimits
+    this.logger = logger
   }
 
   set (name: string, value: SpanAttribute) {
@@ -69,7 +80,7 @@ export class ResourceAttributes extends SpanAttributes {
       initialValues.set('service.version', appVersion)
     }
 
-    super(initialValues)
+    super(initialValues, defaultResourceAttributeLimits, console)
   }
 }
 

--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -67,7 +67,6 @@ export class SpanAttributes {
     this.logger = logger
   }
 
-  // Validate after the span has ended and after the sampling
   private validateAttribute (name: string, value: SpanAttribute) {
     if (name.length > ATTRIBUTE_KEY_LENGTH_LIMIT) {
       this.remove(name)

--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -91,7 +91,7 @@ export class SpanAttributes {
     if (typeof name === 'string' && (typeof value === 'string' || typeof value === 'boolean' || isNumber(value) || Array.isArray(value))) {
       if (!this.attributes.has(name) && this.attributes.size >= this.spanAttributeLimits.attributeCountLimit) {
         this._droppedAttributesCount++
-        this.logger.warn(`Span attribute ${name} in span ${this.spanName} was dropped as the number of attributes exceeds the ${this.spanAttributeLimits.attributeCountLimit} limit set by attributeCountLimit.`)
+        this.logger.warn(`Span attribute ${name} in span ${this.spanName} was dropped as the number of attributes exceeds the ${this.spanAttributeLimits.attributeCountLimit} attribute limit set by attributeCountLimit.`)
         return
       }
 

--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -68,13 +68,6 @@ export class SpanAttributes {
   }
 
   private validateAttribute (name: string, value: SpanAttribute) {
-    if (name.length > ATTRIBUTE_KEY_LENGTH_LIMIT) {
-      this.remove(name)
-      this._droppedAttributesCount++
-      this.logger.warn(`Span attribute ${name} in span ${this.spanName} was dropped as the key length exceeds the ${ATTRIBUTE_KEY_LENGTH_LIMIT} character fixed limit.`)
-      return
-    }
-
     if (typeof value === 'string' && value.length > this.spanAttributeLimits.attributeStringValueLimit) {
       this.attributes.set(name, truncateString(value, this.spanAttributeLimits.attributeStringValueLimit))
       this.logger.warn(`Span attribute ${name} in span ${this.spanName} was truncated as the string exceeds the ${this.spanAttributeLimits.attributeStringValueLimit} character limit set by attributeStringValueLimit.`)
@@ -92,6 +85,12 @@ export class SpanAttributes {
       if (!this.attributes.has(name) && this.attributes.size >= this.spanAttributeLimits.attributeCountLimit) {
         this._droppedAttributesCount++
         this.logger.warn(`Span attribute ${name} in span ${this.spanName} was dropped as the number of attributes exceeds the ${this.spanAttributeLimits.attributeCountLimit} attribute limit set by attributeCountLimit.`)
+        return
+      }
+
+      if (name.length > ATTRIBUTE_KEY_LENGTH_LIMIT) {
+        this._droppedAttributesCount++
+        this.logger.warn(`Span attribute ${name} in span ${this.spanName} was dropped as the key length exceeds the ${ATTRIBUTE_KEY_LENGTH_LIMIT} character fixed limit.`)
         return
       }
 

--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -9,9 +9,6 @@ import type { Span, SpanEnded } from './span'
 import { millisecondsToNanoseconds } from './clock'
 import { spanEndedToSpan } from './span-factory'
 
-import { millisecondsToNanoseconds } from './clock'
-import { spanEndedToSpan } from './span'
-
 export type OnSpanEndCallback = (span: Span) => boolean | Promise<boolean>
 export type OnSpanEndCallbacks = OnSpanEndCallback[]
 

--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -7,7 +7,7 @@ import type { ReadonlySampler } from './sampler'
 import type { Span, SpanEnded } from './span'
 
 import { millisecondsToNanoseconds } from './clock'
-import { spanEndedToSpan } from './span-factory'
+import { spanEndedToSpan } from './span'
 
 export type OnSpanEndCallback = (span: Span) => boolean | Promise<boolean>
 export type OnSpanEndCallbacks = OnSpanEndCallback[]

--- a/packages/core/lib/batch-processor.ts
+++ b/packages/core/lib/batch-processor.ts
@@ -9,6 +9,9 @@ import type { Span, SpanEnded } from './span'
 import { millisecondsToNanoseconds } from './clock'
 import { spanEndedToSpan } from './span-factory'
 
+import { millisecondsToNanoseconds } from './clock'
+import { spanEndedToSpan } from './span'
+
 export type OnSpanEndCallback = (span: Span) => boolean | Promise<boolean>
 export type OnSpanEndCallbacks = OnSpanEndCallback[]
 

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -141,17 +141,17 @@ export const schema: CoreSchema = {
   },
   attributeStringValueLimit: {
     defaultValue: ATTRIBUTE_STRING_VALUE_LIMIT_DEFAULT,
-    message: 'should be a number',
+    message: `should be a number between 1 and ${ATTRIBUTE_STRING_VALUE_LIMIT_MAX}`,
     validate: (value: unknown): value is number => isNumber(value) && value > 0 && value <= ATTRIBUTE_STRING_VALUE_LIMIT_MAX
   },
   attributeArrayLengthLimit: {
     defaultValue: ATTRIBUTE_ARRAY_LENGTH_LIMIT_DEFAULT,
-    message: 'should be a number',
+    message: `should be a number between 1 and ${ATTRIBUTE_ARRAY_LENGTH_LIMIT_MAX}`,
     validate: (value: unknown): value is number => isNumber(value) && value > 0 && value <= ATTRIBUTE_ARRAY_LENGTH_LIMIT_MAX
   },
   attributeCountLimit: {
     defaultValue: ATTRIBUTE_COUNT_LIMIT_DEFAULT,
-    message: 'should be a number',
+    message: `should be a number between 1 and ${ATTRIBUTE_COUNT_LIMIT_MAX}` ,
     validate: (value: unknown): value is number => isNumber(value) && value > 0 && value <= ATTRIBUTE_COUNT_LIMIT_MAX
   }
 }

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -151,7 +151,7 @@ export const schema: CoreSchema = {
   },
   attributeCountLimit: {
     defaultValue: ATTRIBUTE_COUNT_LIMIT_DEFAULT,
-    message: `should be a number between 1 and ${ATTRIBUTE_COUNT_LIMIT_MAX}` ,
+    message: `should be a number between 1 and ${ATTRIBUTE_COUNT_LIMIT_MAX}`,
     validate: (value: unknown): value is number => isNumber(value) && value > 0 && value <= ATTRIBUTE_COUNT_LIMIT_MAX
   }
 }

--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -1,4 +1,12 @@
 import type { OnSpanEndCallbacks } from './batch-processor'
+import {
+  ATTRIBUTE_ARRAY_LENGTH_LIMIT_DEFAULT,
+  ATTRIBUTE_COUNT_LIMIT_DEFAULT,
+  ATTRIBUTE_STRING_VALUE_LIMIT_DEFAULT,
+  ATTRIBUTE_ARRAY_LENGTH_LIMIT_MAX,
+  ATTRIBUTE_COUNT_LIMIT_MAX,
+  ATTRIBUTE_STRING_VALUE_LIMIT_MAX
+} from './custom-attribute-limits'
 import type { Plugin } from './plugin'
 import { isLogger, isNumber, isObject, isOnSpanEndCallbacks, isPluginArray, isString, isStringArray, isStringWithLength } from './validation'
 
@@ -42,6 +50,9 @@ export interface Configuration {
   bugsnag?: BugsnagErrorStatic
   samplingProbability?: number
   onSpanEnd?: OnSpanEndCallbacks
+  attributeStringValueLimit?: number
+  attributeArrayLengthLimit?: number
+  attributeCountLimit?: number
 }
 
 export interface TestConfiguration {
@@ -127,6 +138,21 @@ export const schema: CoreSchema = {
     defaultValue: undefined,
     message: 'should be an array of functions',
     validate: isOnSpanEndCallbacks
+  },
+  attributeStringValueLimit: {
+    defaultValue: ATTRIBUTE_STRING_VALUE_LIMIT_DEFAULT,
+    message: 'should be a number',
+    validate: (value: unknown): value is number => isNumber(value) && value > 0 && value <= ATTRIBUTE_STRING_VALUE_LIMIT_MAX
+  },
+  attributeArrayLengthLimit: {
+    defaultValue: ATTRIBUTE_ARRAY_LENGTH_LIMIT_DEFAULT,
+    message: 'should be a number',
+    validate: (value: unknown): value is number => isNumber(value) && value > 0 && value <= ATTRIBUTE_ARRAY_LENGTH_LIMIT_MAX
+  },
+  attributeCountLimit: {
+    defaultValue: ATTRIBUTE_COUNT_LIMIT_DEFAULT,
+    message: 'should be a number',
+    validate: (value: unknown): value is number => isNumber(value) && value > 0 && value <= ATTRIBUTE_COUNT_LIMIT_MAX
   }
 }
 

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -137,7 +137,7 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
         })
 
         logger = configuration.logger
-        spanFactory.configure(processor, logger)
+        spanFactory.configure(processor, configuration)
       })
 
       for (const plugin of configuration.plugins) {

--- a/packages/core/lib/custom-attribute-limits.ts
+++ b/packages/core/lib/custom-attribute-limits.ts
@@ -1,0 +1,22 @@
+import type { SpanAttributesLimits } from './attributes'
+
+export const ATTRIBUTE_STRING_VALUE_LIMIT_DEFAULT = 1024
+export const ATTRIBUTE_STRING_VALUE_LIMIT_MAX = 10_000
+
+export const ATTRIBUTE_ARRAY_LENGTH_LIMIT_DEFAULT = 1000
+export const ATTRIBUTE_ARRAY_LENGTH_LIMIT_MAX = 10_000
+
+export const ATTRIBUTE_COUNT_LIMIT_DEFAULT = 128
+export const ATTRIBUTE_COUNT_LIMIT_MAX = 1000
+
+export const defaultSpanAttributeLimits: SpanAttributesLimits = {
+  attributeStringValueLimit: ATTRIBUTE_STRING_VALUE_LIMIT_DEFAULT,
+  attributeArrayLengthLimit: ATTRIBUTE_ARRAY_LENGTH_LIMIT_DEFAULT,
+  attributeCountLimit: ATTRIBUTE_COUNT_LIMIT_DEFAULT
+}
+
+export const defaultResourceAttributeLimits: SpanAttributesLimits = {
+  attributeStringValueLimit: Infinity,
+  attributeArrayLengthLimit: Infinity,
+  attributeCountLimit: Infinity
+}

--- a/packages/core/lib/custom-attribute-limits.ts
+++ b/packages/core/lib/custom-attribute-limits.ts
@@ -1,5 +1,7 @@
 import type { SpanAttributesLimits } from './attributes'
 
+export const ATTRIBUTE_KEY_LENGTH_LIMIT = 128
+
 export const ATTRIBUTE_STRING_VALUE_LIMIT_DEFAULT = 1024
 export const ATTRIBUTE_STRING_VALUE_LIMIT_MAX = 10_000
 

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -165,6 +165,9 @@ export class SpanFactory <C extends Configuration> {
       get samplingRate () {
         return span.samplingRate
       },
+      get name () {
+        return span.name
+      },
       isValid: () => span.isValid(),
       setAttribute: (name, value) => { span.setAttribute(name, value) },
       end: (endTime) => {

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -72,7 +72,7 @@ export class SpanFactory <C extends Configuration> {
     const parentSpanId = parentContext ? parentContext.id : undefined
     const traceId = parentContext ? parentContext.traceId : this.idGenerator.generate(128)
 
-    const attributes = new SpanAttributes(new Map(), this.spanAttributeLimits, this.logger)
+    const attributes = new SpanAttributes(new Map(), this.spanAttributeLimits, name, this.logger)
 
     if (typeof options.isFirstClass === 'boolean') {
       attributes.set('bugsnag.span.first_class', options.isFirstClass)

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -7,7 +7,7 @@ import type { IdGenerator } from './id-generator'
 import type { NetworkSpanOptions } from './network-span'
 import type { Processor } from './processor'
 import type { ReadonlySampler } from './sampler'
-import type { InternalSpanOptions, Span, SpanEnded, SpanOptionSchema, SpanOptions } from './span'
+import type { InternalSpanOptions, Span, SpanOptionSchema, SpanOptions } from './span'
 import { SpanInternal, coreSpanOptionSchema } from './span'
 import type { SpanContextStorage } from './span-context'
 import { timeToNumber } from './time'
@@ -199,16 +199,5 @@ export class SpanFactory <C extends Configuration> {
     }
 
     return { name, options: cleanOptions } as unknown as InternalSpanOptions<O>
-  }
-}
-
-export function spanEndedToSpan (span: SpanEnded): Span {
-  return {
-    id: span.id,
-    traceId: span.traceId,
-    samplingRate: span.samplingRate,
-    isValid: () => false,
-    end: () => {}, // no-op
-    setAttribute: (name, value) => { span.attributes.set(name, value) }
   }
 }

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -10,6 +10,7 @@ import { isBoolean, isSpanContext, isTime } from './validation'
 const HOUR_IN_MILLISECONDS = 60 * 60 * 1000
 
 export interface Span extends SpanContext {
+  readonly name: string
   end: (endTime?: Time) => void
   setAttribute: (name: string, value: SpanAttribute) => void
 }
@@ -74,6 +75,9 @@ export function spanEndedToSpan (span: SpanEnded): Span {
     },
     get samplingRate () {
       return span.samplingRate
+    },
+    get name () {
+      return span.name
     },
     isValid: () => false,
     end: () => {}, // no-op

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -66,9 +66,15 @@ export function spanToJson (span: SpanEnded, clock: Clock): DeliverySpan {
 
 export function spanEndedToSpan (span: SpanEnded): Span {
   return {
-    id: span.id,
-    traceId: span.traceId,
-    samplingRate: span.samplingRate,
+    get id () {
+      return span.id
+    },
+    get traceId () {
+      return span.traceId
+    },
+    get samplingRate () {
+      return span.samplingRate
+    },
     isValid: () => false,
     end: () => {}, // no-op
     setAttribute: (name, value) => { span.attributes.set(name, value) }

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -48,7 +48,17 @@ export interface SpanEnded {
   readonly endTime: number // stored in the format returned from Clock.now (see clock.ts) - written once when 'end' is called
   samplingProbability: SpanProbability
   readonly parentSpanId?: string
-  setAttribute: (name: string, value: SpanAttribute) => void
+}
+
+export function spanEndedToSpan (span: SpanEnded): Span {
+  return {
+    id: span.id,
+    traceId: span.traceId,
+    samplingRate: span.samplingRate,
+    isValid: () => false,
+    end: () => {}, // no-op
+    setAttribute: (...args) => { span.attributes.set(...args) }
+  }
 }
 
 export function spanToJson (span: SpanEnded, clock: Clock): DeliverySpan {
@@ -113,7 +123,6 @@ export class SpanInternal implements SpanContext {
       events: this.events,
       samplingRate: this.samplingRate,
       endTime,
-      setAttribute: this.setAttribute,
       get samplingProbability (): SpanProbability {
         return _samplingProbability
       },

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -50,17 +50,6 @@ export interface SpanEnded {
   readonly parentSpanId?: string
 }
 
-export function spanEndedToSpan (span: SpanEnded): Span {
-  return {
-    id: span.id,
-    traceId: span.traceId,
-    samplingRate: span.samplingRate,
-    isValid: () => false,
-    end: () => {}, // no-op
-    setAttribute: (...args) => { span.attributes.set(...args) }
-  }
-}
-
 export function spanToJson (span: SpanEnded, clock: Clock): DeliverySpan {
   return {
     name: span.name,

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -48,6 +48,7 @@ export interface SpanEnded {
   readonly endTime: number // stored in the format returned from Clock.now (see clock.ts) - written once when 'end' is called
   samplingProbability: SpanProbability
   readonly parentSpanId?: string
+  setAttribute: (name: string, value: SpanAttribute) => void
 }
 
 export function spanToJson (span: SpanEnded, clock: Clock): DeliverySpan {
@@ -112,6 +113,7 @@ export class SpanInternal implements SpanContext {
       events: this.events,
       samplingRate: this.samplingRate,
       endTime,
+      setAttribute: this.setAttribute,
       get samplingProbability (): SpanProbability {
         return _samplingProbability
       },

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -64,6 +64,17 @@ export function spanToJson (span: SpanEnded, clock: Clock): DeliverySpan {
   }
 }
 
+export function spanEndedToSpan (span: SpanEnded): Span {
+  return {
+    id: span.id,
+    traceId: span.traceId,
+    samplingRate: span.samplingRate,
+    isValid: () => false,
+    end: () => {}, // no-op
+    setAttribute: (name, value) => { span.attributes.set(name, value) }
+  }
+}
+
 export class SpanInternal implements SpanContext {
   readonly id: string
   readonly traceId: string

--- a/packages/core/tests/attributes.test.ts
+++ b/packages/core/tests/attributes.test.ts
@@ -142,7 +142,7 @@ describe('attribute validation', () => {
 
     // New attribute should be discarded
     attributes.set('test.6', 'value')
-    expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.6 in span test.span was dropped as the number of attributes exceeds the 5 limit set by attributeCountLimit.')
+    expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.6 in span test.span was dropped as the number of attributes exceeds the 5 attribute limit set by attributeCountLimit.')
     expect(jestLogger.warn).toHaveBeenCalledTimes(1)
     expect(attributes.droppedAttributesCount).toBe(1)
     expect(attributes.toJson()).toStrictEqual([
@@ -156,7 +156,7 @@ describe('attribute validation', () => {
     // Existing attribute can be updated when at the attribute limit
     attributes.set('test.5', 'new-value')
     expect(jestLogger.warn).toHaveBeenCalledTimes(1)
-    expect(jestLogger.warn).not.toHaveBeenCalledWith('Span attribute test.5 in span test.span was dropped as the number of attributes exceeds the 5 limit set by attributeCountLimit.')
+    expect(jestLogger.warn).not.toHaveBeenCalledWith('Span attribute test.5 in span test.span was dropped as the number of attributes exceeds the 5 attribute limit set by attributeCountLimit.')
     expect(attributes.droppedAttributesCount).toBe(1)
     expect(attributes.toJson()).toStrictEqual([
       { key: 'test.1', value: { stringValue: 'value' } },

--- a/packages/core/tests/attributes.test.ts
+++ b/packages/core/tests/attributes.test.ts
@@ -1,8 +1,9 @@
 import { SpanAttributes, attributeToJson } from '../lib/attributes'
+import { defaultSpanAttributeLimits } from '../lib/custom-attribute-limits'
 
 describe('SpanAttributes', () => {
   it('prevents adding span attributes with invalid values', () => {
-    const attributes = new SpanAttributes(new Map())
+    const attributes = new SpanAttributes(new Map(), defaultSpanAttributeLimits, console)
     attributes.set('test.NaN', NaN)
     attributes.set('test.Infinity', Infinity)
     attributes.set('test.-Infinity', -Infinity)

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -7,19 +7,19 @@ import {
   StableIdGenerator,
   VALID_API_KEY,
   createSamplingProbability,
+  createSpanAttributes,
   createTestClient,
   spanAttributesSource
 } from '@bugsnag/js-performance-test-utilities'
+import type { SpanEnded } from '../lib'
 import {
+  DISCARD_END_TIME,
   InMemoryPersistence,
-  SpanAttributes,
   SpanFactory,
   SpanInternal,
-  spanToJson,
   spanContextEquals,
-  DISCARD_END_TIME
+  spanToJson
 } from '../lib'
-import type { SpanAttribute, SpanEnded } from '../lib'
 import Sampler from '../lib/sampler'
 
 jest.useFakeTimers()
@@ -115,7 +115,7 @@ describe('SpanInternal', () => {
         'trace id',
         'name',
         1234,
-        new SpanAttributes(new Map<string, SpanAttribute>()),
+        createSpanAttributes(),
         clock
       )
 
@@ -132,7 +132,7 @@ describe('SpanInternal', () => {
         'trace id',
         'name',
         1234,
-        new SpanAttributes(new Map<string, SpanAttribute>()),
+        createSpanAttributes(),
         clock
       )
 

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -115,7 +115,7 @@ describe('SpanInternal', () => {
         'trace id',
         'name',
         1234,
-        createSpanAttributes(),
+        createSpanAttributes('name'),
         clock
       )
 
@@ -132,7 +132,7 @@ describe('SpanInternal', () => {
         'trace id',
         'name',
         1234,
-        createSpanAttributes(),
+        createSpanAttributes('name'),
         clock
       )
 

--- a/packages/core/tests/span.test.ts
+++ b/packages/core/tests/span.test.ts
@@ -151,6 +151,7 @@ describe('Span', () => {
       const client = createTestClient()
       const span = client.startSpan('test span')
       expect(span).toStrictEqual({
+        name: expect.any(String),
         id: expect.any(String),
         traceId: expect.any(String),
         end: expect.any(Function),

--- a/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/route-change-plugin.ts
@@ -1,5 +1,5 @@
 import { coreSpanOptionSchema, isString, isObject } from '@bugsnag/core-performance'
-import type { InternalConfiguration, Plugin, SpanFactory, SpanOptionSchema, Time } from '@bugsnag/core-performance'
+import type { InternalConfiguration, Plugin, Span, SpanFactory, SpanOptionSchema, Time } from '@bugsnag/core-performance'
 import type { BrowserConfiguration } from '../config'
 import type { RouteChangeSpanEndOptions, RouteChangeSpanOptions } from '../routing-provider'
 import { getPermittedAttributes } from '../send-page-attributes'
@@ -52,12 +52,13 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
 
           return {
             id: '',
+            name: '',
             traceId: '',
             samplingRate: 0,
             isValid: () => false,
             setAttribute: () => {},
             end: () => {}
-          }
+          } satisfies Span
         }
       }
 
@@ -88,10 +89,19 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
       previousRoute = route
 
       return {
-        id: span.id,
-        traceId: span.traceId,
+        get id () {
+          return span.id
+        },
+        get traceId () {
+          return span.traceId
+        },
+        get samplingRate () {
+          return span.samplingRate
+        },
+        get name () {
+          return span.name
+        },
         isValid: span.isValid,
-        samplingRate: span.samplingRate,
         setAttribute: span.setAttribute,
         end: (endTimeOrOptions?: Time | RouteChangeSpanEndOptions): void => {
           const options: RouteChangeSpanEndOptions = isObject(endTimeOrOptions) ? endTimeOrOptions : { endTime: endTimeOrOptions }
@@ -117,7 +127,7 @@ export class RouteChangePlugin implements Plugin<BrowserConfiguration> {
           this.spanFactory.toPublicApi(span).end(options.endTime)
         }
 
-      }
+      } satisfies Span
     })
   }
 }

--- a/packages/platforms/browser/tests/span-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/span-attributes-source.test.ts
@@ -1,5 +1,5 @@
-import { SpanAttributes, SpanInternal } from '@bugsnag/core-performance'
-import { createConfiguration, IncrementingClock } from '@bugsnag/js-performance-test-utilities'
+import { SpanInternal } from '@bugsnag/core-performance'
+import { createConfiguration, createSpanAttributes, IncrementingClock } from '@bugsnag/js-performance-test-utilities'
 import type { BrowserConfiguration } from '../lib'
 import createSpanAttributesSource from '../lib/span-attributes-source'
 
@@ -15,7 +15,7 @@ const spanAttributesSource = createSpanAttributesSource(mockDocument as Document
 describe('spanAttributesSource', () => {
   it('adds permitted attributes to a span', () => {
     const browserConfiguration = createConfiguration<BrowserConfiguration>({ sendPageAttributes: { url: true, title: true } })
-    const spanAttributes = new SpanAttributes(new Map())
+    const spanAttributes = createSpanAttributes()
     const clock = new IncrementingClock()
     const span = new SpanInternal('id', 'traceId', 'test span', 1234, spanAttributes, clock)
 

--- a/packages/platforms/browser/tests/span-attributes-source.test.ts
+++ b/packages/platforms/browser/tests/span-attributes-source.test.ts
@@ -15,9 +15,9 @@ const spanAttributesSource = createSpanAttributesSource(mockDocument as Document
 describe('spanAttributesSource', () => {
   it('adds permitted attributes to a span', () => {
     const browserConfiguration = createConfiguration<BrowserConfiguration>({ sendPageAttributes: { url: true, title: true } })
-    const spanAttributes = createSpanAttributes()
+    const spanAttributes = createSpanAttributes('test.span')
     const clock = new IncrementingClock()
-    const span = new SpanInternal('id', 'traceId', 'test span', 1234, spanAttributes, clock)
+    const span = new SpanInternal('id', 'traceId', 'test.span', 1234, spanAttributes, clock)
 
     spanAttributesSource.requestAttributes(span)
 

--- a/packages/test-utilities/lib/create-span-attributes.ts
+++ b/packages/test-utilities/lib/create-span-attributes.ts
@@ -1,0 +1,12 @@
+import type { Logger } from '@bugsnag/core-performance'
+import { SpanAttributes } from '@bugsnag/core-performance'
+
+const createSpanAttributes = (logger: Logger = console) => {
+  return new SpanAttributes(new Map(), {
+    attributeStringValueLimit: 1024,
+    attributeArrayLengthLimit: 128,
+    attributeCountLimit: 128
+  }, logger)
+}
+
+export default createSpanAttributes

--- a/packages/test-utilities/lib/create-span-attributes.ts
+++ b/packages/test-utilities/lib/create-span-attributes.ts
@@ -1,12 +1,12 @@
 import type { Logger } from '@bugsnag/core-performance'
 import { SpanAttributes } from '@bugsnag/core-performance'
 
-const createSpanAttributes = (logger: Logger = console) => {
+const createSpanAttributes = (spanName: string, logger: Logger = console) => {
   return new SpanAttributes(new Map(), {
     attributeStringValueLimit: 1024,
     attributeArrayLengthLimit: 128,
     attributeCountLimit: 128
-  }, logger)
+  }, spanName, logger)
 }
 
 export default createSpanAttributes

--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -1,11 +1,10 @@
+import type { ScaledProbability, SpanEnded, SpanProbability } from '@bugsnag/core-performance'
 import {
-  SpanAttributes,
   SpanEvents,
   traceIdToSamplingRate
-
 } from '@bugsnag/core-performance'
-import type { ScaledProbability, SpanEnded, SpanProbability } from '@bugsnag/core-performance'
 import { randomBytes } from 'crypto'
+import createSpanAttributes from './create-span-attributes'
 
 export function createSamplingProbability (rawProbability: number): SpanProbability {
   return {
@@ -18,7 +17,7 @@ export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded 
   const traceId = overrides.traceId || randomBytes(16).toString('hex')
 
   return {
-    attributes: new SpanAttributes(new Map()),
+    attributes: createSpanAttributes(),
     events: new SpanEvents(),
     id: randomBytes(8).toString('hex'),
     name: 'test span',

--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -16,11 +16,10 @@ export function createSamplingProbability (rawProbability: number): SpanProbabil
 
 export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded {
   const traceId = overrides.traceId || randomBytes(16).toString('hex')
-
-  const defaultAttributes = new SpanAttributes(new Map())
+  const attributes = overrides.attributes || new SpanAttributes(new Map())
 
   return {
-    attributes: defaultAttributes,
+    attributes,
     events: new SpanEvents(),
     id: randomBytes(8).toString('hex'),
     name: 'test span',
@@ -30,7 +29,7 @@ export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded 
     samplingRate: traceIdToSamplingRate(traceId),
     endTime: 23456,
     samplingProbability: createSamplingProbability(1),
-    setAttribute: defaultAttributes.set,
+    setAttribute: attributes.set,
     ...overrides
   }
 }

--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -16,10 +16,9 @@ export function createSamplingProbability (rawProbability: number): SpanProbabil
 
 export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded {
   const traceId = overrides.traceId || randomBytes(16).toString('hex')
-  const attributes = overrides.attributes || new SpanAttributes(new Map())
 
   return {
-    attributes,
+    attributes: new SpanAttributes(new Map()),
     events: new SpanEvents(),
     id: randomBytes(8).toString('hex'),
     name: 'test span',
@@ -29,7 +28,6 @@ export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded 
     samplingRate: traceIdToSamplingRate(traceId),
     endTime: 23456,
     samplingProbability: createSamplingProbability(1),
-    setAttribute: attributes.set,
     ...overrides
   }
 }

--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -15,12 +15,13 @@ export function createSamplingProbability (rawProbability: number): SpanProbabil
 
 export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded {
   const traceId = overrides.traceId || randomBytes(16).toString('hex')
+  const spanName = overrides.name || 'test span'
 
   return {
-    attributes: createSpanAttributes(),
+    attributes: createSpanAttributes(spanName),
     events: new SpanEvents(),
     id: randomBytes(8).toString('hex'),
-    name: 'test span',
+    name: spanName,
     kind: 1,
     startTime: 12345,
     traceId,

--- a/packages/test-utilities/lib/create-span.ts
+++ b/packages/test-utilities/lib/create-span.ts
@@ -17,8 +17,10 @@ export function createSamplingProbability (rawProbability: number): SpanProbabil
 export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded {
   const traceId = overrides.traceId || randomBytes(16).toString('hex')
 
+  const defaultAttributes = new SpanAttributes(new Map())
+
   return {
-    attributes: new SpanAttributes(new Map()),
+    attributes: defaultAttributes,
     events: new SpanEvents(),
     id: randomBytes(8).toString('hex'),
     name: 'test span',
@@ -28,6 +30,7 @@ export function createEndedSpan (overrides: Partial<SpanEnded> = {}): SpanEnded 
     samplingRate: traceIdToSamplingRate(traceId),
     endTime: 23456,
     samplingProbability: createSamplingProbability(1),
+    setAttribute: defaultAttributes.set,
     ...overrides
   }
 }

--- a/packages/test-utilities/lib/index.ts
+++ b/packages/test-utilities/lib/index.ts
@@ -11,6 +11,7 @@ export { default as IncrementingClock } from './incrementing-clock'
 export { default as IncrementingIdGenerator } from './incrementing-id-generator'
 export { default as MockSpanFactory } from './mock-span-factory'
 export { default as resourceAttributesSource } from './resource-attributes-source'
+export { default as createSpanAttributes } from './create-span-attributes'
 export { default as spanAttributesSource } from './span-attributes-source'
 export { default as StableIdGenerator } from './stable-id-generator'
 


### PR DESCRIPTION
## Goal

Add validation for custom span attributes

## Changeset

- Add new configuration options for attribute validation
- Add new validation method for truncating string and array attributes based on configuration options
- Add new validation method for dropping spans based on configuration options
- Add logging for modified spans

## Testing

Add unit tests for all attribute limits and behaviours