### PR TITLE
Implement current state enum in client

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -149,7 +149,7 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
       }
 
       for (const plugin of plugins) {
-        plugin.configure(configuration, spanFactory)
+        plugin.configure(configuration, spanFactory, setAppState)
       }
     },
     startSpan: (name, spanOptions?: SpanOptions) => {

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -45,7 +45,7 @@ export interface ClientOptions<S extends CoreSchema, C extends Configuration, T>
   resourceAttributesSource: ResourceAttributeSource<C>
   spanAttributesSource: SpanAttributesSource<C>
   schema: S
-  plugins: (spanFactory: SpanFactory<C>, spanContextStorage: SpanContextStorage, setAppState: (state: AppState) => void) => Array<Plugin<C>>
+  plugins: (spanFactory: SpanFactory<C>, spanContextStorage: SpanContextStorage) => Array<Plugin<C>>
   persistence: Persistence
   retryQueueFactory: RetryQueueFactory
   spanContextStorage?: SpanContextStorage
@@ -74,7 +74,7 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
   const setAppState = (state: AppState) => {
     appState = state
   }
-  const plugins = options.plugins(spanFactory, spanContextStorage, setAppState)
+  const plugins = options.plugins(spanFactory, spanContextStorage)
 
   return {
     start: (config: C | string) => {

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -26,8 +26,10 @@ import { timeToNumber } from './time'
 
 interface Constructor<T> { new(): T, prototype: T }
 
+export type AppState = 'starting' | 'navigating' | 'settling' | 'ready'
+
 export interface Client<C extends Configuration> {
-  appState: 'starting' | 'navigating' | 'settling' | 'ready'
+  appState: AppState
   start: (config: C | string) => void
   startSpan: (name: string, options?: SpanOptions) => Span
   startNetworkSpan: (options: NetworkSpanOptions) => NetworkSpan
@@ -43,7 +45,7 @@ export interface ClientOptions<S extends CoreSchema, C extends Configuration, T>
   resourceAttributesSource: ResourceAttributeSource<C>
   spanAttributesSource: SpanAttributesSource<C>
   schema: S
-  plugins: (spanFactory: SpanFactory<C>, spanContextStorage: SpanContextStorage) => Array<Plugin<C>>
+  plugins: (spanFactory: SpanFactory<C>, spanContextStorage: SpanContextStorage, setAppState: (state: AppState) => void) => Array<Plugin<C>>
   persistence: Persistence
   retryQueueFactory: RetryQueueFactory
   spanContextStorage?: SpanContextStorage
@@ -69,7 +71,10 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
     logger,
     spanContextStorage
   )
-  const plugins = options.plugins(spanFactory, spanContextStorage)
+  const setAppState = (state: AppState) => {
+    appState = state;
+  };
+  const plugins = options.plugins(spanFactory, spanContextStorage, setAppState);
 
   return {
     start: (config: C | string) => {

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -27,6 +27,7 @@ import { timeToNumber } from './time'
 interface Constructor<T> { new(): T, prototype: T }
 
 export interface Client<C extends Configuration> {
+  appState: 'starting' | 'navigating' | 'settling' | 'ready'
   start: (config: C | string) => void
   startSpan: (name: string, options?: SpanOptions) => Span
   startNetworkSpan: (options: NetworkSpanOptions) => NetworkSpan
@@ -56,6 +57,7 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
   let processor: Processor = bufferingProcessor
   const spanContextStorage = options.spanContextStorage || new DefaultSpanContextStorage(options.backgroundingListener)
   let logger = options.schema.logger.defaultValue
+  let appState = 'starting'
   const sampler = new Sampler(1.0)
   const spanFactory = new SpanFactory(
     processor,
@@ -179,6 +181,9 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
     },
     get currentSpanContext () {
       return spanContextStorage.current
+    },
+    get appState () {
+      return appState
     },
     ...(options.platformExtensions && options.platformExtensions(spanFactory, spanContextStorage))
   } as BugsnagPerformance<C, T>

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -59,7 +59,7 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
   let processor: Processor = bufferingProcessor
   const spanContextStorage = options.spanContextStorage || new DefaultSpanContextStorage(options.backgroundingListener)
   let logger = options.schema.logger.defaultValue
-  let appState = 'starting'
+  let appState: AppState = 'starting'
   const sampler = new Sampler(1.0)
   const spanFactory = new SpanFactory(
     processor,
@@ -72,9 +72,9 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
     spanContextStorage
   )
   const setAppState = (state: AppState) => {
-    appState = state;
-  };
-  const plugins = options.plugins(spanFactory, spanContextStorage, setAppState);
+    appState = state
+  }
+  const plugins = options.plugins(spanFactory, spanContextStorage, setAppState)
 
   return {
     start: (config: C | string) => {

--- a/packages/core/lib/plugin.ts
+++ b/packages/core/lib/plugin.ts
@@ -1,5 +1,5 @@
 import type { Configuration, InternalConfiguration } from './config'
-import { AppState } from './core'
+import type { AppState } from './core'
 import type { SpanFactory } from './span-factory'
 
 export interface Plugin<C extends Configuration> {

--- a/packages/core/lib/plugin.ts
+++ b/packages/core/lib/plugin.ts
@@ -1,6 +1,7 @@
 import type { Configuration, InternalConfiguration } from './config'
+import { AppState } from './core'
 import type { SpanFactory } from './span-factory'
 
 export interface Plugin<C extends Configuration> {
-  configure: (configuration: InternalConfiguration<C>, spanFactory: SpanFactory<C>) => void
+  configure: (configuration: InternalConfiguration<C>, spanFactory: SpanFactory<C>, setAppState: (state: AppState) => void) => void
 }

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -378,16 +378,16 @@ describe('Core', () => {
       describe('appState', () => {
         it('changes the current app state', () => {
           class AppStatePlugin {
-            setAppState;
+            setAppState
 
-            constructor(setAppState: (state: AppState) => void) {
+            constructor (setAppState: (state: AppState) => void) {
               this.setAppState = setAppState
             }
 
-            configure() {}
+            configure () {}
 
-            updateState(appState: AppState) {
-              this.setAppState(appState);
+            updateState (appState: AppState) {
+              this.setAppState(appState)
             }
           }
 
@@ -523,7 +523,3 @@ describe('Core', () => {
     })
   })
 })
-function setAppState(state: AppState): void {
-  throw new Error('Function not implemented.')
-}
-

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -8,7 +8,7 @@ import type { BackgroundingListener } from '../lib/backgrounding-listener'
 import { createNoopClient } from '../lib/core'
 import { DefaultSpanContextStorage } from '../lib/span-context'
 import { InMemoryPersistence } from '../lib/persistence'
-import type { AppState } from '../dist/types'
+import type { AppState } from '../lib/core'
 
 jest.useFakeTimers()
 

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -8,6 +8,7 @@ import type { BackgroundingListener } from '../lib/backgrounding-listener'
 import { createNoopClient } from '../lib/core'
 import { DefaultSpanContextStorage } from '../lib/span-context'
 import { InMemoryPersistence } from '../lib/persistence'
+import { AppState } from '../dist/types'
 
 jest.useFakeTimers()
 
@@ -374,6 +375,36 @@ describe('Core', () => {
         })
       })
 
+      describe('appState', () => {
+        it('changes the current app state', () => {
+          class AppStatePlugin {
+            setAppState;
+
+            constructor(setAppState: (state: AppState) => void) {
+              this.setAppState = setAppState
+            }
+
+            configure() {}
+
+            updateState(appState: AppState) {
+              this.setAppState(appState);
+            }
+          }
+
+          const client = createTestClient({ plugins: (spanFactory, spanContextStorage, setAppState: (state: AppState) => void) => [new AppStatePlugin(setAppState)] })
+
+          client.start(VALID_API_KEY)
+
+          const plugin = client.getPlugin(AppStatePlugin)
+
+          expect(plugin).toBeInstanceOf(AppStatePlugin)
+
+          plugin?.updateState('navigating')
+
+          expect(client.appState).toBe('navigating')
+        })
+      })
+
       describe('getPlugin()', () => {
         it('returns an instance of a plugin', () => {
           const listener = jest.fn()
@@ -492,3 +523,7 @@ describe('Core', () => {
     })
   })
 })
+function setAppState(state: AppState): void {
+  throw new Error('Function not implemented.')
+}
+

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -8,7 +8,7 @@ import type { BackgroundingListener } from '../lib/backgrounding-listener'
 import { createNoopClient } from '../lib/core'
 import { DefaultSpanContextStorage } from '../lib/span-context'
 import { InMemoryPersistence } from '../lib/persistence'
-import { AppState } from '../dist/types'
+import type { AppState } from '../dist/types'
 
 jest.useFakeTimers()
 

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -22,8 +22,8 @@ describe('Core', () => {
         startNetworkSpan: expect.any(Function),
         currentSpanContext: undefined,
         appState: 'starting',
-        getPlugin: expect.any(Function),
-      });
+        getPlugin: expect.any(Function)
+      })
     })
 
     describe('BugsnagPerformance', () => {

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -21,8 +21,9 @@ describe('Core', () => {
         startSpan: expect.any(Function),
         startNetworkSpan: expect.any(Function),
         currentSpanContext: undefined,
-        getPlugin: expect.any(Function)
-      })
+        appState: 'starting',
+        getPlugin: expect.any(Function),
+      });
     })
 
     describe('BugsnagPerformance', () => {

--- a/packages/platforms/browser/tests/on-settle/index.test.ts
+++ b/packages/platforms/browser/tests/on-settle/index.test.ts
@@ -433,8 +433,9 @@ describe('createNoopOnSettle', () => {
     expect(() => {
       const noopOnSettle = createNoopOnSettle()
       const spanFactory = new MockSpanFactory()
+      const setAppState = () => void
       noopOnSettle(() => {})
-      noopOnSettle.configure(createConfiguration(), spanFactory)
+      noopOnSettle.configure(createConfiguration(), spanFactory, setAppState);
     }).not.toThrow()
   })
 })

--- a/packages/platforms/browser/tests/on-settle/index.test.ts
+++ b/packages/platforms/browser/tests/on-settle/index.test.ts
@@ -433,9 +433,9 @@ describe('createNoopOnSettle', () => {
     expect(() => {
       const noopOnSettle = createNoopOnSettle()
       const spanFactory = new MockSpanFactory()
-      const setAppState = () => void
+      const setAppState = jest.fn()
       noopOnSettle(() => {})
-      noopOnSettle.configure(createConfiguration(), spanFactory, setAppState);
+      noopOnSettle.configure(createConfiguration(), spanFactory, setAppState)
     }).not.toThrow()
   })
 })

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -15,7 +15,7 @@ import {
 
 } from '@bugsnag/core-performance'
 import type { BugsnagPerformance, ClientOptions, Configuration, CoreSchema, Delivery } from '@bugsnag/core-performance'
-import { AppState } from '@bugsnag/react-native-performance/__mocks__/react-native'
+import type { AppState } from '../../core'
 
 const defaultOptions = () => ({
   backgroundingListener: new ControllableBackgroundingListener(),
@@ -26,11 +26,12 @@ const defaultOptions = () => ({
   spanAttributesSource,
   schema,
   plugins: () => [],
-  appState: 'starting',
-  setAppState: () => AppState,
+  appState: "starting",
+  setAppState: (appState: AppState) => {appState},
   persistence: new InMemoryPersistence(),
-  retryQueueFactory: (delivery: Delivery, retryQueueMaxSize: number) => new InMemoryQueue(delivery, retryQueueMaxSize)
-})
+  retryQueueFactory: (delivery: Delivery, retryQueueMaxSize: number) =>
+    new InMemoryQueue(delivery, retryQueueMaxSize),
+});
 
 function createTestClient <S extends CoreSchema, C extends Configuration, T = void> (optionOverrides: Partial<ClientOptions<S, C, T>> = {}): BugsnagPerformance<C, T> {
   return createClient({ ...defaultOptions(), ...optionOverrides })

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -27,7 +27,7 @@ const defaultOptions = () => ({
   schema,
   plugins: () => [],
   appState: 'starting',
-  setAppState: (appState: AppState) => { appState },
+  setAppState: (appState: AppState) => appState,
   persistence: new InMemoryPersistence(),
   retryQueueFactory: (delivery: Delivery, retryQueueMaxSize: number) =>
     new InMemoryQueue(delivery, retryQueueMaxSize)

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -26,12 +26,12 @@ const defaultOptions = () => ({
   spanAttributesSource,
   schema,
   plugins: () => [],
-  appState: "starting",
-  setAppState: (appState: AppState) => {appState},
+  appState: 'starting',
+  setAppState: (appState: AppState) => { appState },
   persistence: new InMemoryPersistence(),
   retryQueueFactory: (delivery: Delivery, retryQueueMaxSize: number) =>
-    new InMemoryQueue(delivery, retryQueueMaxSize),
-});
+    new InMemoryQueue(delivery, retryQueueMaxSize)
+})
 
 function createTestClient <S extends CoreSchema, C extends Configuration, T = void> (optionOverrides: Partial<ClientOptions<S, C, T>> = {}): BugsnagPerformance<C, T> {
   return createClient({ ...defaultOptions(), ...optionOverrides })

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -15,6 +15,7 @@ import {
 
 } from '@bugsnag/core-performance'
 import type { BugsnagPerformance, ClientOptions, Configuration, CoreSchema, Delivery } from '@bugsnag/core-performance'
+import { AppState } from '@bugsnag/react-native-performance/__mocks__/react-native'
 
 const defaultOptions = () => ({
   backgroundingListener: new ControllableBackgroundingListener(),
@@ -26,6 +27,7 @@ const defaultOptions = () => ({
   schema,
   plugins: () => [],
   appState: 'starting',
+  setAppState: () => AppState,
   persistence: new InMemoryPersistence(),
   retryQueueFactory: (delivery: Delivery, retryQueueMaxSize: number) => new InMemoryQueue(delivery, retryQueueMaxSize)
 })

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -15,7 +15,7 @@ import {
 
 } from '@bugsnag/core-performance'
 import type { BugsnagPerformance, ClientOptions, Configuration, CoreSchema, Delivery } from '@bugsnag/core-performance'
-import type { AppState } from '../../core'
+import type { AppState } from '../../core/lib/core'
 
 const defaultOptions = () => ({
   backgroundingListener: new ControllableBackgroundingListener(),

--- a/packages/test-utilities/lib/create-test-client.ts
+++ b/packages/test-utilities/lib/create-test-client.ts
@@ -25,6 +25,7 @@ const defaultOptions = () => ({
   spanAttributesSource,
   schema,
   plugins: () => [],
+  appState: 'starting',
   persistence: new InMemoryPersistence(),
   retryQueueFactory: (delivery: Delivery, retryQueueMaxSize: number) => new InMemoryQueue(delivery, retryQueueMaxSize)
 })


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Add a new `appState` property to the core client. -->

## Changeset

Add a new `appState` property and `setAppState` to the core client.

## Testing

Add unit test to test `setAppState` 
Update `createTestClient` default options