### PR TITLE
Add ReactNativeSpanFactory class

### DIFF
--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -22,6 +22,7 @@ import type { Span, SpanOptions } from './span'
 import type { SpanContext, SpanContextStorage } from './span-context'
 import { DefaultSpanContextStorage } from './span-context'
 import { SpanFactory } from './span-factory'
+import type { SpanFactoryConstructor } from './span-factory'
 import { timeToNumber } from './time'
 
 interface Constructor<T> { new(): T, prototype: T }
@@ -46,6 +47,7 @@ export interface ClientOptions<S extends CoreSchema, C extends Configuration, T>
   persistence: Persistence
   retryQueueFactory: RetryQueueFactory
   spanContextStorage?: SpanContextStorage
+  spanFactory?: SpanFactoryConstructor<C>
   platformExtensions?: (spanFactory: SpanFactory<C>, spanContextStorage: SpanContextStorage) => T
 }
 
@@ -57,7 +59,10 @@ export function createClient<S extends CoreSchema, C extends Configuration, T> (
   const spanContextStorage = options.spanContextStorage || new DefaultSpanContextStorage(options.backgroundingListener)
   let logger = options.schema.logger.defaultValue
   const sampler = new Sampler(1.0)
-  const spanFactory = new SpanFactory(
+
+  const SpanFactoryClass = options.spanFactory || SpanFactory
+
+  const spanFactory = new SpanFactoryClass(
     processor,
     sampler,
     options.idGenerator,

--- a/packages/core/lib/span-factory.ts
+++ b/packages/core/lib/span-factory.ts
@@ -16,7 +16,11 @@ import { isObject, isParentContext } from './validation'
 
 export const DISCARD_END_TIME = -1
 
-export class SpanFactory <C extends Configuration> {
+export type SpanFactoryConstructor<C extends Configuration> = new (
+  ...args: ConstructorParameters<typeof SpanFactory<C>>
+) => InstanceType<typeof SpanFactory<C>>
+
+export class SpanFactory<C extends Configuration> {
   private processor: Processor
   readonly sampler: ReadonlySampler
   private readonly idGenerator: IdGenerator

--- a/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
+++ b/packages/platforms/react-native/lib/auto-instrumentation/app-start-plugin.tsx
@@ -1,14 +1,14 @@
 import type {
   Clock,
   InternalConfiguration,
-  Plugin,
-  SpanFactory
+  Plugin
 } from '@bugsnag/core-performance'
 import type { ReactNode } from 'react'
 import React from 'react'
 import type { AppRegistry, WrapperComponentProvider } from 'react-native'
 import type { ReactNativeConfiguration } from '../config'
 import { createAppStartSpan } from '../create-app-start-span'
+import type { ReactNativeSpanFactory } from '../span-factory'
 
 interface WrapperProps {
   children: ReactNode
@@ -19,13 +19,13 @@ export const isWrapperComponentProvider = (value: unknown): value is WrapperComp
 
 export class AppStartPlugin implements Plugin<ReactNativeConfiguration> {
   private readonly appStartTime: number
-  private readonly spanFactory: SpanFactory<ReactNativeConfiguration>
+  private readonly spanFactory: ReactNativeSpanFactory
   private readonly clock: Clock
   private readonly appRegistry: typeof AppRegistry
 
   constructor (
     appStartTime: number,
-    spanFactory: SpanFactory<ReactNativeConfiguration>,
+    spanFactory: ReactNativeSpanFactory,
     clock: Clock,
     appRegistry: typeof AppRegistry
   ) {

--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -15,6 +15,7 @@ import resourceAttributesSourceFactory from './resource-attributes-source'
 import createRetryQueueFactory from './retry-queue'
 import { createSpanAttributesSource } from './span-attributes-source'
 import createBrowserBackgroundingListener from './backgrounding-listener'
+import { ReactNativeSpanFactory } from './span-factory'
 
 // this is how some internal react native code detects whether the app is running
 // in the remote debugger:
@@ -47,14 +48,15 @@ const BugsnagPerformance = createClient({
   idGenerator,
   persistence,
   plugins: (spanFactory, spanContextStorage) => [
-    new AppStartPlugin(appStartTime, spanFactory, clock, AppRegistry),
+    new AppStartPlugin(appStartTime, spanFactory as ReactNativeSpanFactory, clock, AppRegistry),
     new NetworkRequestPlugin(spanFactory, spanContextStorage, xhrRequestTracker)
   ],
   resourceAttributesSource,
   schema,
   spanAttributesSource,
   retryQueueFactory: createRetryQueueFactory(FileSystem),
-  platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(appStartTime, clock, spanFactory, spanContextStorage)
+  spanFactory: ReactNativeSpanFactory,
+  platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(appStartTime, clock, spanFactory as ReactNativeSpanFactory, spanContextStorage)
 })
 
 BugsnagPerformance.attach = (config) => {

--- a/packages/platforms/react-native/lib/clock.ts
+++ b/packages/platforms/react-native/lib/clock.ts
@@ -5,7 +5,7 @@ interface Performance {
   now: () => number
 }
 
-interface ReactNativeClock extends Clock {
+export interface ReactNativeClock extends Clock {
   toUnixNanoseconds: (time: number) => number
 }
 

--- a/packages/platforms/react-native/lib/create-app-start-span.ts
+++ b/packages/platforms/react-native/lib/create-app-start-span.ts
@@ -1,9 +1,9 @@
-import type { SpanFactory, SpanInternal } from '@bugsnag/core-performance'
-import type { ReactNativeConfiguration } from './config'
+import type { SpanInternal } from '@bugsnag/core-performance'
+import type { ReactNativeSpanFactory } from './span-factory'
 
 let appStartSpan: SpanInternal
 
-export function createAppStartSpan (spanFactory: SpanFactory<ReactNativeConfiguration>, appStartTime: number) {
+export function createAppStartSpan (spanFactory: ReactNativeSpanFactory, appStartTime: number) {
   if (appStartSpan) {
     return appStartSpan
   }

--- a/packages/platforms/react-native/lib/create-navigation-span.ts
+++ b/packages/platforms/react-native/lib/create-navigation-span.ts
@@ -1,6 +1,7 @@
-import type { Configuration, SpanFactory, SpanOptions } from '@bugsnag/core-performance'
+import type { SpanOptions } from '@bugsnag/core-performance'
+import type { ReactNativeSpanFactory } from './span-factory'
 
-export function createNavigationSpan <C extends Configuration> (spanFactory: SpanFactory<C>, routeName: string, spanOptions: SpanOptions) {
+export function createNavigationSpan (spanFactory: ReactNativeSpanFactory, routeName: string, spanOptions: SpanOptions) {
   // Navigation spans are always first class
   spanOptions.isFirstClass = true
 

--- a/packages/platforms/react-native/lib/index.ts
+++ b/packages/platforms/react-native/lib/index.ts
@@ -6,3 +6,4 @@ export type { PlatformExtensions } from './platform-extensions'
 export default BugsnagPerformance
 
 export { createNavigationSpan } from './create-navigation-span'
+export * from './span-factory'

--- a/packages/platforms/react-native/lib/platform-extensions.tsx
+++ b/packages/platforms/react-native/lib/platform-extensions.tsx
@@ -1,12 +1,13 @@
-import type { Clock, SpanContextStorage, SpanFactory, SpanOptions } from '@bugsnag/core-performance'
+import type { Clock, SpanContextStorage, SpanOptions } from '@bugsnag/core-performance'
 import React from 'react'
-import type { ReactNativeConfiguration, ReactNativeAttachConfiguration } from './config'
+import type { ReactNativeAttachConfiguration } from './config'
 import { createAppStartSpan } from './create-app-start-span'
 import { createNavigationSpan } from './create-navigation-span'
+import type { ReactNativeSpanFactory } from './span-factory'
 
 type NavigationSpanOptions = Omit<SpanOptions, 'isFirstClass'>
 
-export const platformExtensions = (appStartTime: number, clock: Clock, spanFactory: SpanFactory<ReactNativeConfiguration>, spanContextStorage: SpanContextStorage) => ({
+export const platformExtensions = (appStartTime: number, clock: Clock, spanFactory: ReactNativeSpanFactory, spanContextStorage: SpanContextStorage) => ({
   startNavigationSpan: (routeName: string, spanOptions?: NavigationSpanOptions) => {
     const cleanOptions = spanFactory.validateSpanOptions(routeName, spanOptions)
     cleanOptions.options.isFirstClass = true

--- a/packages/platforms/react-native/lib/span-factory.ts
+++ b/packages/platforms/react-native/lib/span-factory.ts
@@ -1,0 +1,9 @@
+import { SpanFactory } from '@bugsnag/core-performance'
+import type { SpanAttributes, ParentContext } from '@bugsnag/core-performance'
+import type { ReactNativeConfiguration } from './config'
+
+export class ReactNativeSpanFactory extends SpanFactory<ReactNativeConfiguration> {
+  protected createSpanInternal (name: string, startTime: number, parentContext: ParentContext | null | undefined, isFirstClass: boolean | undefined, attributes: SpanAttributes) {
+    return super.createSpanInternal(name, startTime, parentContext, isFirstClass, attributes)
+  }
+}

--- a/packages/platforms/react-native/tests/auto-instrumentation/app-start-plugin.test.ts
+++ b/packages/platforms/react-native/tests/auto-instrumentation/app-start-plugin.test.ts
@@ -4,6 +4,7 @@ import createClock from '../../lib/clock'
 import { AppStartPlugin } from '../../lib/auto-instrumentation/app-start-plugin'
 import type { ReactNativeConfiguration } from '../../lib/config'
 import type { AppRegistry } from 'react-native'
+import type { ReactNativeSpanFactory } from '../../lib/span-factory'
 
 describe('app start plugin', () => {
   let spanFactory: MockSpanFactory<ReactNativeConfiguration>
@@ -20,7 +21,7 @@ describe('app start plugin', () => {
 
   it('starts an app start span when autoInstrumentAppStarts is true', () => {
     const appStartTime = 1234
-    const plugin = new AppStartPlugin(appStartTime, spanFactory, clock, appRegistry)
+    const plugin = new AppStartPlugin(appStartTime, spanFactory as unknown as ReactNativeSpanFactory, clock, appRegistry)
 
     plugin.configure(createConfiguration<ReactNativeConfiguration>({ autoInstrumentAppStarts: true }))
 
@@ -34,7 +35,7 @@ describe('app start plugin', () => {
   })
 
   it('does not start an app start span when autoInstrumentAppStarts is false', () => {
-    const plugin = new AppStartPlugin(1234, spanFactory, clock, appRegistry)
+    const plugin = new AppStartPlugin(1234, spanFactory as unknown as ReactNativeSpanFactory, clock, appRegistry)
 
     plugin.configure(createConfiguration<ReactNativeConfiguration>({ autoInstrumentAppStarts: false }))
 

--- a/packages/platforms/react-native/tests/create-navigation-span.test.ts
+++ b/packages/platforms/react-native/tests/create-navigation-span.test.ts
@@ -1,10 +1,11 @@
 import { MockSpanFactory } from '@bugsnag/js-performance-test-utilities'
 import { createNavigationSpan } from '../lib/create-navigation-span'
+import type { ReactNativeSpanFactory } from '../lib/span-factory'
 
 describe('createNavigationSpan', () => {
   it('sets the span name to the route prefixed with [Navigation]', () => {
     const spanFactory = new MockSpanFactory()
-    const span = createNavigationSpan(spanFactory, 'testRoute', { isFirstClass: false })
+    const span = createNavigationSpan(spanFactory as unknown as ReactNativeSpanFactory, 'testRoute', { isFirstClass: false })
     const endedSpan = span.end(12345, spanFactory.sampler.spanProbability)
 
     expect(endedSpan.name).toBe('[Navigation]testRoute')
@@ -12,7 +13,7 @@ describe('createNavigationSpan', () => {
 
   it('always sets the span as first class', () => {
     const spanFactory = new MockSpanFactory()
-    const span = createNavigationSpan(spanFactory, 'testRoute', { isFirstClass: false })
+    const span = createNavigationSpan(spanFactory as unknown as ReactNativeSpanFactory, 'testRoute', { isFirstClass: false })
     const endedSpan = span.end(12345, spanFactory.sampler.spanProbability)
 
     expect(endedSpan.attributes.toJson()).toContainEqual({ key: 'bugsnag.span.first_class', value: { boolValue: true } })
@@ -20,7 +21,7 @@ describe('createNavigationSpan', () => {
 
   it('includes navigation category attribute', () => {
     const spanFactory = new MockSpanFactory()
-    const span = createNavigationSpan(spanFactory, 'testRoute', { isFirstClass: true })
+    const span = createNavigationSpan(spanFactory as unknown as ReactNativeSpanFactory, 'testRoute', { isFirstClass: true })
     const endedSpan = span.end(12345, spanFactory.sampler.spanProbability)
 
     expect(endedSpan.attributes.toJson()).toContainEqual({ key: 'bugsnag.span.category', value: { stringValue: 'navigation' } })
@@ -28,7 +29,7 @@ describe('createNavigationSpan', () => {
 
   it('includes the route attribute', () => {
     const spanFactory = new MockSpanFactory()
-    const span = createNavigationSpan(spanFactory, 'testRoute', { isFirstClass: true })
+    const span = createNavigationSpan(spanFactory as unknown as ReactNativeSpanFactory, 'testRoute', { isFirstClass: true })
     const endedSpan = span.end(12345, spanFactory.sampler.spanProbability)
 
     expect(endedSpan.attributes.toJson()).toContainEqual({ key: 'bugsnag.navigation.route', value: { stringValue: 'testRoute' } })

--- a/packages/platforms/react-native/tests/platform-extensions.test.ts
+++ b/packages/platforms/react-native/tests/platform-extensions.test.ts
@@ -1,3 +1,4 @@
+import type { ReactNativeSpanFactory } from '../lib'
 import { platformExtensions } from '../lib/platform-extensions'
 import { createTestClient, IncrementingClock, InMemoryDelivery, VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
 
@@ -7,7 +8,7 @@ describe('startNavigationSpan', () => {
   it('creates a navigation span', async () => {
     const delivery = new InMemoryDelivery()
     const clock = new IncrementingClock()
-    const testClient = createTestClient({ deliveryFactory: () => delivery, platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(0, clock, spanFactory, spanContextStorage) })
+    const testClient = createTestClient({ deliveryFactory: () => delivery, platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(0, clock, spanFactory as unknown as ReactNativeSpanFactory, spanContextStorage) })
     testClient.start({ apiKey: VALID_API_KEY })
     await jest.runOnlyPendingTimersAsync()
 

--- a/packages/plugin-react-native-navigation/lib/react-native-navigation-plugin.ts
+++ b/packages/plugin-react-native-navigation/lib/react-native-navigation-plugin.ts
@@ -1,5 +1,5 @@
 import type { Plugin, SpanFactory, SpanInternal } from '@bugsnag/core-performance'
-import type { ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import type { ReactNativeConfiguration, ReactNativeSpanFactory } from '@bugsnag/react-native-performance'
 import type { NavigationDelegate } from 'react-native-navigation/lib/dist/src/NavigationDelegate'
 
 import { createNavigationSpan } from '@bugsnag/react-native-performance'
@@ -16,7 +16,7 @@ class BugsnagPluginReactNativeNavigationPerformance implements Plugin<ReactNativ
   private startTimeout?: NodeJS.Timeout
   private endTimeout?: NodeJS.Timeout
   private componentsWaiting = 0
-  private spanFactory?: SpanFactory<ReactNativeConfiguration>
+  private spanFactory?: ReactNativeSpanFactory
   private previousRoute?: string
 
   constructor (Navigation: NavigationDelegate) {
@@ -67,7 +67,7 @@ class BugsnagPluginReactNativeNavigationPerformance implements Plugin<ReactNativ
   }
 
   configure (configuration: ReactNativeConfiguration, spanFactory: SpanFactory<ReactNativeConfiguration>) {
-    this.spanFactory = spanFactory
+    this.spanFactory = spanFactory as ReactNativeSpanFactory
 
     // Potential for a navigation to occur
     this.Navigation.events().registerCommandListener((name, params) => {
@@ -84,7 +84,7 @@ class BugsnagPluginReactNativeNavigationPerformance implements Plugin<ReactNativ
         clearTimeout(this.startTimeout)
 
         const routeName = event.componentName
-        this.currentNavigationSpan = createNavigationSpan(spanFactory, routeName, { startTime: this.startTime })
+        this.currentNavigationSpan = createNavigationSpan(spanFactory as ReactNativeSpanFactory, routeName, { startTime: this.startTime })
         this.currentNavigationSpan.setAttribute('bugsnag.navigation.triggered_by', '@bugsnag/plugin-react-native-navigation-performance')
 
         if (this.previousRoute) {

--- a/packages/plugin-react-navigation/lib/create-navigation-container.tsx
+++ b/packages/plugin-react-navigation/lib/create-navigation-container.tsx
@@ -1,5 +1,4 @@
-import type { SpanFactory } from '@bugsnag/core-performance'
-import type { ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import type { ReactNativeSpanFactory } from '@bugsnag/react-native-performance'
 import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native'
 import type { NavigationContainerProps, NavigationContainerRefWithCurrent } from '@react-navigation/native'
 import React, { forwardRef, useRef } from 'react'
@@ -8,10 +7,10 @@ import { NavigationContextProvider } from './navigation-context'
 // Prevent rollup plugin from tree shaking NavigationContextProvider
 const Provider = NavigationContextProvider
 
-type CreateNavigationContainer = (NavigationContainerComponent: typeof NavigationContainer, spanFactory: SpanFactory<ReactNativeConfiguration>) => typeof NavigationContainer
+type CreateNavigationContainer = (NavigationContainerComponent: typeof NavigationContainer, spanFactory: ReactNativeSpanFactory) => typeof NavigationContainer
 type NavigationContainerRef = NavigationContainerRefWithCurrent<ReactNavigation.RootParamList>
 
-export const createNavigationContainer: CreateNavigationContainer = (NavigationContainerComponent = NavigationContainer, spanFactory: SpanFactory<ReactNativeConfiguration>) => {
+export const createNavigationContainer: CreateNavigationContainer = (NavigationContainerComponent = NavigationContainer, spanFactory: ReactNativeSpanFactory) => {
   return forwardRef<NavigationContainerRef, NavigationContainerProps>((props, _ref) => {
     const { onStateChange, ...rest } = props
 

--- a/packages/plugin-react-navigation/lib/navigation-context.tsx
+++ b/packages/plugin-react-navigation/lib/navigation-context.tsx
@@ -1,5 +1,5 @@
-import type { SpanFactory, SpanInternal } from '@bugsnag/core-performance'
-import type { ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import type { SpanInternal } from '@bugsnag/core-performance'
+import type { ReactNativeSpanFactory } from '@bugsnag/react-native-performance'
 import type { PropsWithChildren } from 'react'
 
 import React from 'react'
@@ -13,7 +13,7 @@ export const NavigationContext = React.createContext({
 
 interface Props extends PropsWithChildren {
   currentRoute?: string
-  spanFactory: SpanFactory<ReactNativeConfiguration>
+  spanFactory: ReactNativeSpanFactory
 }
 
 type EndCondition = 'condition' | 'mount' | 'unmount' | 'immediate'

--- a/packages/plugin-react-navigation/lib/react-navigation-native-plugin.ts
+++ b/packages/plugin-react-navigation/lib/react-navigation-native-plugin.ts
@@ -1,13 +1,13 @@
 import type { Plugin, SpanFactory } from '@bugsnag/core-performance'
-import type { ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import type { ReactNativeConfiguration, ReactNativeSpanFactory } from '@bugsnag/react-native-performance'
 import { NavigationContainer } from '@react-navigation/native'
 import { createNavigationContainer } from './create-navigation-container'
 
 class BugsnagPluginReactNavigationNativePerformance implements Plugin<ReactNativeConfiguration> {
-  private spanFactory?: SpanFactory<ReactNativeConfiguration>
+  private spanFactory?: ReactNativeSpanFactory
 
   configure (_configuration: ReactNativeConfiguration, spanFactory: SpanFactory<ReactNativeConfiguration>) {
-    this.spanFactory = spanFactory
+    this.spanFactory = spanFactory as ReactNativeSpanFactory
   }
 
   createNavigationContainer = (Container = NavigationContainer) => {

--- a/packages/plugin-react-navigation/test/create-navigation-container.test.tsx
+++ b/packages/plugin-react-navigation/test/create-navigation-container.test.tsx
@@ -1,5 +1,5 @@
 import { MockSpanFactory } from '@bugsnag/js-performance-test-utilities'
-import type { ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import type { ReactNativeConfiguration, ReactNativeSpanFactory } from '@bugsnag/react-native-performance'
 import { NavigationContainer, createNavigationContainerRef } from '@react-navigation/native'
 import type { ParamListBase } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
@@ -20,7 +20,7 @@ afterEach(() => {
 describe('createNavigationContainer', () => {
   it('creates a navigation span when the route changes', () => {
     const spanFactory = new MockSpanFactory<ReactNativeConfiguration>()
-    const BugsnagNavigationContainer = createNavigationContainer(NavigationContainer, spanFactory)
+    const BugsnagNavigationContainer = createNavigationContainer(NavigationContainer, spanFactory as unknown as ReactNativeSpanFactory)
 
     render(
       <BugsnagNavigationContainer>
@@ -44,7 +44,7 @@ describe('createNavigationContainer', () => {
   it('forwards the provided ref to the NavigationContainer', () => {
     const navigationRef = createNavigationContainerRef()
     const spanFactory = new MockSpanFactory<ReactNativeConfiguration>()
-    const BugsnagNavigationContainer = createNavigationContainer(NavigationContainer, spanFactory)
+    const BugsnagNavigationContainer = createNavigationContainer(NavigationContainer, spanFactory as unknown as ReactNativeSpanFactory)
 
     render(
       <BugsnagNavigationContainer ref={navigationRef}>

--- a/packages/plugin-react-navigation/test/navigation-context.test.tsx
+++ b/packages/plugin-react-navigation/test/navigation-context.test.tsx
@@ -1,6 +1,6 @@
 import type { SpanFactory } from '@bugsnag/core-performance'
 import { MockSpanFactory } from '@bugsnag/js-performance-test-utilities'
-import type { ReactNativeConfiguration } from '@bugsnag/react-native-performance'
+import type { ReactNativeConfiguration, ReactNativeSpanFactory } from '@bugsnag/react-native-performance'
 import { fireEvent, render, screen } from '@testing-library/react-native'
 import React, { useContext } from 'react'
 import { Button, View } from 'react-native'
@@ -189,7 +189,7 @@ const App = ({ spanFactory }: AppProps) => {
   const [currentRoute, setCurrentRoute] = React.useState('initial-route')
 
   return (
-    <NavigationContextProvider spanFactory={spanFactory} currentRoute={currentRoute} >
+    <NavigationContextProvider spanFactory={spanFactory as unknown as ReactNativeSpanFactory} currentRoute={currentRoute} >
       <Route />
       <Button title='Change to route 1' onPress={() => { setCurrentRoute('route-1') }} />
       <Button title='Change to route 2' onPress={() => { setCurrentRoute('route-2') }} />

--- a/packages/test-utilities/lib/mock-span-factory.ts
+++ b/packages/test-utilities/lib/mock-span-factory.ts
@@ -1,9 +1,7 @@
 import {
   DefaultSpanContextStorage,
   Sampler,
-
   SpanFactory
-
 } from '@bugsnag/core-performance'
 import type { SpanAttribute, Configuration, SpanEnded, SpanInternal, SpanOptions } from '@bugsnag/core-performance'
 import ControllableBackgroundingListener from './controllable-backgrounding-listener'


### PR DESCRIPTION
## Goal

Allow platforms to provide their own span factory class that extends the core `SpanFactory` class in client options.

Adds the outline for a specialised `ReactNativeSpanFactory` class to support the native integration.

## Design

`ReactNativeSpanFactory` doesn't do anything yet - this PR just puts in place the basic structure for extending the core span factory and will be built upon in subsequent PRs

## Testing

Updated some broken unit tests and relied on CI