### PR TITLE
bump and pin GitHub Action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/compare-pr-stats.yml
+++ b/.github/workflows/compare-pr-stats.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: 18
           cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
       - run: npm ci
 
       - name: Leave comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const leaveComment = require('./.github/leave-pr-stats-comment.js')

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: 18
           cache: 'npm'
@@ -21,8 +21,8 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: 18
           cache: 'npm'
@@ -33,8 +33,8 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: 18
           cache: 'npm'

--- a/.github/workflows/record-pr-stats.yml
+++ b/.github/workflows/record-pr-stats.yml
@@ -35,11 +35,11 @@ jobs:
       code-coverage: ${{ steps.code-coverage.outputs.result }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: 18
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
       - run: npm run test:coverage
 
       - id: package
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             let json = ''
@@ -85,18 +85,18 @@ jobs:
           echo "size=$SIZE" >> $GITHUB_OUTPUT
 
       - id: code-coverage
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             return require('./coverage/coverage-summary.json')
 
-      - uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: packages-${{ inputs.ref }}
           path: |
             bugsnag-*.tgz
 
-      - uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: bundles-${{ inputs.ref }}
           path: |

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "${{ secrets.PLATFORMS_GPG_KEY_BASE64 }}" | base64 --decode | gpg --batch --import
       - name: Sign assets
-        uses: bugsnag/platforms-release-signer@main
+        uses: uses: bugsnag/platforms-release-signer@4d88944b11e503624f8a511cf6d0fa2901822b60
         with:
           github_token: ${{ secrets.PLATFORMS_SIGNING_GITHUB_TOKEN }}
           full_repository: ${{ github.repository }}


### PR DESCRIPTION
## Goal

Bumps the soon-to-be-deprecated `upload-artifact` as well as pinning all the dependencies and using dependabot config to check for updates weekly.