### PR TITLE
React Native platform extensions improvements

### DIFF
--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -1,12 +1,11 @@
 import { createClient } from '@bugsnag/core-performance'
 import createFetchDeliveryFactory from '@bugsnag/delivery-fetch-performance'
 import { createXmlHttpRequestTracker } from '@bugsnag/request-tracker-performance'
-import { AppRegistry, AppState, Platform } from 'react-native'
+import { AppRegistry, AppState } from 'react-native'
 import { FileSystem } from 'react-native-file-access'
 import { AppStartPlugin, NetworkRequestPlugin } from './auto-instrumentation'
 import createClock from './clock'
 import createSchema from './config'
-import type { ReactNativeConfiguration } from './config'
 import createIdGenerator from './id-generator'
 import NativeBugsnagPerformance from './native'
 import persistenceFactory from './persistence'
@@ -24,8 +23,6 @@ import { ReactNativeSpanFactory } from './span-factory'
 
 // @ts-expect-error Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
 const isDebuggingRemotely = !global.nativeCallSyncHook && !global.RN$Bridgeless
-
-const isNativePerformanceAvailable = NativeBugsnagPerformance !== null && NativeBugsnagPerformance.isNativePerformanceAvailable()
 
 const clock = createClock(performance)
 const appStartTime = clock.now()
@@ -56,28 +53,7 @@ const BugsnagPerformance = createClient({
   spanAttributesSource,
   retryQueueFactory: createRetryQueueFactory(FileSystem),
   spanFactory: ReactNativeSpanFactory,
-  platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(appStartTime, clock, spanFactory as ReactNativeSpanFactory, spanContextStorage)
+  platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(appStartTime, clock, schema, spanFactory as ReactNativeSpanFactory, spanContextStorage)
 })
-
-BugsnagPerformance.attach = (config) => {
-  const logger = schema.logger.validate(config?.logger) ? config.logger : schema.logger.defaultValue
-  if (!isNativePerformanceAvailable) {
-    logger.warn(`Could not attach to native SDK. No compatible version of Bugsnag ${Platform.OS} performance was found`)
-    return
-  }
-
-  const nativeConfig = NativeBugsnagPerformance?.getNativeConfiguration()
-  if (!nativeConfig) {
-    logger.warn(`Could not attach to native SDK. Bugsnag ${Platform.OS} performance has not been started`)
-    return
-  }
-
-  const finalConfig: ReactNativeConfiguration = {
-    ...config,
-    ...nativeConfig
-  }
-
-  BugsnagPerformance.start(finalConfig)
-}
 
 export default BugsnagPerformance

--- a/packages/platforms/react-native/tests/platform-extensions.test.ts
+++ b/packages/platforms/react-native/tests/platform-extensions.test.ts
@@ -1,4 +1,5 @@
 import type { ReactNativeSpanFactory } from '../lib'
+import createSchema from '../lib/config'
 import { platformExtensions } from '../lib/platform-extensions'
 import { createTestClient, IncrementingClock, InMemoryDelivery, VALID_API_KEY } from '@bugsnag/js-performance-test-utilities'
 
@@ -8,7 +9,11 @@ describe('startNavigationSpan', () => {
   it('creates a navigation span', async () => {
     const delivery = new InMemoryDelivery()
     const clock = new IncrementingClock()
-    const testClient = createTestClient({ deliveryFactory: () => delivery, platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(0, clock, spanFactory as unknown as ReactNativeSpanFactory, spanContextStorage) })
+    const testClient = createTestClient({
+      deliveryFactory: () => delivery,
+      platformExtensions: (spanFactory, spanContextStorage) => platformExtensions(0, clock, createSchema(), spanFactory as unknown as ReactNativeSpanFactory, spanContextStorage)
+    })
+
     testClient.start({ apiKey: VALID_API_KEY })
     await jest.runOnlyPendingTimersAsync()
 


### PR DESCRIPTION
## Goal

Update the `attach` platform extension to remove the need for monkey-patching in `client.ts` 

## Design

Previously the `attach` platform extension was implemented as a noop function that was then monkey-patched in `client.ts` - this was an ugly hack to allow us to call `start` from within the `attach` function.

Instead, we can convert the platform extensions to function declarations - this fixes the `this` binding so that `this` refers to the client object that's being extended - we still need to cast `this` to the correct type, but this means we can call other methods on the client without the need for monkey patching. 

## Testing

Covered by existing tests