### PR TITLE
Add support for attaching to native performance SDKs

### DIFF
--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -128,6 +128,12 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
 
 // generate Android Fixture
 if (process.env.BUILD_ANDROID === 'true' || process.env.BUILD_ANDROID === '1') {
+  // build and publish bugsnag-android-performance to local maven repo
+  // this is required even if we're not building the native integration fixture because
+  // @bugsnag/react-native-performance has a compileOnly dependency on bugsnag-android-performance
+  // TODO: remove this once changes have been released in bugsnag-android-performance
+  publishLocalAndroidPerformance()
+
   execFileSync('./gradlew', ['assembleRelease'], { cwd: `${fixtureDir}/android`, stdio: 'inherit' })
   fs.copyFileSync(`${fixtureDir}/android/app/build/outputs/apk/release/app-release.apk`, `${fixtureDir}/reactnative.apk`)
 }
@@ -336,12 +342,34 @@ function replaceGeneratedFixtureFiles() {
   }
 }
 
+function publishLocalAndroidPerformance() {
+  // add bugsnag-android-performance as a git submodule
+  execSync(`git submodule add -b integration/react-native-integration https://github.com/bugsnag/bugsnag-android-performance`, { cwd: fixtureDir, stdio: 'inherit' })
+
+  // build and publish bugsnag-android-performance to maven local
+  execSync(`./gradlew -PVERSION_NAME=9.9.9 clean publishToMavenLocal`, { cwd: `${fixtureDir}/bugsnag-android-performance`, stdio: 'inherit' })
+
+  // add mavenLocal() to the repositories section in the android/build.gradle file
+  const buildGradlePath = resolve(fixtureDir, 'android/build.gradle')
+  let buildGradle = fs.readFileSync(buildGradlePath, 'utf8')
+  const repositoriesBlock = `allprojects {
+  repositories {
+    mavenLocal()
+    mavenCentral()
+    google()
+  }
+}`
+
+  buildGradle = `${repositoriesBlock}\n${buildGradle}`
+  fs.writeFileSync(buildGradlePath, buildGradle)
+}
+
 function installAndroidPerformance() {
-  // add 'implementation "com.bugsnag:bugsnag-android-performance:1.+"' to the dependencies section in the app/build.gradle file
+  // declare dependency in the app/build.gradle file
   const appGradlePath = resolve(fixtureDir, 'android/app/build.gradle')
   let appGradle = fs.readFileSync(appGradlePath, 'utf8')
 
-  const performanceDependency = 'implementation("com.bugsnag:bugsnag-android-performance:1.+")'
+  const performanceDependency = 'implementation("com.bugsnag:bugsnag-android-performance:9.9.9")'
   const dependenciesSection = 'dependencies {'
 
   appGradle = appGradle.replace(dependenciesSection, `${dependenciesSection}\n    ${performanceDependency}`)
@@ -353,7 +381,7 @@ function installCocoaPerformance() {
   const podfilePath = resolve(fixtureDir, 'ios/Podfile')
   let podfile = fs.readFileSync(podfilePath, 'utf8')
 
-  const performancePod = `pod 'BugsnagPerformance'`
+  const performancePod = `pod 'BugsnagPerformance', :git => 'https://github.com/bugsnag/bugsnag-cocoa-performance.git', :branch => 'integration/react-native-integration'`
   const targetSection = 'target \'reactnative\' do'
 
   podfile = podfile.replace(targetSection, `${targetSection}\n  ${performancePod}`)

--- a/packages/platforms/react-native/__mocks__/react-native.ts
+++ b/packages/platforms/react-native/__mocks__/react-native.ts
@@ -136,6 +136,17 @@ const BugsnagReactNativePerformance = {
   }),
   isNativePerformanceAvailable: jest.fn(() => {
     return false
+  }),
+  getNativeConfiguration: jest.fn(() => {
+    return {
+      apiKey: '1234567890abcdef1234567890abcdef12',
+      endpoint: '/traces',
+      releaseStage: 'production',
+      serviceName: 'unknown_service',
+      attributeCountLimit: 128,
+      attributeStringValueLimit: 1024,
+      attributeArrayLengthLimit: 1000
+    }
   })
 }
 

--- a/packages/platforms/react-native/__mocks__/react-native.ts
+++ b/packages/platforms/react-native/__mocks__/react-native.ts
@@ -138,15 +138,7 @@ const BugsnagReactNativePerformance = {
     return false
   }),
   getNativeConfiguration: jest.fn(() => {
-    return {
-      apiKey: '1234567890abcdef1234567890abcdef12',
-      endpoint: '/traces',
-      releaseStage: 'production',
-      serviceName: 'unknown_service',
-      attributeCountLimit: 128,
-      attributeStringValueLimit: 1024,
-      attributeArrayLengthLimit: 1000
-    }
+    return null
   })
 }
 
@@ -160,6 +152,10 @@ export const TurboModuleRegistry = {
         return null
     }
   }
+}
+
+export const NativeModules = {
+  BugsnagReactNativePerformance
 }
 
 export type AppStateStatus = 'active' | 'inactive' | 'background'
@@ -185,3 +181,7 @@ export const AppState = new class {
     }
   }
 }()
+
+export const AppRegistry = {
+  setWrapperComponentProvider: jest.fn()
+}

--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -36,5 +36,5 @@ repositories {
 
 dependencies {
   implementation 'com.facebook.react:react-native'
-  compileOnly("com.bugsnag:bugsnag-android-performance:+")
+  compileOnly("com.bugsnag:bugsnag-android-performance:9.9.9")
 }

--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -36,4 +36,5 @@ repositories {
 
 dependencies {
   implementation 'com.facebook.react:react-native'
+  compileOnly("com.bugsnag:bugsnag-android-performance:+")
 }

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
@@ -12,6 +12,8 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import java.security.SecureRandom;
+import com.bugsnag.android.performance.BugsnagPerformance;
+import com.bugsnag.android.performance.internal.processing.ImmutableConfig;
 
 class NativeBugsnagPerformanceImpl {
   
@@ -91,6 +93,44 @@ class NativeBugsnagPerformanceImpl {
   public boolean isNativePerformanceAvailable() {
     return isNativePerformanceAvailable;
   }
+
+  @Nullable
+  public WritableMap getNativeConfiguration() {
+    if (!isNativePerformanceAvailable) {
+      return null;
+    }
+
+    ImmutableConfig nativeConfig = BugsnagPerformance.INSTANCE.getInstrumentedAppState$internal().getConfig$internal();
+    if (nativeConfig == null) {
+      return null;
+    }
+
+    WritableMap result = Arguments.createMap();
+    result.putString("apiKey", nativeConfig.getApiKey());
+    result.putString("endpoint", nativeConfig.getEndpoint());    
+    result.putString("releaseStage", nativeConfig.getReleaseStage());
+    result.putString("serviceName", nativeConfig.getServiceName());
+    result.putInt("attributeCountLimit", nativeConfig.getAttributeCountLimit());
+    result.putInt("attriubuteStringValueLimit", nativeConfig.getAttributeStringValueLimit());
+    result.putInt("attributeArrayLengthLimit", nativeConfig.getAttributeArrayLengthLimit());
+
+    var appVersion = nativeConfig.getAppVersion();
+    if (appVersion != null) {
+      result.putString("appVersion", nativeConfig.getAppVersion());
+    }
+
+    var samplingProbability = nativeConfig.getSamplingProbability();
+    if (samplingProbability != null) {
+      result.putDouble("samplingProbability", samplingProbability);
+    }
+
+    var enabledReleaseStages = nativeConfig.getEnabledReleaseStages();
+    if (enabledReleaseStages != null) {
+      result.putArray("enabledReleaseStages", Arguments.fromArray(enabledReleaseStages.toArray(new String[0])));
+    }
+
+    return result;
+  } 
 
   @Nullable
   private String abiToArchitecture(@Nullable String abi) {

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -39,5 +39,10 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
   public boolean isNativePerformanceAvailable() {
     return impl.isNativePerformanceAvailable();
   }
+
+  @Override
+  public WritableMap getNativeConfiguration() {
+    return impl.getNativeConfiguration();
+  }
 }
 

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -41,4 +41,9 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
   public boolean isNativePerformanceAvailable() {
     return impl.isNativePerformanceAvailable();
   }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableMap getNativeConfiguration() {
+    return impl.getNativeConfiguration();
+  }
 }

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
@@ -95,6 +95,40 @@ BOOL isAvailable = BugsnagCocoaPerformanceFromBugsnagReactNativePerformance.shar
 return [NSNumber numberWithBool: isAvailable];
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getNativeConfiguration) {
+    if (BugsnagCocoaPerformanceFromBugsnagReactNativePerformance.sharedInstance == nil) {
+        return nil;
+    }
+
+    BugsnagPerformanceConfiguration *nativeConfig = [BugsnagCocoaPerformanceFromBugsnagReactNativePerformance.sharedInstance getConfiguration];
+    if (nativeConfig == nil) {
+        return nil;
+    }
+
+    NSMutableDictionary *config = [NSMutableDictionary new];
+    config[@"apiKey"] = nativeConfig.apiKey;
+    config[@"endpoint"] = [nativeConfig.endpoint absoluteString];
+    config[@"releaseStage"] = nativeConfig.releaseStage;
+    config[@"serviceName"] = nativeConfig.serviceName;
+    config[@"attributeCountLimit"] = [NSNumber numberWithUnsignedInteger: nativeConfig.attributeCountLimit];
+    config[@"attributeStringValueLimit"] = [NSNumber numberWithUnsignedInteger: nativeConfig.attributeStringValueLimit];
+    config[@"attributeArrayLengthLimit"] = [NSNumber numberWithUnsignedInteger: nativeConfig.attributeArrayLengthLimit];
+
+    if (nativeConfig.samplingProbability != nil) {
+        config[@"samplingProbability"] = nativeConfig.samplingProbability;
+    }
+
+    if (nativeConfig.appVersion != nil) {
+        config[@"appVersion"] = nativeConfig.appVersion;
+    }
+
+    if (nativeConfig.enabledReleaseStages != nil && nativeConfig.enabledReleaseStages.count > 0) {
+        config[@"enabledReleaseStages"] = [nativeConfig.enabledReleaseStages allObjects];
+    }
+
+    return config;
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -10,11 +10,26 @@ export type DeviceInfo = {
   bundleIdentifier?: string
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type NativeConfiguration = {
+  apiKey: string
+  endpoint: string
+  samplingProbability?: number
+  appVersion?: string
+  releaseStage: string
+  enabledReleaseStages?: string[]
+  serviceName: string
+  attributeCountLimit: number
+  attributeStringValueLimit: number
+  attributeArrayLengthLimit: number
+}
+
 export interface Spec extends TurboModule {
   getDeviceInfo: () => DeviceInfo
   requestEntropy: () => string
   requestEntropyAsync: () => Promise<string>
   isNativePerformanceAvailable: () => boolean
+  getNativeConfiguration: () => NativeConfiguration | null
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/packages/platforms/react-native/lib/config.ts
+++ b/packages/platforms/react-native/lib/config.ts
@@ -26,6 +26,20 @@ export interface ReactNativeConfiguration extends Configuration {
   tracePropagationUrls?: Array<string | RegExp>
 }
 
+// These config options are applied from the native SDKs and are not configurable in JS.
+export type ReactNativeAttachConfiguration = Omit<ReactNativeConfiguration,
+'apiKey' |
+'endpoint' |
+'samplingProbability' |
+'appVersion' |
+'releaseStage' |
+'enabledReleaseStages' |
+'serviceName' |
+'attributeCountLimit' |
+'attributeStringValueLimit' |
+'attributeArrayLengthLimit'
+>
+
 function createSchema (): ReactNativeSchema {
   return {
     ...schema,

--- a/packages/platforms/react-native/lib/index.ts
+++ b/packages/platforms/react-native/lib/index.ts
@@ -1,6 +1,6 @@
 import BugsnagPerformance from './client'
 
-export type { ReactNativeConfiguration } from './config'
+export type { ReactNativeConfiguration, ReactNativeAttachConfiguration } from './config'
 export type { PlatformExtensions } from './platform-extensions'
 
 export default BugsnagPerformance

--- a/packages/platforms/react-native/lib/platform-extensions.tsx
+++ b/packages/platforms/react-native/lib/platform-extensions.tsx
@@ -1,6 +1,6 @@
 import type { Clock, SpanContextStorage, SpanFactory, SpanOptions } from '@bugsnag/core-performance'
 import React from 'react'
-import type { ReactNativeConfiguration } from './config'
+import type { ReactNativeConfiguration, ReactNativeAttachConfiguration } from './config'
 import { createAppStartSpan } from './create-app-start-span'
 import { createNavigationSpan } from './create-navigation-span'
 
@@ -25,6 +25,9 @@ export const platformExtensions = (appStartTime: number, clock: Clock, spanFacto
 
       return <App />
     }
+  },
+  attach: (config?: ReactNativeAttachConfiguration) => {
+    // this noop implementation is overridden by the client and is just defined here for correct typing
   }
 })
 

--- a/packages/platforms/react-native/tests/client.test.ts
+++ b/packages/platforms/react-native/tests/client.test.ts
@@ -1,0 +1,177 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+import type { ReactNativeConfiguration } from '../lib/config'
+import type { BugsnagPerformance } from '@bugsnag/core-performance'
+import type { PlatformExtensions } from '../lib/platform-extensions'
+import type { Spec } from '../lib/NativeBugsnagPerformance'
+
+let client: BugsnagPerformance<ReactNativeConfiguration, PlatformExtensions>
+let turboModule: Spec
+const RESPONSE_TIME = 100
+
+const response = {
+  status: 200,
+  headers: new Headers({ 'Bugsnag-Sampling-Probability': '1.0' })
+}
+
+const createMockFetch = () => jest.fn().mockImplementation(() => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve(response)
+  }, RESPONSE_TIME)
+}))
+
+let mockFetch: ReturnType<typeof createMockFetch>
+
+class XMLHttpRequest {
+  _listeners: { load: Array<() => void>, error: Array<() => void> }
+  status: number | null
+
+  constructor () {
+    this._listeners = { load: [], error: [] }
+    this.status = null
+  }
+
+  open (method: string, url: string | { toString: () => any }) {
+  }
+
+  send (fail: boolean, status: number | null = null) {
+    if (fail) {
+      this?._listeners.error.forEach(fn => { fn() })
+    } else {
+      this.status = status
+      this?._listeners.load.forEach(fn => { fn() })
+    }
+  }
+
+  addEventListener (evt: 'load' | 'error', listener: () => void) {
+    this?._listeners[evt].push(listener)
+  }
+
+  removeEventListener (evt: 'load' | 'error', listener: () => void) {
+    for (let i = this?._listeners?.[evt]?.length ?? 0 - 1; i >= 0; i--) {
+      if (listener.name === this?._listeners?.[evt]?.[i]?.name) delete this?._listeners[evt][i]
+    }
+  }
+}
+
+global.XMLHttpRequest = XMLHttpRequest as unknown as typeof globalThis.XMLHttpRequest
+
+beforeEach(() => {
+  jest.resetModules()
+  mockFetch = createMockFetch()
+  global.fetch = mockFetch
+  turboModule = require('../lib/native').default
+})
+
+describe('React Native client tests', () => {
+  describe('attach()', () => {
+    it('logs a warning and noops if native performance is not available', () => {
+      client = require('../lib/client').default
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      client.attach({})
+      expect(warnSpy).toHaveBeenCalledWith('Could not attach to native SDK. No compatible version of Bugsnag ios performance was found')
+    })
+
+    it('logs a warning and noops if native performance has not been started', () => {
+      turboModule.isNativePerformanceAvailable = jest.fn().mockReturnValue(true)
+      turboModule.getNativeConfiguration = jest.fn().mockReturnValue(null)
+
+      client = require('../lib/client').default
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      client.attach()
+      expect(warnSpy).toHaveBeenCalledWith('Could not attach to native SDK. Bugsnag ios performance has not been started')
+    })
+
+    it('starts the client using the native configuration', () => {
+      turboModule.isNativePerformanceAvailable = jest.fn().mockReturnValue(true)
+      turboModule.getNativeConfiguration = jest.fn().mockReturnValue({
+        apiKey: '1234567890abcdef1234567890abcdef12',
+        endpoint: '/traces',
+        releaseStage: 'production',
+        serviceName: 'unknown_service',
+        attributeCountLimit: 128,
+        attributeStringValueLimit: 1024,
+        attributeArrayLengthLimit: 1000
+      })
+
+      client = require('../lib/client').default
+      const startSpy = jest.spyOn(client, 'start')
+
+      client.attach({
+        autoInstrumentAppStarts: false,
+        autoInstrumentNetworkRequests: false,
+        codeBundleId: '12345',
+        logger: console,
+        tracePropagationUrls: [/^https:\/\/example\.com/],
+        generateAnonymousId: true
+      })
+
+      expect(startSpy).toHaveBeenCalledWith(expect.objectContaining({
+        apiKey: '1234567890abcdef1234567890abcdef12',
+        endpoint: '/traces',
+        releaseStage: 'production',
+        serviceName: 'unknown_service',
+        attributeCountLimit: 128,
+        attributeStringValueLimit: 1024,
+        attributeArrayLengthLimit: 1000,
+        autoInstrumentAppStarts: false,
+        autoInstrumentNetworkRequests: false,
+        codeBundleId: '12345',
+        logger: console,
+        tracePropagationUrls: [/^https:\/\/example\.com/],
+        generateAnonymousId: true
+      }))
+    })
+
+    it('does not overwrite native configuration with JS values', () => {
+      turboModule.isNativePerformanceAvailable = jest.fn().mockReturnValue(true)
+      turboModule.getNativeConfiguration = jest.fn().mockReturnValue({
+        apiKey: '1234567890abcdef1234567890abcdef12',
+        endpoint: '/traces',
+        releaseStage: 'production',
+        serviceName: 'unknown_service',
+        attributeCountLimit: 128,
+        attributeStringValueLimit: 1024,
+        attributeArrayLengthLimit: 1000
+      })
+
+      client = require('../lib/client').default
+      const startSpy = jest.spyOn(client, 'start')
+
+      client.attach({
+        // @ts-expect-error passing properties that do not exist in type 'ReactNativeAttachConfiguration'
+        apiKey: 'ignored',
+        endpoint: 'ignored',
+        releaseStage: 'ignored',
+        serviceName: 'ignored',
+        attributeCountLimit: 0,
+        attributeStringValueLimit: 0,
+        attributeArrayLengthLimit: 0,
+        autoInstrumentAppStarts: false,
+        autoInstrumentNetworkRequests: false,
+        codeBundleId: '12345',
+        logger: console,
+        tracePropagationUrls: [/^https:\/\/example\.com/],
+        generateAnonymousId: true
+      })
+
+      expect(startSpy).toHaveBeenCalledWith(expect.objectContaining({
+        apiKey: '1234567890abcdef1234567890abcdef12',
+        endpoint: '/traces',
+        releaseStage: 'production',
+        serviceName: 'unknown_service',
+        attributeCountLimit: 128,
+        attributeStringValueLimit: 1024,
+        attributeArrayLengthLimit: 1000,
+        autoInstrumentAppStarts: false,
+        autoInstrumentNetworkRequests: false,
+        codeBundleId: '12345',
+        logger: console,
+        tracePropagationUrls: [/^https:\/\/example\.com/],
+        generateAnonymousId: true
+      }))
+    })
+  })
+})

--- a/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
+++ b/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 
 dependencies {
   api "com.bugsnag:bugsnag-android:6.+"
-  compileOnly("com.bugsnag:bugsnag-android-performance:+")
+  compileOnly("com.bugsnag:bugsnag-android-performance:9.9.9")
   implementation 'com.facebook.react:react-native'
 }

--- a/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
+++ b/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 
 dependencies {
   api "com.bugsnag:bugsnag-android:6.+"
-  compileOnly "com.bugsnag:bugsnag-android-performance:1.+"
+  compileOnly("com.bugsnag:bugsnag-android-performance:+")
   implementation 'com.facebook.react:react-native'
 }

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
@@ -166,16 +166,11 @@ class ScenarioLauncherImpl {
         BugsnagPerformance.start(config);
         Log.d(MODULE_NAME, "Started Android performance");
     
-        Span span = BugsnagPerformance.startSpan("NativeIntegration");
-        span.end();
-
-        // Move the app to the background to force the queue to flush
-        reactContext.getCurrentActivity().moveTaskToBack(true);
+        promise.resolve(true);
 
     } catch (Exception e) {
         Log.d(MODULE_NAME, "Failed to start Android performance", e);
+        promise.reject(e);
     }
-
-    promise.resolve(true);
   }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
@@ -126,12 +126,8 @@ RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(
     config.internal.autoTriggerExportOnBatchSize = 1;
 
     [BugsnagPerformance startWithConfiguration:config];
-
-    BugsnagPerformanceSpan *span = [BugsnagPerformance startSpanWithName:@"NativeIntegration"];
-    [span end];
-  });
-    
     resolve(nil);
+  });    
 }
 #else
 RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {

--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -51,8 +51,10 @@ async function runScenario (rootTag, scenarioName, apiKey, endpoint) {
 
   await scenario.initialise(scenarioConfig)
 
-  BugsnagPerformance.start(scenarioConfig)
-
+  if (!scenario.doNotStartBugsnagPerformance) {
+    BugsnagPerformance.start(scenarioConfig)
+  }
+  
   if (process.env.REACT_NATIVE_NAVIGATION) {
     loadReactNavigationScenario(scenario)
   } else {

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/NativeIntegrationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/NativeIntegrationScenario.js
@@ -1,6 +1,9 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
 import { NativeScenarioLauncher } from '../lib/native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+
+export const doNotStartBugsnagPerformance = true
 
 export const initialise = async (config) => {
   const nativeConfig = {
@@ -9,9 +12,15 @@ export const initialise = async (config) => {
   }
 
   await NativeScenarioLauncher.startNativePerformance(nativeConfig)
+
+  BugsnagPerformance.attach({ maximumBatchSize: 1, autoInstrumentAppStarts: false, autoInstrumentNetworkRequests: false })
 }
 
 export const App = () => {
+  useEffect(() => {
+    BugsnagPerformance.startSpan('NativeIntegration').end()
+  }, [])
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.scenario}>

--- a/test/react-native/features/native-integration.feature
+++ b/test/react-native/features/native-integration.feature
@@ -3,8 +3,8 @@ Feature: Native Integration
 
   Scenario: Native Integration
     When I run 'NativeIntegrationScenario'
-    And I wait to receive at least 1 span
+    And I wait to receive 1 span
     Then a span named "NativeIntegration" contains the attributes:
             | attribute                         | type             | value                    |
-            | bugsnag.span.first_class          | boolValue        | true                     |
+            | bugsnag.span.category             | stringValue      | custom                   |
 


### PR DESCRIPTION
## Goal

Adds a new `BugsnagPerformance.attach` method to React Native Performance to allow attaching to an already running native (Android or Cocoa) performance SDK.

This is effectively a wrapper around `BugsnagPerformance.start` that loads the native configuration and uses this to start the native SDK

## Design

Added a new method `getNativeConfiguration` to the Turbo Module, which returns the finalised configuration passed to native `start` or `null` if the native SDK has not been started.

When `attach` is called, the native config is merged with JS-specific config passed to `attach` before calling `start`

`BugsnagPerformance.attach` will log a warning and noop if the native SDK is not installed or has not been started.

## Testing

- Added new unit tests for attach
- Updated the e2e tests to check that the React Native SDK is started using native config and a span is delivered. 
- Updated the test fixture generation to install Cocoa and Android Performance from integration branches

