### PR TITLE
Support discarding native spans in Turbo Module

### DIFF
--- a/packages/platforms/react-native/__mocks__/react-native.ts
+++ b/packages/platforms/react-native/__mocks__/react-native.ts
@@ -139,6 +139,22 @@ const BugsnagReactNativePerformance = {
   }),
   getNativeConfiguration: jest.fn(() => {
     return null
+  }),
+  startNativeSpan: jest.fn((name, options) => {
+    return {
+      name,
+      id: 'native-span-id',
+      traceId: 'native-trace-id',
+      startTime: options.startTime,
+      parentSpanId: options.parentContext?.id || undefined
+    }
+  }),
+  endNativeSpan: jest.fn(() => {
+    return Promise.resolve()
+  }),
+  markNativeSpanEndTime: jest.fn(),
+  discardNativeSpan: jest.fn(() => {
+    return Promise.resolve()
   })
 }
 

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
@@ -189,6 +189,15 @@ class NativeBugsnagPerformanceImpl {
     promise.resolve(null);
   }
 
+  public void discardNativeSpan(String spanId, String traceId, Promise promise) {
+    SpanImpl nativeSpan = openSpans.remove(spanId + traceId);
+    if (nativeSpan != null) {
+      nativeSpan.discard();
+    }
+
+    promise.resolve(null);
+  }
+
   private WritableMap nativeSpanToJsSpan(SpanImpl nativeSpan) {
     WritableMap span = Arguments.createMap();
     span.putString("name", nativeSpan.getName());

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -60,5 +60,10 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
   public void markNativeSpanEndTime(String spanId, String traceId, double endTime) {
     impl.markNativeSpanEndTime(spanId, traceId, endTime);
   }
+
+  @Override
+  public void discardNativeSpan(String spanId, String traceId, Promise promise) {
+    impl.discardNativeSpan(spanId, traceId, promise);
+  }
 }
 

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -62,4 +62,9 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
   public void markNativeSpanEndTime(String spanId, String traceId, double endTime) {
     impl.markNativeSpanEndTime(spanId, traceId, endTime);
   }
+
+  @ReactMethod
+  public void discardNativeSpan(String spanId, String traceId, Promise promise) {
+    impl.discardNativeSpan(spanId, traceId, promise);
+  }
 }

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
@@ -248,6 +248,20 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(markNativeSpanEndTime:(NSString *)spanId 
     return nil;
 }
 
+RCT_EXPORT_METHOD(discardNativeSpan:(NSString *)spanId
+                traceId:(NSString *)traceId
+                resolve:(RCTPromiseResolveBlock)resolve
+                reject:(RCTPromiseRejectBlock)reject) {
+    NSString *spanKey = [spanId stringByAppendingString:traceId];
+    BugsnagPerformanceSpan *nativeSpan = openSpans[spanKey];    
+    if (nativeSpan != nil) {
+        [openSpans removeObjectForKey:spanKey];
+        [nativeSpan abortUnconditionally];
+    }
+
+    resolve(nil);
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -46,6 +46,7 @@ export interface Spec extends TurboModule {
   startNativeSpan: (name: string, options: UnsafeObject) => NativeSpan
   endNativeSpan: (spanId: string, traceId: string, endTime: number, attributes: UnsafeObject) => Promise<void>
   markNativeSpanEndTime: (spanId: string, traceId: string, endTime: number) => void
+  discardNativeSpan: (spanId: string, traceId: string) => Promise<void>
 }
 
 export default TurboModuleRegistry.get<Spec>(


### PR DESCRIPTION
## Goal

Add support for discarding native spans to the Turbo Module

## Design

Added a new Turbo Module method `discardNativeSpan` - when called, this removes the reference to the native span from the Turbo Module and formally discards/aborts the native span.

## Testing

Tested manually as this isn't called from JS yet