### PR TITLE
Remove CI pipeline Docker env files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,6 @@ services:
       BITBAR_ACCESS_KEY:
       HOST: "${HOST:-maze-runner}"
       API_HOST: "${API_HOST:-maze-runner}"
-    env_file:
-      - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
     networks:
       default:
         aliases:
@@ -66,8 +64,6 @@ services:
       BROWSER_STACK_ACCESS_KEY:
       HOST: "${HOST:-maze-runner}"
       API_HOST: "${API_HOST:-maze-runner}"
-    env_file:
-      - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
     networks:
       default:
         aliases:
@@ -87,8 +83,6 @@ services:
       BROWSER_STACK_USERNAME:
       BROWSER_STACK_ACCESS_KEY:
       USE_LEGACY_DRIVER: 1
-    env_file:
-      - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
     networks:
       default:
         aliases:


### PR DESCRIPTION
## Goal

Fix the following overnight failures building the Maze Runner image:
```
Failed to load /var/lib/buildkite-agent/builds/docker_env_file: open /var/lib/buildkite-agent/builds/docker_env_file: no such file or directory
```

## Design

It's unclear how the failures started (why best guess is an S3 secrets change), but we don't actually provide a Docker env file anyway and so this complexity can just be removed.

## Testing

Covered by a full CI run.