### PR TITLE
feat(react-native): support for starting native spans on android

### DIFF
--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
@@ -9,10 +9,20 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import java.security.SecureRandom;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
 import com.bugsnag.android.performance.BugsnagPerformance;
+import com.bugsnag.android.performance.SpanContext;
+import com.bugsnag.android.performance.SpanOptions;
+
+import com.bugsnag.android.performance.internal.BugsnagClock;
+import com.bugsnag.android.performance.internal.EncodingUtils;
+import com.bugsnag.android.performance.internal.SpanFactory;
+import com.bugsnag.android.performance.internal.SpanImpl;
 import com.bugsnag.android.performance.internal.processing.ImmutableConfig;
 
 class NativeBugsnagPerformanceImpl {
@@ -111,7 +121,7 @@ class NativeBugsnagPerformanceImpl {
     result.putString("releaseStage", nativeConfig.getReleaseStage());
     result.putString("serviceName", nativeConfig.getServiceName());
     result.putInt("attributeCountLimit", nativeConfig.getAttributeCountLimit());
-    result.putInt("attriubuteStringValueLimit", nativeConfig.getAttributeStringValueLimit());
+    result.putInt("attributeStringValueLimit", nativeConfig.getAttributeStringValueLimit());
     result.putInt("attributeArrayLengthLimit", nativeConfig.getAttributeArrayLengthLimit());
 
     var appVersion = nativeConfig.getAppVersion();
@@ -130,9 +140,98 @@ class NativeBugsnagPerformanceImpl {
     }
 
     return result;
-  } 
-
+  }
+  
   @Nullable
+  public WritableMap startNativeSpan(String name, ReadableMap options) {
+    if (!isNativePerformanceAvailable) {
+      return null;
+    }
+
+    SpanOptions spanOptions = jsSpanOptionsToNativeSpanOptions(options);
+    SpanFactory spanFactory = BugsnagPerformance.INSTANCE.getInstrumentedAppState$internal().getSpanFactory();
+    SpanImpl nativeSpan = spanFactory.createCustomSpan(name, spanOptions);
+
+    nativeSpan.getAttributes().getEntries$internal().clear();
+
+    WritableMap span = nativeSpanToJsSpan(nativeSpan);
+    return span;
+  }
+
+  private WritableMap nativeSpanToJsSpan(SpanImpl nativeSpan) {
+    WritableMap span = Arguments.createMap();
+    span.putString("name", nativeSpan.getName());
+    span.putString("id", EncodingUtils.toHexString(nativeSpan.getSpanId()));
+    span.putString("traceId", EncodingUtils.toHexString(nativeSpan.getTraceId()));
+
+    long unixNanoStartTime = BugsnagClock.INSTANCE.elapsedNanosToUnixTime(nativeSpan.getStartTime$internal());
+    span.putDouble("startTime", (double)unixNanoStartTime);
+
+    Long parentSpanId = nativeSpan.getParentSpanId();
+    if (parentSpanId > 0L) {
+      span.putString("parentSpanId", EncodingUtils.toHexString(parentSpanId));
+    }
+
+    return span;
+  }
+
+  private SpanOptions jsSpanOptionsToNativeSpanOptions(ReadableMap options) {
+    SpanOptions spanOptions = SpanOptions.DEFAULTS
+      .setFirstClass(true)
+      .makeCurrentContext(false)
+      .within(null);
+
+    if (options.hasKey("startTime")) {
+      double startTime = options.getDouble("startTime");
+      long nativeStartTime = BugsnagClock.INSTANCE.unixNanoTimeToElapsedRealtime((long)startTime);
+      spanOptions = spanOptions.startTime(nativeStartTime);
+    }
+
+    ReadableMap parentContext = null;
+    if (options.hasKey("parentContext") && (parentContext = options.getMap("parentContext")) != null) {
+      SpanContext nativeParentContext = jsSpanContextToNativeSpanContext(parentContext);
+      spanOptions = spanOptions.within(nativeParentContext);
+    }
+
+    return spanOptions;
+  }
+
+  private SpanContext jsSpanContextToNativeSpanContext(ReadableMap spanContext) {
+    String spanId = spanContext.getString("id");
+    String traceId = spanContext.getString("traceId");
+
+    long nativeSpanId = Long.parseUnsignedLong(spanId, 16);
+    UUID nativeTraceId = new UUID(Long.parseUnsignedLong(traceId.substring(0, 16), 16), Long.parseUnsignedLong(traceId.substring(16), 16));
+
+    SpanContext nativeSpanContext = new SpanContext() {
+        @Override
+        public long getSpanId() {
+            return nativeSpanId;
+        }
+
+        @NonNull
+        @Override
+        public UUID getTraceId() {
+            return nativeTraceId;
+        }
+
+        @NonNull
+        @Override
+        public Runnable wrap(@NonNull Runnable runnable) {
+            return null;
+        }
+
+        @NonNull
+        @Override
+        public <T> Callable<T> wrap(@NonNull Callable<T> callable) {
+            return null;
+        }
+    };
+
+    return nativeSpanContext;
+  }
+
+    @Nullable
   private String abiToArchitecture(@Nullable String abi) {
     if (abi == null) {
       return null;

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
@@ -34,15 +34,11 @@ class NativeBugsnagPerformanceImpl {
     this.reactContext = reactContext;
 
     try {
-      Class.forName("com.bugsnag.android.performance.BugsnagPerformance");
-      Class.forName("com.bugsnag.android.performance.internal.InstrumentedAppState");
+      BugsnagPerformance.INSTANCE.getInstrumentedAppState$internal().getConfig$internal();
       isNativePerformanceAvailable = true;
     }
     catch (LinkageError e) {
-      // do nothing, class found but is incompatible
-    }
-    catch (ClassNotFoundException e) {
-      // do nothing, Android Performance SDK is not installed
+      // do nothing, Android Performance SDK is not installed or is incompatible
     }
   }
 

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeSpanContext.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeSpanContext.java
@@ -6,14 +6,17 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 
 class ReactNativeSpanContext implements SpanContext {
+  private static final int HEX_RADIX = 16;
+  private static final int TRACE_ID_MIDPOINT = 16;
+
   private final long nativeSpanId;
   private final UUID nativeTraceId;
-
-  public ReactNativeSpanContext(String spanId, String traceId) {
-    nativeSpanId = Long.parseUnsignedLong(spanId, 16);
+  
+  ReactNativeSpanContext(String spanId, String traceId) {
+    nativeSpanId = Long.parseUnsignedLong(spanId, HEX_RADIX);
     nativeTraceId = new UUID(
-      Long.parseUnsignedLong(traceId.substring(0, 16), 16),
-      Long.parseUnsignedLong(traceId.substring(16), 16)
+      Long.parseUnsignedLong(traceId.substring(0, TRACE_ID_MIDPOINT), HEX_RADIX),
+      Long.parseUnsignedLong(traceId.substring(TRACE_ID_MIDPOINT), HEX_RADIX)
     );
   }
 

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeSpanContext.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeSpanContext.java
@@ -1,0 +1,42 @@
+package com.bugsnag.reactnative.performance;
+
+import androidx.annotation.NonNull;
+import com.bugsnag.android.performance.SpanContext;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+class ReactNativeSpanContext implements SpanContext {
+  private final long nativeSpanId;
+  private final UUID nativeTraceId;
+
+  public ReactNativeSpanContext(String spanId, String traceId) {
+    nativeSpanId = Long.parseUnsignedLong(spanId, 16);
+    nativeTraceId = new UUID(
+      Long.parseUnsignedLong(traceId.substring(0, 16), 16),
+      Long.parseUnsignedLong(traceId.substring(16), 16)
+    );
+  }
+
+  @Override
+  public long getSpanId() {
+    return nativeSpanId;
+  }
+
+  @NonNull
+  @Override
+  public UUID getTraceId() {
+    return nativeTraceId;
+  }
+
+  @NonNull
+  @Override
+  public Runnable wrap(@NonNull Runnable runnable) {
+    return SpanContext.DefaultImpls.wrap(this, runnable);
+  }
+
+  @NonNull
+  @Override
+  public <T> Callable<T> wrap(@NonNull Callable<T> callable) {
+    return SpanContext.DefaultImpls.wrap(this, callable);
+  }
+}

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import com.bugsnag.reactnative.performance.NativeBugsnagPerformanceSpec;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec {
@@ -43,6 +44,10 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
   @Override
   public WritableMap getNativeConfiguration() {
     return impl.getNativeConfiguration();
+  }
+
+  @Override public WritableMap startNativeSpan(String name, ReadableMap options) {
+    return impl.startNativeSpan(name, options);
   }
 }
 

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 import java.util.Map;
@@ -45,5 +46,10 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
   @ReactMethod(isBlockingSynchronousMethod = true)
   public WritableMap getNativeConfiguration() {
     return impl.getNativeConfiguration();
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableMap startNativeSpan(String name, ReadableMap options) {
+    return impl.startNativeSpan(name, options);
   }
 }

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -1,7 +1,7 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 import type { TurboModule } from 'react-native/Libraries/TurboModule/RCTExport'
 import { TurboModuleRegistry } from 'react-native'
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type DeviceInfo = {
   arch: string | undefined
   model: string | undefined
@@ -10,18 +10,35 @@ export type DeviceInfo = {
   bundleIdentifier: string | undefined
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type NativeConfiguration = {
   apiKey: string
   endpoint: string
-  samplingProbability?: number
-  appVersion?: string
+  samplingProbability: number | undefined
+  appVersion: string | undefined
   releaseStage: string
-  enabledReleaseStages?: string[]
+  enabledReleaseStages: string[] | undefined
   serviceName: string
   attributeCountLimit: number
   attributeStringValueLimit: number
   attributeArrayLengthLimit: number
+}
+
+export type ParentContext = {
+  id: string
+  traceId: string
+}
+
+export type NativeSpanOptions = {
+  startTime: number | undefined
+  parentContext: ParentContext | null
+}
+
+export type NativeSpan = {
+  name: string
+  id: string
+  traceId: string
+  startTime: number
+  parentSpanId: string
 }
 
 export interface Spec extends TurboModule {
@@ -30,6 +47,7 @@ export interface Spec extends TurboModule {
   requestEntropyAsync: () => Promise<string>
   isNativePerformanceAvailable: () => boolean
   getNativeConfiguration: () => NativeConfiguration | null
+  startNativeSpan: (name: string, options: NativeSpanOptions) => NativeSpan
 }
 
 export default TurboModuleRegistry.get<Spec>(


### PR DESCRIPTION
## Goal

Add support for starting native spans on Android

## Design

Added a new Turbo Module method called `startNativeSpan` which creates a span in the Android Performance SDK and returns a JS representation of the native Android span to JS.

The Turbo Module method accepts a limited set of span options (`startTime` and `parentContext`) as native spans should always be first class and should never become the current context in the native SDK.

## Testing

Tested manually as this is not yet being used