### PR TITLE
fix CI full pipeline

### DIFF
--- a/.buildkite/browser-pipeline.full.yml
+++ b/.buildkite/browser-pipeline.full.yml
@@ -29,7 +29,6 @@ steps:
         run: browser-maze-runner-bs
         use-aliases: true
         command:
-          - --https
           - --farm=bs
           - --browser={{ matrix }}
       artifacts#v1.5.0:

--- a/test/browser/features/fixtures/packages/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/rollup.config.mjs
@@ -10,8 +10,8 @@ export const isCdnBuild = process.env.USE_CDN_BUILD === "1" || process.env.USE_C
 const cdnOutputOptions = {
   // import BugsnagPerformance from the CDN build
   banner: process.env.DEBUG
-    ? 'import BugsnagPerformance from "/bugsnag-performance.js"\n'
-    : 'import BugsnagPerformance from "/bugsnag-performance.min.js"\n',
+    ? 'import BugsnagPerformance from "/docs/bugsnag-performance.js"\n'
+    : 'import BugsnagPerformance from "/docs/bugsnag-performance.min.js"\n',
   globals: {
     '@bugsnag/browser-performance': 'BugsnagPerformance',
     '@bugsnag/react-router-performance': 'BugsnagReactRouterPerformance',

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -15,14 +15,14 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" double attribute "bugsnag.sampling.p" equals 0.999999
 
     # App bundle
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]https:\/\/.*:[0-9]{4}\/docs\/resource-load-spans\/dist\/bundle\.js$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http(s)?:\/\/.*:[0-9]{4}\/docs\/resource-load-spans\/dist\/bundle\.js$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" equals "1.1"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 0.999999
 
     # Image
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]https:\/\/.*:[0-9]{4}\/docs\/favicon.png$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]http(s)?:\/\/.*:[0-9]{4}\/docs\/favicon.png$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "http.url" matches the regex "^http(s)?:\/\/.*:[0-9]{4}\/docs\/favicon\.png\?height=100&width=100$"
@@ -45,20 +45,20 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.3" double attribute "bugsnag.sampling.p" equals 0.999999
 
     # App bundle
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]https:\/\/.*:[0-9]{4}\/docs\/resource-load-spans\/dist\/bundle\.js$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" matches the regex "^\[ResourceLoad\]http(s)?:\/\/.*:[0-9]{4}\/docs\/resource-load-spans\/dist\/bundle\.js$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.flavor" equals "1.1"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 0.999999
 
     # CDN bundle
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]https:\/\/.*:[0-9]{4}\/docs\/bugsnag-performance(?:\.min)?\.js$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]http(s)?:\/\/.*:[0-9]{4}\/docs\/bugsnag-performance(?:\.min)?\.js$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" double attribute "bugsnag.sampling.p" equals 0.999999
 
     # Image
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.name" matches the regex "^\[ResourceLoad\]https:\/\/.*:[0-9]{4}\/docs\/favicon.png$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.name" matches the regex "^\[ResourceLoad\]http(s)?:\/\/.*:[0-9]{4}\/docs\/favicon.png$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" string attribute "http.url" matches the regex "^http(s)?:\/\/.*:[0-9]{4}\/docs\/favicon\.png\?height=100&width=100$"

--- a/test/browser/features/resource-load-spans.feature
+++ b/test/browser/features/resource-load-spans.feature
@@ -52,7 +52,7 @@ Feature: Resource Load Spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 0.999999
 
     # CDN bundle
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]https:\/\/.*:[0-9]{4}\/bugsnag-performance(?:\.min)?\.js$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" matches the regex "^\[ResourceLoad\]https:\/\/.*:[0-9]{4}\/docs\/bugsnag-performance(?:\.min)?\.js$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.parentSpanId" equals the stored value "parent_span_id"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "resource_load"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" double attribute "bugsnag.sampling.p" equals 0.999999


### PR DESCRIPTION
Fixes the "full build" CI pipeline following the change to use `--https`:
- Disable `--https` for the browser mobile tests. Whilst they do work on android they do not on iOS but it doesn't seem worth splitting the build step so just disable for all
- Fix the CDN build to take into account the new document server path