### PR TITLE
Fix React Native CI

### DIFF
--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -127,7 +127,8 @@ if (process.env.BUILD_IOS === 'true' || process.env.BUILD_IOS === '1') {
   fs.rmSync(`${fixtureDir}/reactnative.xcarchive`, { recursive: true, force: true })
 
   // install pods
-  execFileSync('pod', ['install'], { cwd: `${fixtureDir}/ios`, stdio: 'inherit' })
+  execFileSync('bundle', ['install'], { cwd: `${fixtureDir}/ios`, stdio: 'inherit' })
+  execFileSync('bundle', ['exec', 'pod', 'install'], { cwd: `${fixtureDir}/ios`, stdio: 'inherit' })
 
   // build the iOS app
   const archiveArgs = [
@@ -222,6 +223,9 @@ function configureRN064Fixture(fixtureDir) {
   let yogaCpp = fs.readFileSync(yogaCppPath, 'utf8')
   yogaCpp = yogaCpp.replace('node->getLayout().hadOverflow() |', 'node->getLayout().hadOverflow() ||')
   fs.writeFileSync(yogaCppPath, yogaCpp)
+
+  // copy gemfile
+  fs.copyFileSync(resolve(ROOT_DIR, 'test/react-native/features/fixtures/app/Gemfile'), resolve(fixtureDir, 'Gemfile'))
 }
 
 /** Pack and install local packages from this repo */
@@ -312,4 +316,12 @@ function replaceGeneratedFixtureFiles() {
   }
 
   fs.writeFileSync(`${fixtureDir}/ios/Podfile`, podfileContents)
+
+  // pin xcodeproj version to < 1.26.0
+  const gemfilePath = resolve(fixtureDir, 'Gemfile')
+  if (fs.existsSync(gemfilePath)) {
+    let gemfileContents = fs.readFileSync(gemfilePath, 'utf8')
+    gemfileContents += `\ngem 'xcodeproj', '< 1.26.0'`
+    fs.writeFileSync(gemfilePath, gemfileContents)
+  }
 }

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -302,4 +302,14 @@ function replaceGeneratedFixtureFiles() {
       resolve(fixtureDir, `android/app/src/main/java/com/bugsnag/fixtures/reactnative/performance/MainActivity.${fileExtension}`)
     )
   }
+
+  // disable Flipper
+  let podfileContents = fs.readFileSync(`${fixtureDir}/ios/Podfile`, 'utf8')
+  if (podfileContents.includes('use_flipper!')) {
+    podfileContents = podfileContents.replace(/use_flipper!/, '# use_flipper!')
+  } else if (podfileContents.includes(':flipper_configuration')) {
+    podfileContents = podfileContents.replace(/:flipper_configuration/, '# :flipper_configuration')
+  }
+
+  fs.writeFileSync(`${fixtureDir}/ios/Podfile`, podfileContents)
 }

--- a/test/react-native/features/fixtures/app/Gemfile
+++ b/test/react-native/features/fixtures/app/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'cocoapods', '1.14.3'
+gem 'xcodeproj', '< 1.26.0'


### PR DESCRIPTION
## Goal

Fix the React Native CI pipeline:

- Pin the xcodeproj gem version in generated test fixtures - for RN 0.64 this requires a gemfile to be added to the generated fixture.
- Run `bundle install && bundle exec pod install` in test fixtures to use the correct version of cocoapods for each fixture

## Testing

Covered by a full CI run