### PR TITLE
Buildkite pipeline tidy-up

### DIFF
--- a/.buildkite/block.full.yml
+++ b/.buildkite/block.full.yml
@@ -4,4 +4,7 @@ steps:
 
   - label: 'Upload the full test pipeline'
     depends_on: 'trigger-full-build'
+    agents:
+      queue: macos
+    timeout_in_minutes: 2
     command: buildkite-agent pipeline upload .buildkite/pipeline.full.yml

--- a/.buildkite/browser-pipeline.full.yml
+++ b/.buildkite/browser-pipeline.full.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "opensource"
+
 steps:
   - label: ":docker: Build BrowserStack Maze Runner image"
     key: "browser-maze-runner-bs"
@@ -43,5 +46,8 @@ steps:
     concurrency_group: "browserstack"
 
   - label: ":pipeline_upload: Basic browser pipeline with CDN build"
+    agents:
+      queue: "macos"
+    timeout_in_minutes: 2
     commands:
       - USE_CDN_BUILD=1 EXTRA_STEP_LABEL=" (CDN)" buildkite-agent pipeline upload .buildkite/browser-pipeline.yml

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "opensource"
+
 steps:
   - group: "Browser Tests"
     steps:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,16 +1,22 @@
+agents:
+  queue: macos
+
 steps:
 
   #
   # Upload all full pipelines
   #
   - label: ":pipeline_upload: Full browser pipeline"
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/browser-pipeline.full.yml
 
   - label: ":pipeline_upload: Full react native pipeline"
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/react-native-pipeline.full.yml
 
   - label: ":pipeline_upload: Full react native navigation pipeline"
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/react-native-navigation-pipeline.full.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,14 @@
+agents:
+  queue: macos
+
 steps:
 
   #
   # License audit
   #
   - label: ":copyright: License Audit"
+    agents:
+      queue: opensource
     timeout_in_minutes: 20
     plugins:
       - docker-compose#v4.12.0:
@@ -13,14 +18,17 @@ steps:
   # Upload each basic pipeline
   #
   - label: ":pipeline_upload: Basic browser pipeline"
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
   - label: ":pipeline_upload: React Native pipeline"
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/react-native-pipeline.yml
 
   - label: ":pipeline_upload: React Native Navigation pipeline"
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/react-native-navigation-pipeline.yml
 
@@ -28,5 +36,5 @@ steps:
   # Conditionally trigger full pipeline
   #
   - label: 'Conditionally trigger full set of tests'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 2
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/react-native-navigation-pipeline.full.yml
+++ b/.buildkite/react-native-navigation-pipeline.full.yml
@@ -1,5 +1,7 @@
 # This pipeline file builds runs the end-to-end tests for
 # React Native Navigation on BitBar.
+agents:
+  queue: opensource
 
 steps:
   - group: "React Native Navigation Tests"
@@ -9,7 +11,7 @@ steps:
       # ------------------------------
       - label: ":building_construction: :android: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (Old Arch)"
         key: "build-react-native-navigation-android-fixture-old-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: macos-12-arm
         env:
@@ -35,7 +37,7 @@ steps:
 
       - label: ":building_construction: :android: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (New Arch)"
         key: "build-react-native-navigation-android-fixture-new-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: macos-12-arm
         env:
@@ -64,7 +66,7 @@ steps:
       # ------------------------------
       - label: ':building_construction: :mac: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (Old Arch)'
         key: "build-react-native-navigation-ios-fixture-old-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: "macos-12-arm"
         env:
@@ -90,7 +92,7 @@ steps:
 
       - label: ':building_construction: :mac: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (New Arch)'
         key: "build-react-native-navigation-ios-fixture-new-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: "macos-12-arm"
         env:
@@ -119,7 +121,7 @@ steps:
       # ------------------------------
       - label: ":bitbar: :android: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (Old Arch) Android {{matrix.android_version}}"
         depends_on: "build-react-native-navigation-android-fixture-old-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
         plugins:
@@ -160,7 +162,7 @@ steps:
 
       - label: ":bitbar: :android: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (New Arch) Android {{matrix.android_version}}"
         depends_on: "build-react-native-navigation-android-fixture-new-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "true"
@@ -204,7 +206,7 @@ steps:
       # ------------------------------
       - label: ":bitbar: :mac: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (Old Arch) iOS {{matrix.ios_version}}"
         depends_on: "build-react-native-navigation-ios-fixture-old-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
         plugins:
@@ -222,7 +224,6 @@ steps:
               - --device=IOS_{{matrix.ios_version}}
               - --a11y-locator
               - --fail-fast
-              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
           test-collector#v1.10.2:
@@ -245,7 +246,7 @@ steps:
 
       - label: ":bitbar: :mac: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (New Arch) iOS {{matrix.ios_version}}"
         depends_on: "build-react-native-navigation-ios-fixture-new-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "true"
@@ -264,7 +265,6 @@ steps:
               - --device=IOS_{{matrix.ios_version}}
               - --a11y-locator
               - --fail-fast
-              - --appium-version=1.22
               - --no-tunnel
               - --aws-public-ip
           test-collector#v1.10.2:

--- a/.buildkite/react-native-navigation-pipeline.yml
+++ b/.buildkite/react-native-navigation-pipeline.yml
@@ -1,5 +1,7 @@
 # This pipeline file builds runs the end-to-end tests for
 # React Native Navigation on BitBar.
+agents:
+  queue: opensource
 
 steps:
   - group: "React Native Navigation Tests"
@@ -8,7 +10,7 @@ steps:
       # ------------------------------
       - label: ":building_construction: :android: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (Old Arch)"
         key: "build-react-native-navigation-android-fixture-old-arch"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: macos-12-arm
         env:
@@ -34,7 +36,7 @@ steps:
 
       - label: ":building_construction: :android: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (New Arch)"
         key: "build-react-native-navigation-android-fixture-new-arch"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: macos-12-arm
         env:
@@ -63,7 +65,7 @@ steps:
       # ------------------------------
       - label: ":building_construction: :mac: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (Old Arch)"
         key: "build-react-native-navigation-ios-fixture-old-arch"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: "macos-12-arm"
         env:
@@ -89,7 +91,7 @@ steps:
 
       - label: ":building_construction: :mac: Build react-native-navigation test fixture - RN {{matrix.rn_version}} (New Arch)"
         key: "build-react-native-navigation-ios-fixture-new-arch"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: "macos-12-arm"
         env:
@@ -118,7 +120,7 @@ steps:
       # ------------------------------
       - label: ":bitbar: :android: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (Old Arch) / Android {{matrix.android_version}} "
         depends_on: "build-react-native-navigation-android-fixture-old-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
         plugins:
@@ -159,7 +161,7 @@ steps:
 
       - label: ":bitbar: :android: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (New Arch) / Android {{matrix.android_version}}"
         depends_on: "build-react-native-navigation-android-fixture-new-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "true"
@@ -203,7 +205,7 @@ steps:
       # ------------------------------
       - label: ":bitbar: :mac: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (Old Arch) / iOS {{matrix.ios_version}}"
         depends_on: "build-react-native-navigation-ios-fixture-old-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
         plugins:
@@ -244,7 +246,7 @@ steps:
 
       - label: ":bitbar: :mac: react-native-navigation end-to-end tests - RN {{matrix.rn_version}} (New Arch) / iOS {{matrix.ios_version}} react-native-navigation end-to-end tests"
         depends_on: "build-react-native-navigation-ios-fixture-new-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         env:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "true"

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "opensource"
+
 steps:
   - group: "React Native Tests"
     steps:
@@ -6,7 +9,7 @@ steps:
       #
       - label: ':android: Build RN {{matrix.reactnative}} test fixture APK (Old Arch)'
         key: "build-react-native-android-fixture-old-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: macos-14
         env:
@@ -39,7 +42,7 @@ steps:
 
       - label: ':android: Build RN {{matrix}} test fixture APK (New Arch)'
         key: "build-react-native-android-fixture-new-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: macos-14
         env:
@@ -65,7 +68,7 @@ steps:
 
       - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
         key: "build-react-native-ios-fixture-old-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: "macos-14"
         env:
@@ -92,7 +95,7 @@ steps:
 
       - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
         key: "build-react-native-ios-fixture-new-arch-full"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         agents:
           queue: "macos-14"
         env:
@@ -122,7 +125,7 @@ steps:
         #
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-old-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk"
@@ -160,7 +163,7 @@ steps:
 
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk"
@@ -199,7 +202,7 @@ steps:
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-old-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa"
@@ -237,7 +240,7 @@ steps:
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch-full"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "opensource"
+
 steps:
   - group: "React Native Tests"
     steps:
@@ -107,7 +110,7 @@ steps:
         #
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-old-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk"
@@ -141,7 +144,7 @@ steps:
 
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk"
@@ -177,7 +180,7 @@ steps:
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-old-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa"
@@ -211,7 +214,7 @@ steps:
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 14 (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         plugins:
           artifacts#v1.9.0:
             download: "test/react-native/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa"


### PR DESCRIPTION
## Goal

General tidy-up of the Buildkite pipeline to:
- Ensure all steps have an adequate but not excessive timeout
- Agent queues are explicitly stated in each file (even if a default is used)
- Generic `macos` queue is used instead of specific macOS versions where possible

## Testing

Covered by a full CI run.