### PR TITLE
Idempotent test commands in React Native

### DIFF
--- a/test/react-native/features/fixtures/scenario-launcher/lib/CommandRunner.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/CommandRunner.js
@@ -4,6 +4,7 @@ const DEFAULT_RETRY_COUNT = 20
 const INTERVAL = 500
 
 let mazeAddress
+let lastCommandUuid
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -16,7 +17,8 @@ export async function getCurrentCommand (allowedRetries = DEFAULT_RETRY_COUNT) {
     mazeAddress = await getMazeRunnerAddress()
   }
 
-  const url = `http://${mazeAddress}/command`
+  const lastCommand = lastCommandUuid || ""
+  const url = `http://${mazeAddress}/command?after=${lastCommand}`
   console.error(`[BugsnagPerformance] Fetching command from ${url}`)
 
   let retries = 0
@@ -28,6 +30,7 @@ export async function getCurrentCommand (allowedRetries = DEFAULT_RETRY_COUNT) {
       console.error(`[BugsnagPerformance] Response from maze runner: ${text}`)
 
       const command = JSON.parse(text)
+      lastCommandUuid = command.uuid
 
       // keep polling until a scenario command is received
       if (command.action !== 'noop') {

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -40,7 +40,7 @@ async function runScenario (rootTag, scenarioName, apiKey, endpoint) {
     appVersion: '1.2.3',
     networkRequestCallback: (requestInfo) => {
       // ignore requests to the maze runner command endpoint
-      if (requestInfo.url.endsWith('/command')) {
+      if (requestInfo.url.includes('/command?after=')) {
         console.error(`[BugsnagPerformance] ignoring request to ${requestInfo.url}`)
         return null
       }

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -61,11 +61,6 @@ def execute_command(action, scenario_name = '')
 
   $logger.debug("Queuing command: #{command}")
   Maze::Server.commands.add command
-
-  # Ensure fixture has read the command
-  count = 900
-  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
-  raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
 end
 
 def get_expected_platform_value(platform_values)


### PR DESCRIPTION
## Goal

Make react-native maze-runner command pattern idempotent 

## Changeset

- Store the last command uuid
- Add the last command uuid to the next command request
- Remove timeout message `Test fixture did not GET /command`