### PR TITLE
feat(react-native): support ending native android spans

### DIFF
--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeSpanAttributes.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeSpanAttributes.java
@@ -1,0 +1,110 @@
+package com.bugsnag.reactnative.performance;
+
+import android.annotation.SuppressLint;
+
+import com.bugsnag.android.performance.internal.Attributes;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+
+@SuppressLint("RestrictedApi")
+public class ReactNativeSpanAttributes {
+
+  public static void setAttributesFromReadableMap(Attributes attributes, ReadableMap jsAttributes) {
+    ReadableMapKeySetIterator iterator = jsAttributes.keySetIterator();
+    while (iterator.hasNextKey()) {
+      String key = iterator.nextKey();
+      switch (jsAttributes.getType(key)) {
+        case String:
+          setAttribute(attributes, key, jsAttributes.getString(key));
+          break;
+        case Boolean:
+          setAttribute(attributes, key, jsAttributes.getBoolean(key));
+          break;
+        case Number:
+          setAttribute(attributes, key, jsAttributes.getDouble(key));
+          break;
+        case Array:
+          setAttribute(attributes, key, jsAttributes.getArray(key));
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  private static void setAttribute(Attributes attributes, String name, String value) {
+    attributes.set(name, value);
+  }
+
+  private static void setAttribute(Attributes attributes, String name, boolean value) {
+    attributes.set(name, value);
+  }
+
+  private static void setAttribute(Attributes attributes, String name, double value) {
+    if (value % 1 == 0) {
+      attributes.set(name, (long)value);
+    } else {
+      attributes.set(name, value);
+    }
+  }
+
+  private static void setAttribute(Attributes attributes, String name, ReadableArray value) {
+    if (value == null) return;
+
+    int size = value.size();
+    if (size == 0) {
+      attributes.set(name, new int[0]);
+      return;
+    }
+
+    // we assume that array values are all of the same type
+    switch (value.getType(0)) {
+      case String:
+        setStringArrayAttribute(attributes, name, value);
+        break;
+      case Number:
+        setNumberArrayAttribute(attributes, name, value);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private static void setStringArrayAttribute(Attributes attributes, String name, ReadableArray jsStringArray) {
+    int size = jsStringArray.size();
+    String[] stringArray = new String[size];
+    for (int i = 0; i < size; i++) {
+      stringArray[i] = jsStringArray.getString(i);
+    }
+
+    attributes.set(name, stringArray);
+  }
+
+  private static void setNumberArrayAttribute(Attributes attributes, String name, ReadableArray jsNumberArray) {
+    int size = jsNumberArray.size();
+    long[] longValues = new long[size];
+    boolean containsDoubles = false;
+    for (int i = 0; i < size; i++) {
+        double arrayValue = jsNumberArray.getDouble(i);
+        if (arrayValue % 1 != 0) {
+            // If a non-integer value is found, we start again with a double[]
+            containsDoubles = true;
+            break;
+        }
+        longValues[i] = (long)arrayValue;
+    }
+
+    if (!containsDoubles) {
+      attributes.set(name, longValues);
+      return;
+    }
+
+    double[] doubleValues = new double[size];
+    for (int i = 0; i < size; i++) {
+      doubleValues[i] = jsNumberArray.getDouble(i);
+    }
+
+    attributes.set(name, doubleValues);
+  }
+}

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -46,13 +46,19 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
     return impl.getNativeConfiguration();
   }
 
-  @Override public WritableMap startNativeSpan(String name, ReadableMap options) {
+  @Override 
+  public WritableMap startNativeSpan(String name, ReadableMap options) {
     return impl.startNativeSpan(name, options);
   }
 
   @Override
   public void endNativeSpan(String spanId, double endTime, ReadableMap attributes, Promise promise) {
     impl.endNativeSpan(spanId, endTime, attributes, promise);
+  }
+
+  @Override 
+  public void markNativeSpanEndTime(String spanId, double endTime) {
+    impl.markNativeSpanEndTime(spanId, endTime);
   }
 }
 

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -52,13 +52,13 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
   }
 
   @Override
-  public void endNativeSpan(String spanId, double endTime, ReadableMap attributes, Promise promise) {
-    impl.endNativeSpan(spanId, endTime, attributes, promise);
+  public void endNativeSpan(String spanId, String traceId, double endTime, ReadableMap attributes, Promise promise) {
+    impl.endNativeSpan(spanId, traceId, endTime, attributes, promise);
   }
 
   @Override 
-  public void markNativeSpanEndTime(String spanId, double endTime) {
-    impl.markNativeSpanEndTime(spanId, endTime);
+  public void markNativeSpanEndTime(String spanId, String traceId, double endTime) {
+    impl.markNativeSpanEndTime(spanId, traceId, endTime);
   }
 }
 

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -49,5 +49,10 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
   @Override public WritableMap startNativeSpan(String name, ReadableMap options) {
     return impl.startNativeSpan(name, options);
   }
+
+  @Override
+  public void endNativeSpan(String spanId, double endTime, ReadableMap attributes, Promise promise) {
+    impl.endNativeSpan(spanId, endTime, attributes, promise);
+  }
 }
 

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -55,6 +55,11 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void endNativeSpan(String spanId, double endTime, ReadableMap attributes, Promise promise) {
-    impl.endNativeSpan(spanId, endTime, attributes, promise);
+    impl.endNativeSpan(spanId, endTime, attributes,  promise);
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public void markNativeSpanEndTime(String spanId, double endTime) {
+    impl.markNativeSpanEndTime(spanId, endTime);
   }
 }

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -54,12 +54,12 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void endNativeSpan(String spanId, double endTime, ReadableMap attributes, Promise promise) {
-    impl.endNativeSpan(spanId, endTime, attributes,  promise);
+  public void endNativeSpan(String spanId, String traceId, double endTime, ReadableMap attributes, Promise promise) {
+    impl.endNativeSpan(spanId, traceId, endTime, attributes,  promise);
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  public void markNativeSpanEndTime(String spanId, double endTime) {
-    impl.markNativeSpanEndTime(spanId, endTime);
+  public void markNativeSpanEndTime(String spanId, String traceId, double endTime) {
+    impl.markNativeSpanEndTime(spanId, traceId, endTime);
   }
 }

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -52,4 +52,9 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
   public WritableMap startNativeSpan(String name, ReadableMap options) {
     return impl.startNativeSpan(name, options);
   }
+
+  @ReactMethod
+  public void endNativeSpan(String spanId, double endTime, ReadableMap attributes, Promise promise) {
+    impl.endNativeSpan(spanId, endTime, attributes, promise);
+  }
 }

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -44,6 +44,7 @@ export interface Spec extends TurboModule {
   isNativePerformanceAvailable: () => boolean
   getNativeConfiguration: () => NativeConfiguration | null
   startNativeSpan: (name: string, options: UnsafeObject) => NativeSpan
+  endNativeSpan: (spanId: string, endTime: number, attributes: UnsafeObject) => Promise<void>
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -45,6 +45,7 @@ export interface Spec extends TurboModule {
   getNativeConfiguration: () => NativeConfiguration | null
   startNativeSpan: (name: string, options: UnsafeObject) => NativeSpan
   endNativeSpan: (spanId: string, endTime: number, attributes: UnsafeObject) => Promise<void>
+  markNativeSpanEndTime: (spanId: string, endTime: number) => void
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -44,8 +44,8 @@ export interface Spec extends TurboModule {
   isNativePerformanceAvailable: () => boolean
   getNativeConfiguration: () => NativeConfiguration | null
   startNativeSpan: (name: string, options: UnsafeObject) => NativeSpan
-  endNativeSpan: (spanId: string, endTime: number, attributes: UnsafeObject) => Promise<void>
-  markNativeSpanEndTime: (spanId: string, endTime: number) => void
+  endNativeSpan: (spanId: string, traceId: string, endTime: number, attributes: UnsafeObject) => Promise<void>
+  markNativeSpanEndTime: (spanId: string, traceId: string, endTime: number) => void
 }
 
 export default TurboModuleRegistry.get<Spec>(


### PR DESCRIPTION
## Goal

Update the Android Turbo Module to support ending native spans, including support for marking a native span's end time independently of processing the span.

## Design

Added two new Turbo Module methods:
- `markNativeSpanEndTime` - sets the end time on a span without sending the span to be processed by the native SDK. This allows us to mark the end time and get an accurate end metrics snapshot in situations where the end time is overridden, e.g. navigation plugins.

- `endNativeSpan` - fully ends a native span and sends it for processing by the native SDK, translating the final JS attributes into native span attributes.

The Turbo Module now stores references to native spans in a `HashMap` when they are started so that they can be retrieved and ended later. The reference is removed when the span is ended.

Added a new `ReactNativeSpanAttributes` class to handle conversion of JS span attributes from a `ReadableMap` to native span attributes. Since all numbers passed from JS are doubles, we need to iterate through each attribute and determine it's type, and for double attributes we need to determine if it is actually a double or an integer.

## Testing

Tested manually as this isn't called from JS yet