### PR TITLE
test(browser): disable full page loads for react and vue router tests

### DIFF
--- a/test/browser/features/angular.feature
+++ b/test/browser/features/angular.feature
@@ -4,7 +4,7 @@
 @skip_on_cdn_build
 Feature: Angular
 
-    Scenario: Route change spans are automatically instrumented
+    Scenario: Angular route change spans are automatically instrumented
         Given I navigate to the test URL "/angular/dist"
         And the element "customers" is present
         And I click the element "customers"

--- a/test/browser/features/fixtures/packages/react-router/src/index.jsx
+++ b/test/browser/features/fixtures/packages/react-router/src/index.jsx
@@ -52,8 +52,9 @@ const router = createBrowserRouter(routes, { basename })
 BugsnagPerformance.start({
     apiKey,
     endpoint,
-    maximumBatchSize: 14,
+    maximumBatchSize: 2,
     batchInactivityTimeoutMs: 5000,
+    autoInstrumentFullPageLoads: false,
     autoInstrumentNetworkRequests: false,
     routingProvider: new ReactRouterRoutingProvider(routes, basename)
 })

--- a/test/browser/features/fixtures/packages/vue-router/src/main.js
+++ b/test/browser/features/fixtures/packages/vue-router/src/main.js
@@ -38,8 +38,9 @@ const router = createRouter({
 BugsnagPerformance.start({
     apiKey,
     endpoint,
-    maximumBatchSize: 14,
+    maximumBatchSize: 2,
     batchInactivityTimeoutMs: 5000,
+    autoInstrumentFullPageLoads: false,
     autoInstrumentNetworkRequests: false,
     routingProvider: new VueRouterRoutingProvider(router, base)
 })

--- a/test/browser/features/react-router.feature
+++ b/test/browser/features/react-router.feature
@@ -3,17 +3,11 @@
 @skip_on_cdn_build
 Feature: React router
 
-    Scenario: Route change spans are automatically instrumented
+    Scenario: React route change spans are automatically instrumented
         Given I navigate to the test URL "/react-router"
         And I click the element "change-route"
-        When I wait to receive 1 trace
-        Then a span named "[FullPageLoad]/" contains the attributes:
-            | attribute                         | type             | value                    |
-            | bugsnag.span.category             | stringValue      | full_page_load           |
-            | bugsnag.browser.page.title        | stringValue      | React router             |
-            | bugsnag.browser.page.route        | stringValue      | /                        |
-
-        And a span named "[RouteChange]/contacts/:contactId" contains the attributes: 
+        When I wait to receive 1 span
+        Then a span named "[RouteChange]/contacts/:contactId" contains the attributes: 
             | attribute                                 | type         | value                | 
             | bugsnag.span.category                     | stringValue  | route_change         |
             | bugsnag.browser.page.title                | stringValue  | Contact 1            |

--- a/test/browser/features/vue-router.feature
+++ b/test/browser/features/vue-router.feature
@@ -1,18 +1,12 @@
 Feature: Vue router
 
-    Scenario: Route change spans are automatically instrumented
+    Scenario: Vue route change spans are automatically instrumented
         Given I navigate to the test URL "/vue-router"
         And I click the element "contact"
         And I click the element "profile"
-        When I wait to receive 1 trace
+        When I wait to receive 2 spans
 
-        Then a span named "[FullPageLoad]/" contains the attributes:
-            | attribute                         | type             | value                              |
-            | bugsnag.span.category             | stringValue      | full_page_load                     |
-            | bugsnag.browser.page.title        | stringValue      | Vue router                         |
-            | bugsnag.browser.page.route        | stringValue      | /                                  |
-
-        And a span named "[RouteChange]/contacts/:contactId()" contains the attributes: 
+        Then a span named "[RouteChange]/contacts/:contactId()" contains the attributes: 
             | attribute                                 | type         | value                          | 
             | bugsnag.span.category                     | stringValue  | route_change                   |
             | bugsnag.browser.page.title                | stringValue  | Contact 1                      |


### PR DESCRIPTION
## Goal

Disables full page load instrumentation for react and vue router e2e tests.

Also updates the scenarios so that they have unique names in CI. This makes it easier to see what has failed and stops buildkite overwriting the artifacts if more than one have failed on the same run.

## Design

These tests were failing on Safari 11 - primarily because the batch timeout is set to 5 seconds and the safari test seems to run very slowly, clicking on the navigation almost 10 seconds after navigating to the URL, so the trace is sent before the navigation happens.

Because we don't get PageLoadPhase spans on Safari 11 the number of spans sent is much less, making the test setup awkward. We could fix this by increasing the batch timeout but that will slow all the tests down, and since the page load spans aren't required to test this functionality, it makes more sense to disable full page loads and keep the number of spans sent in the tests consistent.

## Testing

Covered by CI