### PR TITLE
feat(react-native): support ending native ios spans

### DIFF
--- a/packages/platforms/react-native/ios/BugsnagPerformanceSpan.h
+++ b/packages/platforms/react-native/ios/BugsnagPerformanceSpan.h
@@ -30,6 +30,7 @@ OBJC_EXPORT
 
 @property (nonatomic,readonly) NSMutableDictionary *attributes;
 @property (nonatomic,readwrite) SpanId parentId;
+@property (nonatomic) double samplingProbability;
 
 - (void)markEndTime:(NSDate *)endTime;
 

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.xcodeproj/project.pbxproj
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		DA396E142CCFD327009B37C2 /* BugsnagReactNativePerformanceCrossTalkAPIClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA396E132CCFD327009B37C2 /* BugsnagReactNativePerformanceCrossTalkAPIClient.mm */; };
+		DAC36AB22D0CA66E0076A039 /* ReactNativeSpanAttributes.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAC36AB12D0CA66E0076A039 /* ReactNativeSpanAttributes.mm */; };
 		DAE18DD42C58DF2500D52529 /* BugsnagReactNativePerformance.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAE18DD32C58DF2500D52529 /* BugsnagReactNativePerformance.mm */; };
 		DAE18DD72C58E02C00D52529 /* BugsnagReactNativePerformance.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DAE18DD22C58DF2500D52529 /* BugsnagReactNativePerformance.h */; };
 /* End PBXBuildFile section */
@@ -33,6 +34,8 @@
 		DA434CDC2D007BD700C62B2F /* BugsnagPerformanceSpanContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanContext.h; sourceTree = "<group>"; };
 		DA434CE02D09ACE000C62B2F /* BugsnagPerformanceSpanOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpanOptions.h; sourceTree = "<group>"; };
 		DAC1DC5B2CF8859A0009C7F9 /* BugsnagPerformanceSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceSpan.h; sourceTree = "<group>"; };
+		DAC36AB02D0CA64F0076A039 /* ReactNativeSpanAttributes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeSpanAttributes.h; sourceTree = "<group>"; };
+		DAC36AB12D0CA66E0076A039 /* ReactNativeSpanAttributes.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ReactNativeSpanAttributes.mm; sourceTree = "<group>"; };
 		DAE18DD22C58DF2500D52529 /* BugsnagReactNativePerformance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagReactNativePerformance.h; sourceTree = "<group>"; };
 		DAE18DD32C58DF2500D52529 /* BugsnagReactNativePerformance.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagReactNativePerformance.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -59,6 +62,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				DAC36AB12D0CA66E0076A039 /* ReactNativeSpanAttributes.mm */,
+				DAC36AB02D0CA64F0076A039 /* ReactNativeSpanAttributes.h */,
 				DA434CE02D09ACE000C62B2F /* BugsnagPerformanceSpanOptions.h */,
 				DA434CDC2D007BD700C62B2F /* BugsnagPerformanceSpanContext.h */,
 				DAC1DC5B2CF8859A0009C7F9 /* BugsnagPerformanceSpan.h */,
@@ -128,6 +133,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAC36AB22D0CA66E0076A039 /* ReactNativeSpanAttributes.mm in Sources */,
 				DA396E142CCFD327009B37C2 /* BugsnagReactNativePerformanceCrossTalkAPIClient.mm in Sources */,
 				DAE18DD42C58DF2500D52529 /* BugsnagReactNativePerformance.mm in Sources */,
 			);

--- a/packages/platforms/react-native/ios/ReactNativeSpanAttributes.h
+++ b/packages/platforms/react-native/ios/ReactNativeSpanAttributes.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ReactNativeSpanAttributes : NSObject
+
++ (void)setNativeAttributes:(NSMutableDictionary *)attributes fromJSAttributes:(NSDictionary *)jsAttributes;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/platforms/react-native/ios/ReactNativeSpanAttributes.mm
+++ b/packages/platforms/react-native/ios/ReactNativeSpanAttributes.mm
@@ -1,0 +1,91 @@
+#import "ReactNativeSpanAttributes.h"
+
+@implementation ReactNativeSpanAttributes
+
++ (void)setNativeAttributes:(NSMutableDictionary *)attributes fromJSAttributes:(NSDictionary *)jsAttributes {
+    for (NSString *key in jsAttributes) {
+        id value = jsAttributes[key];
+        if ([value isKindOfClass:[NSNumber class]]) {
+            [self setNSNumberAttribute:attributes key:key value:value];
+        } else if ([value isKindOfClass:[NSArray class]]) {
+            [self setArrayAttribute:attributes key:key value:value];
+        } else {
+            attributes[key] = value;
+        }
+    }
+}
+
++ (void)setNSNumberAttribute:(NSMutableDictionary *)attributes key:(NSString *)key value:(NSNumber *)value {
+    if ([self isBoolean:value]) {
+        attributes[key] = value;
+        return;
+    }
+    
+    double doubleValue = [value doubleValue];
+    long longValue = (long)doubleValue;
+    if (doubleValue == longValue) {
+        attributes[key] = @(longValue);
+    } else {
+        attributes[key] = @(doubleValue);
+    }
+}
+
++ (void)setArrayAttribute:(NSMutableDictionary *)attributes key:(NSString *)key value:(NSArray *)value {
+    NSUInteger size = value.count;
+    if (size == 0) {
+        attributes[key] = @[];
+        return;
+    }
+    
+    if ([self isNumberArray:value]) {
+        [self setNumberArrayAttribute:attributes key:key value:value];
+    } else {
+        attributes[key] = value;
+    }
+}
+
++ (void)setNumberArrayAttribute:(NSMutableDictionary *)attributes key:(NSString *)key value:(NSArray *)value {
+    NSUInteger size = value.count;
+    if (size == 0) {
+        attributes[key] = @[];
+        return;
+    }
+    
+    BOOL allIntegers = YES;
+    NSMutableArray *longValues = [NSMutableArray arrayWithCapacity:size];
+    for (NSNumber *number in value) {
+        double doubleValue = [number doubleValue];
+        long longValue = (long)doubleValue;
+        if (doubleValue != longValue) {
+            allIntegers = NO;
+            break;
+        }
+        
+        [longValues addObject:@(longValue)];
+    }
+
+    if (allIntegers) {
+        attributes[key] = longValues;
+    } else {
+        NSMutableArray *doubleValues = [NSMutableArray arrayWithCapacity:size];
+        for (NSNumber *number in value) {
+            [doubleValues addObject:@([number doubleValue])];
+        }
+        attributes[key] = doubleValues;
+    }
+}
+
++ (BOOL)isNumberArray:(NSArray *)array {
+    id firstValue = array[0];
+    if ([firstValue isKindOfClass:[NSNumber class]]) {
+        return ![self isBoolean:firstValue];
+    }
+    
+    return NO;
+}
+
++ (BOOL) isBoolean:(NSNumber *)value {
+    return CFGetTypeID((__bridge CFTypeRef)(value)) == CFBooleanGetTypeID();
+}
+
+@end


### PR DESCRIPTION
## Goal

Update the iOS Turbo Module to support ending native spans, including support for marking a native span's end time independently of processing the span.

This is the iOS equivalent implementation of https://github.com/bugsnag/bugsnag-js-performance/pull/548 (Android)

## Design

Added iOS implementations for the following Turbo Module methods:
- `markNativeSpanEndTime` - sets the end time on a span without sending the span to be processed by the native SDK. This allows us to mark the end time and get an accurate end metrics snapshot in situations where the end time is overridden, e.g. navigation plugins.

- `endNativeSpan` - fully ends a native span and sends it for processing by the native SDK, translating the final JS attributes into native span attributes.

The Turbo Module now stores references to native spans in a `HashMap` when they are started so that they can be retrieved and ended later. The reference is removed when the span is ended.

Added a new `ReactNativeSpanAttributes` class to handle conversion of JS span attributes from a `ReadableMap` to native span attributes. Since all numbers passed from JS are doubles, we need to iterate through each attribute and determine it's type, and for double attributes we need to determine if it is actually a double or an integer.

## Testing

Tested manually as this isn't called from JS yet