### PR TITLE
test(react-native): Add rendering metrics e2e test (slow frames)

### DIFF
--- a/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/ScenarioLauncher.js
@@ -70,7 +70,7 @@ async function runScenario (rootTag, scenarioName, apiKey, endpoint) {
 
     const Scenario = () => 
       <ScenarioContext.Provider value={{ reflectEndpoint }}>
-        <SafeAreaView>
+        <SafeAreaView style={{ flex: 1 }}>
           <scenario.App />
         </SafeAreaView>
       </ScenarioContext.Provider>

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/NativeIntegrationScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/NativeIntegrationScenario.js
@@ -38,11 +38,9 @@ export const App = () => {
   }, [])
 
   return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.scenario}>
-        <Text>Native Integration Scenario</Text>
-      </View>
-    </SafeAreaView>
+    <View style={styles.scenario}>
+      <Text>Native Integration Scenario</Text>
+    </View>
   )
 }
 

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/RenderingMetricsScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/RenderingMetricsScenario.js
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { SafeAreaView, View, Text, StyleSheet, FlatList } from 'react-native'
+import { NativeScenarioLauncher } from '../lib/native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+
+export const doNotStartBugsnagPerformance = true
+
+const listData = Array.from({ length: 1000 }, (_, index) => {  return { name: `Item ${index + 1}` } })
+
+export const initialise = async (config) => {
+  const nativeConfig = {
+    apiKey: config.apiKey,
+    endpoint: config.endpoint
+  }
+
+  await NativeScenarioLauncher.startNativePerformance(nativeConfig)
+
+  BugsnagPerformance.attach({ maximumBatchSize: 1, autoInstrumentAppStarts: false, autoInstrumentNetworkRequests: false })
+}
+
+const Item = ({title}) => {
+  const [shouldRender, setShouldRender] = useState(false)
+
+  useEffect(() => {
+    setTimeout(() => {
+      setShouldRender(true)
+    }, 250)
+  }, [])
+
+  if (!shouldRender) {
+    return null
+  }
+
+  return (
+    <View style={styles.item}>
+      <Text style={styles.title}>{title}</Text>
+    </View>
+  )
+}
+
+export const App = () => {
+  let nativeSpan = BugsnagPerformance.startSpan('RenderingMetricsScenario', { isFirstClass: true })
+
+  const renderItem = (item, index) => {
+    if (nativeSpan && index === listData.length - 1) {
+      nativeSpan.end()
+      nativeSpan = null
+    }
+
+    return <Item title={item.name} />
+  }
+
+  return (
+    <View style={styles.scenario}>
+      <Text>Rendering Metrics Scenario</Text>
+      <FlatList
+        ref={(ref) => { this.flatListRef = ref }} 
+        onContentSizeChange={()=> this.flatListRef.scrollToEnd()} 
+        data={listData} 
+        renderItem={({ item, index }) => renderItem(item, index)}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  },
+  item: {
+    backgroundColor: '#f9c2ff',
+    padding: 20,
+    marginVertical: 8,
+    marginHorizontal: 16,
+  },
+  title: {
+    fontSize: 32
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -21,3 +21,4 @@ export * as ReactNavigationScenario from './ReactNavigationScenario'
 
 // Native Integration Scenarios
 export * as NativeIntegrationScenario from './NativeIntegrationScenario'
+export * as RenderingMetricsScenario from './RenderingMetricsScenario'

--- a/test/react-native/features/rendering-metrics.feature
+++ b/test/react-native/features/rendering-metrics.feature
@@ -1,0 +1,16 @@
+@native_integration
+Feature: Rendering Metrics
+
+  Scenario: Rendering metrics are reported
+    When I run 'RenderingMetricsScenario'
+    And I wait to receive 1 trace
+
+    # Native trace
+    Then the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals the platform-dependent string:
+        | ios     | bugsnag.performance.cocoa   |
+        | android | bugsnag.performance.android |
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "RenderingMetricsScenario"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.rendering.total_frames" is greater than 0
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.rendering.slow_frames" is greater than 0


### PR DESCRIPTION
## Goal

Adds an e2e test to check that rendering metrics are added to React Native spans when attached to the native SDK

## Design

The scenario forces some dropped frames by attempting to scroll through a large `FlatList` of items with a delayed render
