### PR TITLE
Turbomodule changed to never be null, default object used instead

### DIFF
--- a/packages/platforms/react-native/__mocks__/react-native.ts
+++ b/packages/platforms/react-native/__mocks__/react-native.ts
@@ -1,5 +1,3 @@
-import type { NativeDirs } from '../lib/NativeBugsnagPerformance'
-
 type Os = 'android' | 'ios' | 'other'
 interface SelectOptions<T> { android: T, ios: T, default: T }
 type PlatformConstants
@@ -136,7 +134,7 @@ const BugsnagReactNativePerformance = {
   requestEntropyAsync: jest.fn(() => {
     return Promise.resolve(createPool())
   }),
-  getNativeConstants (): NativeDirs {
+  getNativeConstants () {
     return {
       CacheDir: '/mock/CacheDir',
       DocumentDir: '/mock/DocumentDir'

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -17,7 +17,7 @@ export type NativeDirs = {
 }
 
 export interface Spec extends TurboModule {
-  getDeviceInfo: () => DeviceInfo
+  getDeviceInfo: () => DeviceInfo | undefined
   requestEntropy: () => string
   requestEntropyAsync: () => Promise<string>
   getNativeConstants: () => NativeDirs

--- a/packages/platforms/react-native/lib/client.ts
+++ b/packages/platforms/react-native/lib/client.ts
@@ -27,7 +27,7 @@ const clock = createClock(performance)
 const appStartTime = clock.now()
 const deliveryFactory = createFetchDeliveryFactory(fetch, clock)
 const spanAttributesSource = createSpanAttributesSource()
-const deviceInfo = NativeBugsnagPerformance && !isDebuggingRemotely ? NativeBugsnagPerformance.getDeviceInfo() : undefined
+const deviceInfo = !isDebuggingRemotely ? NativeBugsnagPerformance.getDeviceInfo() : undefined
 const persistence = persistenceFactory(FileSystem, deviceInfo)
 const resourceAttributesSource = resourceAttributesSourceFactory(persistence, deviceInfo)
 const backgroundingListener = createBrowserBackgroundingListener(AppState)
@@ -35,7 +35,7 @@ const backgroundingListener = createBrowserBackgroundingListener(AppState)
 // React Native's fetch polyfill uses xhr under the hood, so we only track xhr requests
 const xhrRequestTracker = createXmlHttpRequestTracker(XMLHttpRequest, clock)
 
-const idGenerator = createIdGenerator(NativeBugsnagPerformance, isDebuggingRemotely)
+const idGenerator = createIdGenerator(isDebuggingRemotely)
 
 const BugsnagPerformance = createClient({
   backgroundingListener,

--- a/packages/platforms/react-native/lib/native.ts
+++ b/packages/platforms/react-native/lib/native.ts
@@ -7,32 +7,22 @@ declare const global: {
 
 const isTurboModuleEnabled = () => global.__turboModuleProxy != null
 
-const LINKING_ERROR =
-  'The package \'BugsnagReactNativePerformance\' doesn\'t seem to be linked.'
-
-export const NativeBsgModule = isTurboModuleEnabled()
+const NativeBsgModule = isTurboModuleEnabled()
   ? TurboModuleRegistry.get('BugsnagReactNativePerformance')
   : NativeModules.BugsnagReactNativePerformance
 
-const NativeBugsnagPerformance = NativeBsgModule || new Proxy(
-  {
-    getDeviceInfo: () => undefined,
-    requestEntropy: () => '',
-    requestEntropyAsync: async () => '',
-    getNativeConstants: () => ({ CacheDir: '', DocumentDir: '' }),
-    exists: async (path: string) => false,
-    isDir: async (path: string) => false,
-    ls: async (path: string) => [],
-    mkdir: async (path: string) => '',
-    readFile: async (path: string, encoding: string) => '',
-    unlink: async (path: string) => { },
-    writeFile: async (path: string, data: string, encoding: string) => { }
-  },
-  {
-    get () {
-      throw new Error(LINKING_ERROR)
-    }
-  }
-)
+const NativeBugsnagPerformance = NativeBsgModule || {
+  getDeviceInfo: () => undefined,
+  requestEntropy: () => '',
+  requestEntropyAsync: async () => '',
+  getNativeConstants: () => ({ CacheDir: '', DocumentDir: '' }),
+  exists: async (path: string) => false,
+  isDir: async (path: string) => false,
+  ls: async (path: string) => [],
+  mkdir: async (path: string) => '',
+  readFile: async (path: string, encoding: string) => '',
+  unlink: async (path: string) => { },
+  writeFile: async (path: string, data: string, encoding: string) => { }
+}
 
 export default NativeBugsnagPerformance as Spec

--- a/packages/platforms/react-native/lib/native.ts
+++ b/packages/platforms/react-native/lib/native.ts
@@ -7,8 +7,32 @@ declare const global: {
 
 const isTurboModuleEnabled = () => global.__turboModuleProxy != null
 
-export const NativeBugsnagPerformance = isTurboModuleEnabled()
+const LINKING_ERROR =
+  'The package \'BugsnagReactNativePerformance\' doesn\'t seem to be linked.'
+
+export const NativeBsgModule = isTurboModuleEnabled()
   ? TurboModuleRegistry.get('BugsnagReactNativePerformance')
   : NativeModules.BugsnagReactNativePerformance
 
-export default NativeBugsnagPerformance as Spec | null
+const NativeBugsnagPerformance = NativeBsgModule || new Proxy(
+  {
+    getDeviceInfo: () => undefined,
+    requestEntropy: () => '',
+    requestEntropyAsync: async () => '',
+    getNativeConstants: () => ({ CacheDir: '', DocumentDir: '' }),
+    exists: async (path: string) => false,
+    isDir: async (path: string) => false,
+    ls: async (path: string) => [],
+    mkdir: async (path: string) => '',
+    readFile: async (path: string, encoding: string) => '',
+    unlink: async (path: string) => { },
+    writeFile: async (path: string, data: string, encoding: string) => { }
+  },
+  {
+    get () {
+      throw new Error(LINKING_ERROR)
+    }
+  }
+)
+
+export default NativeBugsnagPerformance as Spec

--- a/packages/platforms/react-native/lib/persistence/file-native.ts
+++ b/packages/platforms/react-native/lib/persistence/file-native.ts
@@ -1,56 +1,30 @@
-import type { Spec } from '../NativeBugsnagPerformance'
 import NativeBugsnagPerformance from '../native'
-
-const LINKING_ERROR =
-  'The package \'BugsnagReactNativePerformance\' doesn\'t seem to be linked.'
-
-type FileAccessType = Pick<Spec, 'getNativeConstants' | 'exists' | 'isDir' | 'ls' | 'mkdir' | 'readFile' | 'writeFile' | 'unlink'>
-
-const BugsnagFileAccessNative: FileAccessType = NativeBugsnagPerformance || new Proxy(
-  {
-    getNativeConstants: () => ({ CacheDir: '', DocumentDir: '' }),
-    exists: async (path: string) => false,
-    isDir: async (path: string) => false,
-    ls: async (path: string) => [],
-    mkdir: async (path: string) => '',
-    readFile: async (path: string, encoding: string) => '',
-    unlink: async (path: string) => {},
-    writeFile: async (path: string, data: string, encoding: string) => {}
-  },
-  {
-    get () {
-      throw new Error(LINKING_ERROR)
-    }
-  }
-)
 
 export const Dirs: {
   CacheDir: string
   DocumentDir: string
-} = NativeBugsnagPerformance
-  ? BugsnagFileAccessNative.getNativeConstants()
-  : { CacheDir: '', DocumentDir: '' }
+} = NativeBugsnagPerformance.getNativeConstants()
 
 export const FileSystem = {
   exists (path: string) {
-    return BugsnagFileAccessNative.exists(path)
+    return NativeBugsnagPerformance.exists(path)
   },
   isDir (path: string) {
-    return BugsnagFileAccessNative.isDir(path)
+    return NativeBugsnagPerformance.isDir(path)
   },
   ls (path: string) {
-    return BugsnagFileAccessNative.ls(path)
+    return NativeBugsnagPerformance.ls(path)
   },
   mkdir (path: string) {
-    return BugsnagFileAccessNative.mkdir(path)
+    return NativeBugsnagPerformance.mkdir(path)
   },
   readFile (path: string, encoding: string = 'utf8') {
-    return BugsnagFileAccessNative.readFile(path, encoding)
+    return NativeBugsnagPerformance.readFile(path, encoding)
   },
   unlink (path: string) {
-    return BugsnagFileAccessNative.unlink(path)
+    return NativeBugsnagPerformance.unlink(path)
   },
   writeFile (path: string, data: string, encoding: string = 'utf8') {
-    return BugsnagFileAccessNative.writeFile(path, data, encoding)
+    return NativeBugsnagPerformance.writeFile(path, data, encoding)
   }
 }

--- a/packages/platforms/react-native/tests/id-generator.test.ts
+++ b/packages/platforms/react-native/tests/id-generator.test.ts
@@ -102,4 +102,20 @@ describe('React Native ID generator', () => {
       expect(id).toMatch(/^[a-f0-9]{16}$/)
     })
   })
+
+  // Test written here so it does not clash with native module jest override
+  describe('React Native turbomodule is not null so implementation uses turbomodule', () => {
+    it('getDeviceInfo returns expected values', () => {
+      expect(NativeBugsnagPerformance.getDeviceInfo()).toStrictEqual({
+        arch: 'arm64',
+        model: 'iPhone14,1',
+        bundleVersion: '12345',
+        bundleIdentifier: 'my.cool.app'
+      })
+    })
+
+    it('getNativeConstants returns expected values', () => {
+      expect(NativeBugsnagPerformance.getNativeConstants()).toStrictEqual({ CacheDir: '/mock/CacheDir', DocumentDir: '/mock/DocumentDir' })
+    })
+  })
 })

--- a/packages/platforms/react-native/tests/native.test.ts
+++ b/packages/platforms/react-native/tests/native.test.ts
@@ -1,0 +1,53 @@
+import NativeBugsnagPerformance from '../lib/native'
+
+jest.mock('react-native', () => {
+  return {
+    NativeModules: {},
+    TurboModuleRegistry: {
+      get () {
+        return null
+      }
+    }
+  }
+})
+
+describe('React Native turbomodule is null so implementation falls back to stub functions', () => {
+  afterAll(() => {
+    jest.resetModules()
+  })
+  it('getDeviceInfo returns undefined', () => {
+    expect(NativeBugsnagPerformance.getDeviceInfo()).toBeUndefined()
+  })
+
+  it('requestEntropy returns an empty string', () => {
+    expect(NativeBugsnagPerformance.requestEntropy()).toBe('')
+  })
+
+  it('requestEntropyAsync returns an empty string', async () => {
+    expect(await NativeBugsnagPerformance.requestEntropyAsync()).toBe('')
+  })
+
+  it('getNativeConstants returns an empty string', () => {
+    expect(NativeBugsnagPerformance.getNativeConstants()).toStrictEqual({ CacheDir: '', DocumentDir: '' })
+  })
+
+  it('exists returns false', async () => {
+    expect(await NativeBugsnagPerformance.exists('')).toBe(false)
+  })
+
+  it('isDir returns false', async () => {
+    expect(await NativeBugsnagPerformance.isDir('')).toBe(false)
+  })
+
+  it('ls returns an empty array', async () => {
+    expect(await NativeBugsnagPerformance.ls('')).toStrictEqual([])
+  })
+
+  it('mkdir returns an empty string', async () => {
+    expect(await NativeBugsnagPerformance.mkdir('')).toBe('')
+  })
+
+  it('readFile returns an empty string', async () => {
+    expect(await NativeBugsnagPerformance.readFile('', '')).toBe('')
+  })
+})

--- a/packages/platforms/react-native/tests/resource-attributes-source.test.ts
+++ b/packages/platforms/react-native/tests/resource-attributes-source.test.ts
@@ -3,12 +3,12 @@ import { createConfiguration } from '@bugsnag/js-performance-test-utilities'
 import { Platform } from 'react-native'
 import type { ReactNativeConfiguration } from '../lib/config'
 import resourceAttributesSourceFactory from '../lib/resource-attributes-source'
-import NativeBugsnagPerformance from '../lib/NativeBugsnagPerformance'
+import NativeBugsnagPerformance from '../lib/native'
 
 describe('resourceAttributesSource', () => {
   it('includes all expected attributes (iOS)', async () => {
     const configuration = createConfiguration<ReactNativeConfiguration>({ releaseStage: 'test', appVersion: '1.0.0', codeBundleId: '12345678' })
-    const deviceInfo = NativeBugsnagPerformance?.getDeviceInfo()
+    const deviceInfo = NativeBugsnagPerformance.getDeviceInfo()
     const resourceAttributesSource = resourceAttributesSourceFactory(new InMemoryPersistence(), deviceInfo)
     const resourceAttributes = await resourceAttributesSource(configuration)
     const jsonAttributes = resourceAttributes.toJson()
@@ -39,7 +39,7 @@ describe('resourceAttributesSource', () => {
     //                  our Platform mock (see '__mocks__/react-native.ts')
     await Platform.bugsnagWithTestPlatformSetTo('android', async () => {
       const configuration = createConfiguration<ReactNativeConfiguration>({ releaseStage: 'test', appVersion: '1.0.0', codeBundleId: '12345678' })
-      const deviceInfo = NativeBugsnagPerformance?.getDeviceInfo()
+      const deviceInfo = NativeBugsnagPerformance.getDeviceInfo()
       const resourceAttributesSource = resourceAttributesSourceFactory(new InMemoryPersistence(), deviceInfo)
       const resourceAttributes = await resourceAttributesSource(configuration)
       const jsonAttributes = resourceAttributes.toJson()


### PR DESCRIPTION
# Goal
Remove check for null in turbomodules loading.

## Changeset
Added a default proxy for situations where neither new nor old turbomodule can be loaded.

## Testing
Changed unit tests for id generation - by default tests always fallback to JS implementation because proxy's return value is empty. But no null check needed.