### PR TITLE
fix(react-native): prevent duplicate app start spans from being started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- (react-native) Prevent duplicate app start spans from being started [#524](https://github.com/bugsnag/bugsnag-js-performance/pull/524)
+
 ### Changed
 
 - (browser) Update Span and Trace ID generator code to allow for modified `Array.from` API [#518](https://github.com/bugsnag/bugsnag-js-performance/pull/518)

--- a/packages/platforms/react-native/lib/create-app-start-span.ts
+++ b/packages/platforms/react-native/lib/create-app-start-span.ts
@@ -9,8 +9,6 @@ export function createAppStartSpan (spanFactory: SpanFactory<ReactNativeConfigur
   }
 
   appStartSpan = spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
-
-  spanFactory.startSpan('[AppStart/ReactNativeInit]', { startTime: appStartTime, parentContext: null })
   appStartSpan.setAttribute('bugsnag.span.category', 'app_start')
   appStartSpan.setAttribute('bugsnag.app_start.type', 'ReactNativeInit')
 

--- a/packages/platforms/react-native/tests/create-app-start-span.test.ts
+++ b/packages/platforms/react-native/tests/create-app-start-span.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+import { MockSpanFactory } from '@bugsnag/js-performance-test-utilities'
+import type { ReactNativeConfiguration } from '../lib/config'
+import type { SpanFactory, SpanInternal } from '@bugsnag/core-performance'
+
+let createAppStartSpan: (spanFactory: SpanFactory<ReactNativeConfiguration>, appStartTime: number) => SpanInternal
+let spanFactory: SpanFactory<ReactNativeConfiguration>
+
+describe('createAppStartSpan', () => {
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      spanFactory = new MockSpanFactory()
+      createAppStartSpan = require('../lib/create-app-start-span').createAppStartSpan
+    })
+  })
+
+  it('creates an app start span with the supplied start time', () => {
+    const appStartSpan = createAppStartSpan(spanFactory, 12345)
+    const appStartSpanEnded = appStartSpan.end(12345, spanFactory.sampler.spanProbability)
+
+    expect(appStartSpanEnded.name).toBe('[AppStart/ReactNativeInit]')
+    expect(appStartSpanEnded.startTime).toBe(12345)
+  })
+
+  it('sets the parent context to null', () => {
+    spanFactory.startSpan('should not become parent', { startTime: 12345 })
+
+    const appStartSpan = createAppStartSpan(spanFactory, 12345)
+    const appStartSpanEnded = appStartSpan.end(54321, spanFactory.sampler.spanProbability)
+
+    expect(appStartSpanEnded.parentSpanId).toBeUndefined()
+  })
+
+  it('sets the required attributes', () => {
+    const appStartSpan = createAppStartSpan(spanFactory, 12345)
+    const appStartSpanEnded = appStartSpan.end(12345, spanFactory.sampler.spanProbability)
+
+    expect(appStartSpanEnded.attributes.toJson()).toStrictEqual([
+      { key: 'bugsnag.span.category', value: { stringValue: 'app_start' } },
+      { key: 'bugsnag.app_start.type', value: { stringValue: 'ReactNativeInit' } },
+      { key: 'bugsnag.sampling.p', value: { doubleValue: 1 } }
+    ])
+  })
+
+  it('prevents multiple app start spans from being created', () => {
+    const appStartSpan1 = createAppStartSpan(spanFactory, 12345)
+
+    expect(spanFactory.startSpan).toHaveBeenCalledTimes(1)
+
+    const appStartSpan2 = createAppStartSpan(spanFactory, 12345)
+
+    expect(spanFactory.startSpan).toHaveBeenCalledTimes(1)
+    expect(appStartSpan1).toBe(appStartSpan2)
+  })
+})


### PR DESCRIPTION
## Goal

Fixes a bug in `createAppStartSpan` where a duplicate app start span was being started

## Testing

Added some unit tests around `createAppStartSpan`