### PR TITLE
Pin react-navigation to v6.x in React Native test fixtures

### DIFF
--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -59,10 +59,10 @@ const DEPENDENCIES = [
   `react-native-file-access@${reactNativeFileAccessVersion}`
 ]
 
-const reactNavigationVersion = parseFloat(reactNativeVersion) <= 0.64 ? '6.1.18' : 'latest'
-const reactNavigationNativeStackVersion = parseFloat(reactNativeVersion) <= 0.64 ? '6.11.0' : 'latest'
-const reactNativeScreensVersion = parseFloat(reactNativeVersion) <= 0.64 ? '3.14.0' : 'latest'
-const reactNativeSafeAreaContextVersion = parseFloat(reactNativeVersion) <= 0.64 ? '4.1.0' : 'latest'
+const reactNavigationVersion = '6.1.18'
+const reactNavigationNativeStackVersion = '6.11.0'
+const reactNativeScreensVersion = parseFloat(reactNativeVersion) <= 0.64 ? '3.14.0' : '3.35.0'
+const reactNativeSafeAreaContextVersion = parseFloat(reactNativeVersion) <= 0.64 ? '4.1.0' : '4.14.0'
 const REACT_NAVIGATION_DEPENDENCIES = [
   `@react-navigation/native@${reactNavigationVersion}`,
   `@react-navigation/native-stack@${reactNavigationNativeStackVersion}`,


### PR DESCRIPTION
## Goal

Pins the version of react-navigation (and its dependencies) installed into the React Native test fixtures to 6.x because v7.x fails to build on React Native 0.71 Android.

## Testing

Covered by a full CI run