### PR TITLE
Avoid optional properties in Turbo Module spec

### DIFF
--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -3,11 +3,11 @@ import { TurboModuleRegistry } from 'react-native'
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type DeviceInfo = {
-  arch?: string
-  model?: string
-  versionCode?: string // Android only
-  bundleVersion?: string // iOS only
-  bundleIdentifier?: string
+  arch: string | undefined
+  model: string | undefined
+  versionCode: string | undefined // Android only
+  bundleVersion: string | undefined // iOS only
+  bundleIdentifier: string | undefined
 }
 
 export interface Spec extends TurboModule {


### PR DESCRIPTION
## Goal

Replace the use of optional properties with `| undefined` types in Turbo Module type definitions. 

## Design

This is in line with the type mappings in the React Native docs and is more representative of the native types to which they map.

## Testing

Covered by a full CI run