### PR TITLE
RN native integration e2e test setup

### DIFF
--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -297,6 +297,7 @@ steps:
               - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
+              - --tags=@native_integration
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -333,6 +334,7 @@ steps:
               - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
+              - --tags=@native_integration
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -440,6 +442,7 @@ steps:
               - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
+              - --tags=@native_integration
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -476,6 +479,7 @@ steps:
               - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
+              - --tags=@native_integration
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -55,6 +55,59 @@ steps:
             - exit_status: "*"
               limit: 1
 
+      - label: ':android: Build RN {{matrix}} native integration test fixture APK (Old Arch)'
+        key: "build-react-native-android-fixture-native-integration-old-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: macos-14
+        env:
+          JAVA_VERSION: "17"
+          NODE_VERSION: "18"
+          RN_VERSION: "{{matrix}}"
+          NOTIFIER_VERSION: '8.0.0'
+          BUILD_ANDROID: "true"
+          NATIVE_INTEGRATION: "1"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/reactnative.apk"
+        plugins:
+          artifacts#v1.9.3:
+            upload: "test/react-native/features/fixtures/generated/native-integration/old-arch"
+            compressed: rn-projects.zip
+        commands:
+          - bundle install
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.75"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+      - label: ':android: Build RN {{matrix}} native integration test fixture APK (New Arch)'
+        key: "build-react-native-android-fixture-native-integration-new-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: macos-14
+        env:
+          JAVA_VERSION: "17"
+          NODE_VERSION: "18"
+          RN_VERSION: "{{matrix}}"
+          NOTIFIER_VERSION: '8.0.0'
+          RCT_NEW_ARCH_ENABLED: "true"
+          BUILD_ANDROID: "true"
+          NATIVE_INTEGRATION: "1"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/native-integration/new-arch/**/reactnative.apk"
+        commands:
+          - bundle install
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.75"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
       - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
         key: "build-react-native-ios-fixture-old-arch"
         timeout_in_minutes: 30
@@ -92,6 +145,55 @@ steps:
           XCODE_VERSION: "15.3.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/new-arch/**/output/reactnative.ipa"
+        commands:
+          - bundle install
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.75"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+      - label: ':mac: Build RN {{matrix}} native integration test fixture ipa (Old Arch)'
+        key: "build-react-native-ios-fixture-native-integration-old-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: "macos-14"
+        env:
+          NODE_VERSION: "18"
+          RN_VERSION: "{{matrix}}"
+          NOTIFIER_VERSION: '8.0.0'
+          BUILD_IOS: "true"
+          XCODE_VERSION: "15.3.0"
+          NATIVE_INTEGRATION: "1"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/output/reactnative.ipa"
+        commands:
+          - bundle install
+          - ./bin/generate-react-native-fixture
+        matrix:
+          - "0.75"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+      - label: ':mac: Build RN {{matrix}} native integration test fixture ipa (New Arch)'
+        key: "build-react-native-ios-fixture-native-integration-new-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: "macos-14"
+        env:
+          NODE_VERSION: "18"
+          RN_VERSION: "{{matrix}}"
+          RCT_NEW_ARCH_ENABLED: "1"
+          NOTIFIER_VERSION: '8.0.0'
+          BUILD_IOS: "true"
+          XCODE_VERSION: "15.3.0"
+          NATIVE_INTEGRATION: "1"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/native-integration/new-arch/**/output/reactnative.ipa"
         commands:
           - bundle install
           - ./bin/generate-react-native-fixture
@@ -175,6 +277,79 @@ steps:
         matrix:
           - "0.75"
 
+      - label: ":bitbar: :android: RN {{matrix}} native integration Android 12 (Old Arch) end-to-end tests"
+        depends_on: "build-react-native-android-fixture-native-integration-old-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.7.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk
+              - --farm=bb
+              - --device=ANDROID_12
+              - --a11y-locator
+              - --fail-fast
+              - --appium-version=1.22
+              - --no-tunnel
+              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+        env:
+          NATIVE_INTEGRATION: "1"
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: eager
+        matrix:
+          - "0.75"
+
+      - label: ":bitbar: :android: RN {{matrix}} native integration Android 12 (New Arch) end-to-end tests"
+        depends_on: "build-react-native-android-fixture-native-integration-new-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/native-integration/new-arch/{{matrix}}/reactnative.apk"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.7.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/native-integration/new-arch/{{matrix}}/reactnative.apk
+              - --farm=bb
+              - --device=ANDROID_12
+              - --a11y-locator
+              - --fail-fast
+              - --appium-version=1.22
+              - --no-tunnel
+              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+        env:
+          RCT_NEW_ARCH_ENABLED: "1"
+          NATIVE_INTEGRATION: "1"
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: eager
+        matrix:
+          - "0.75"
+
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-old-arch"
         timeout_in_minutes: 60
@@ -236,6 +411,79 @@ steps:
             api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           RCT_NEW_ARCH_ENABLED: "1"
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: eager
+        matrix:
+          - "0.75"
+
+      - label: ":bitbar: :mac: RN {{matrix}} native integration iOS 14 (Old Arch) end-to-end tests"
+        depends_on: "build-react-native-ios-fixture-native-integration-old-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.12.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa
+              - --farm=bb
+              - --device=IOS_14
+              - --a11y-locator
+              - --fail-fast
+              - --appium-version=1.22
+              - --no-tunnel
+              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+        env:
+          NATIVE_INTEGRATION: "1"
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: eager
+        matrix:
+          - "0.75"
+
+      - label: ":bitbar: :mac: RN {{matrix}} native integration iOS 14 (New Arch) end-to-end tests"
+        depends_on: "build-react-native-ios-fixture-native-integration-new-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/native-integration/new-arch/{{matrix}}/output/reactnative.ipa"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.12.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/native-integration/new-arch/{{matrix}}/output/reactnative.ipa
+              - --farm=bb
+              - --device=IOS_14
+              - --a11y-locator
+              - --fail-fast
+              - --appium-version=1.22
+              - --no-tunnel
+              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+        env:
+          RCT_NEW_ARCH_ENABLED: "1"
+          NATIVE_INTEGRATION: "1"
         retry:
           manual:
             permit_on_passed: true

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -17,10 +17,6 @@ steps:
           BUILD_ANDROID: "true"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/old-arch/**/reactnative.apk"
-        plugins:
-          artifacts#v1.9.3:
-            upload: "test/react-native/features/fixtures/generated/old-arch"
-            compressed: rn-projects.zip
         commands:
           - bundle install
           - ./bin/generate-react-native-fixture
@@ -69,10 +65,6 @@ steps:
           NATIVE_INTEGRATION: "1"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/reactnative.apk"
-        plugins:
-          artifacts#v1.9.3:
-            upload: "test/react-native/features/fixtures/generated/native-integration/old-arch"
-            compressed: rn-projects.zip
         commands:
           - bundle install
           - ./bin/generate-react-native-fixture

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -22,6 +22,11 @@ let fixturePath = 'test/react-native/features/fixtures/generated/'
 if (process.env.REACT_NATIVE_NAVIGATION === 'true' || process.env.REACT_NATIVE_NAVIGATION === '1') {
   fixturePath += 'react-native-navigation/'
 }
+
+if (process.env.NATIVE_INTEGRATION) {
+  fixturePath += 'native-integration/'
+}
+
 if (process.env.RCT_NEW_ARCH_ENABLED === 'true' || process.env.RCT_NEW_ARCH_ENABLED === '1') {
   fixturePath += 'new-arch/'
 } else {
@@ -108,6 +113,11 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
   // apply additional modifications required for RN 0.64
   if (parseFloat(reactNativeVersion) === 0.64) {
     configureRN064Fixture(fixtureDir)
+  }
+
+  if (process.env.NATIVE_INTEGRATION === '1') {
+    installAndroidPerformance()
+    installCocoaPerformance()
   }
 
   // link react-native-navigation using rnn-link tool
@@ -302,4 +312,28 @@ function replaceGeneratedFixtureFiles() {
       resolve(fixtureDir, `android/app/src/main/java/com/bugsnag/fixtures/reactnative/performance/MainActivity.${fileExtension}`)
     )
   }
+}
+
+function installAndroidPerformance() {
+  // add 'implementation "com.bugsnag:bugsnag-android-performance:1.+"' to the dependencies section in the app/build.gradle file
+  const appGradlePath = resolve(fixtureDir, 'android/app/build.gradle')
+  let appGradle = fs.readFileSync(appGradlePath, 'utf8')
+
+  const performanceDependency = 'implementation("com.bugsnag:bugsnag-android-performance:1.+")'
+  const dependenciesSection = 'dependencies {'
+
+  appGradle = appGradle.replace(dependenciesSection, `${dependenciesSection}\n    ${performanceDependency}`)
+  fs.writeFileSync(appGradlePath, appGradle)
+}
+
+function installCocoaPerformance() {
+  // add 'pod "BugsnagPerformance"' to the Podfile
+  const podfilePath = resolve(fixtureDir, 'ios/Podfile')
+  let podfile = fs.readFileSync(podfilePath, 'utf8')
+
+  const performancePod = `pod 'BugsnagPerformance'`
+  const targetSection = 'target \'reactnative\' do'
+
+  podfile = podfile.replace(targetSection, `${targetSection}\n  ${performancePod}`)
+  fs.writeFileSync(podfilePath, podfile)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       BITBAR_ACCESS_KEY:
       RCT_NEW_ARCH_ENABLED:
       REACT_NATIVE_NAVIGATION:
+      NATIVE_INTEGRATION:
     ports:
       - "9000-9499:9339"
     networks:

--- a/test/react-native/features/fixtures/scenario-launcher/ScenarioLauncher.podspec
+++ b/test/react-native/features/fixtures/scenario-launcher/ScenarioLauncher.podspec
@@ -21,4 +21,8 @@ Pod::Spec.new do |s|
   else
     s.dependency "React-Core"
   end
+
+  if ENV["NATIVE_INTEGRATION"] == "1"
+    s.compiler_flags = "$(inherited)", "-DNATIVE_INTEGRATION=1"
+  end
 end

--- a/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
+++ b/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
@@ -36,5 +36,6 @@ repositories {
 
 dependencies {
   api "com.bugsnag:bugsnag-android:6.+"
+  compileOnly "com.bugsnag:bugsnag-android-performance:1.+"
   implementation 'com.facebook.react:react-native'
 }

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
@@ -3,10 +3,16 @@ package com.bugsnag.reactnative.scenariolauncher;
 import android.util.Log;
 import android.content.Context;
 import android.content.SharedPreferences;
+
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.EndpointConfiguration;
 import com.bugsnag.android.Logger;
+
+import com.bugsnag.android.performance.BugsnagPerformance;
+import com.bugsnag.android.performance.PerformanceConfiguration;
+import com.bugsnag.android.performance.Span;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -146,5 +152,22 @@ class ScenarioLauncherImpl {
 
   public void exitApp() {
     System.exit(0);
+  }
+
+  public void startNativePerformance(ReadableMap configuration, Promise promise) {
+    try {
+        PerformanceConfiguration config = PerformanceConfiguration.load(reactContext);
+        config.setApiKey(configuration.getString("apiKey"));
+        config.setEndpoint(configuration.getString("endpoint"));
+        BugsnagPerformance.start(config);
+        Log.d(MODULE_NAME, "Started Android performance");
+    
+        Span span = BugsnagPerformance.startSpan("NativeIntegration");
+        span.end();
+    } catch (Exception e) {
+        Log.d(MODULE_NAME, "Failed to start Android performance", e);
+    }
+
+    promise.resolve(true);
   }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
@@ -9,6 +9,7 @@ import com.bugsnag.android.Configuration;
 import com.bugsnag.android.EndpointConfiguration;
 import com.bugsnag.android.Logger;
 
+import com.bugsnag.android.performance.AutoInstrument;
 import com.bugsnag.android.performance.BugsnagPerformance;
 import com.bugsnag.android.performance.PerformanceConfiguration;
 import com.bugsnag.android.performance.Span;
@@ -159,11 +160,18 @@ class ScenarioLauncherImpl {
         PerformanceConfiguration config = PerformanceConfiguration.load(reactContext);
         config.setApiKey(configuration.getString("apiKey"));
         config.setEndpoint(configuration.getString("endpoint"));
+        config.setAutoInstrumentAppStarts(false);
+        config.setAutoInstrumentActivities(AutoInstrument.OFF);
+
         BugsnagPerformance.start(config);
         Log.d(MODULE_NAME, "Started Android performance");
     
         Span span = BugsnagPerformance.startSpan("NativeIntegration");
         span.end();
+
+        // Move the app to the background to force the queue to flush
+        reactContext.getCurrentActivity().moveTaskToBack(true);
+
     } catch (Exception e) {
         Log.d(MODULE_NAME, "Failed to start Android performance", e);
     }

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/newarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/newarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
@@ -45,5 +45,10 @@ public class ScenarioLauncher extends NativeScenarioLauncherSpec {
   public void exitApp() {
     impl.exitApp();
   }
+
+  @Override
+  public void startNativePerformance(ReadableMap configuration, Promise promise) {
+    impl.startNativePerformance(configuration, promise);
+  }
 }
 

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/oldarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/oldarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
@@ -47,4 +47,9 @@ public class ScenarioLauncher extends ReactContextBaseJavaModule {
   public void exitApp() {
     impl.exitApp();
   }
+
+  @ReactMethod
+  public void startNativePerformance(ReadableMap configuration, Promise promise) {
+    impl.startNativePerformance(configuration, promise);
+  }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.h
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.h
@@ -13,6 +13,7 @@
     - (id) saveStartupConfig:(NSDictionary *)config;
     - (NSDictionary *) readStartupConfig;
     - (id) exitApp;
+    - (void) startNativePerformance:(NSDictionary *)configuration resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 @end
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
@@ -4,6 +4,7 @@
 
 #ifdef NATIVE_INTEGRATION
 #import <BugsnagPerformance/BugsnagPerformance.h>
+#import <BugsnagPerformance/BugsnagPerformanceConfiguration+Private.h>
 #endif
 
 @implementation ScenarioLauncher
@@ -119,6 +120,11 @@ RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(
     BugsnagPerformanceConfiguration *config = [BugsnagPerformanceConfiguration loadConfig];
     config.apiKey = apiKey;
     config.endpoint = [[NSURL alloc] initWithString: endpoint];
+    config.autoInstrumentAppStarts = NO;
+    config.autoInstrumentViewControllers = NO;
+    config.autoInstrumentNetworkRequests = NO;
+    config.internal.autoTriggerExportOnBatchSize = 1;
+
     [BugsnagPerformance startWithConfiguration:config];
 
     BugsnagPerformanceSpan *span = [BugsnagPerformance startSpanWithName:@"NativeIntegration"];

--- a/test/react-native/features/fixtures/scenario-launcher/lib/NativeScenarioLauncher.ts
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/NativeScenarioLauncher.ts
@@ -7,6 +7,7 @@ export interface Spec extends TurboModule {
   saveStartupConfig(config: UnsafeObject): void;
   readStartupConfig(): UnsafeObject | null | undefined;
   exitApp(): void;
+  startNativePerformance(configuration: UnsafeObject): Promise<void>;
 }
 
 export default TurboModuleRegistry.get<Spec>("ScenarioLauncher") as Spec | null;

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/NativeIntegrationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/NativeIntegrationScenario.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import { NativeScenarioLauncher } from '../lib/native'
+
+export const initialise = async (config) => {
+  const nativeConfig = {
+    apiKey: config.apiKey,
+    endpoint: config.endpoint
+  }
+
+  await NativeScenarioLauncher.startNativePerformance(nativeConfig)
+}
+
+export const App = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>Native Integration Scenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -18,3 +18,6 @@ export * as ReactNativeNavigationScenario from './ReactNativeNavigationScenario'
 
 // React Navigation Scenarios
 export * as ReactNavigationScenario from './ReactNavigationScenario'
+
+// Native Integration Scenarios
+export * as NativeIntegrationScenario from './NativeIntegrationScenario'

--- a/test/react-native/features/native-integration.feature
+++ b/test/react-native/features/native-integration.feature
@@ -1,0 +1,10 @@
+@native_integration
+Feature: Native Integration
+
+  Scenario: Native Integration
+    When I run 'NativeIntegrationScenario'
+    And I wait for 60 seconds
+    Then a span named "NativeIntegration" contains the attributes:
+            | attribute                         | type             | value                    |
+            | bugsnag.span.first_class          | boolValue        | true                     |
+

--- a/test/react-native/features/native-integration.feature
+++ b/test/react-native/features/native-integration.feature
@@ -3,7 +3,7 @@ Feature: Native Integration
 
   Scenario: Native Integration
     When I run 'NativeIntegrationScenario'
-    And I wait for 60 seconds
+    And I wait to receive at least 1 span
     Then a span named "NativeIntegration" contains the attributes:
             | attribute                         | type             | value                    |
             | bugsnag.span.first_class          | boolValue        | true                     |

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -24,3 +24,7 @@ end
 Before('@skip_react_native_navigation') do |scenario|
   skip_this_scenario("Skipping scenario") if ENV["REACT_NATIVE_NAVIGATION"]
 end
+
+Before('@native_integration') do |scenario|
+  skip_this_scenario("Skipping scenario: Not running native integration fixture") unless ENV["NATIVE_INTEGRATION"]
+end

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -3,6 +3,11 @@ BeforeAll do
     Maze.config.android_app_files_directory = '/data/local/tmp'
   end
   Maze.config.enforce_bugsnag_integrity = false
+
+  if ENV["NATIVE_INTEGRATION"]
+    Maze.config.receive_requests_wait = 60
+  end
+
 end
 
 Before('@skip') do


### PR DESCRIPTION
## Goal

e2e test setup for native performance integration in React Native:

 - Generate a separate e2e test fixture with native performance SDKs installed.
 - Add support for starting the native Android and Cocoa SDKs through the scenario launcher
 - Add a basic scenario that sends a custom native span - this is really a placeholder test to make sure that the setup works and will be replaced when we start to add functionality.

## Design

A separate test fixture is required so that we can make sure the SDK continues to work as expected when native Android and Cocoa performance SDKs are not installed (existing fixtures and tests).

The test fixture generation script will only install the native Android and Cocoa SDKs when the `NATIVE_INTEGRATION` environment variable is set.

## Testing

Covered by CI