### PR TITLE
Periodically clean up native spans that are open for > 1 hour

### DIFF
--- a/packages/platforms/react-native/__mocks__/react-native.ts
+++ b/packages/platforms/react-native/__mocks__/react-native.ts
@@ -141,7 +141,7 @@ const BugsnagReactNativePerformance = {
   isNativePerformanceAvailable: jest.fn(() => {
     return true
   }),
-  getNativeConfiguration: jest.fn(() => {
+  attachToNativeSDK: jest.fn(() => {
     return {
       apiKey: VALID_API_KEY,
       endpoint: '/traces',

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -42,8 +42,8 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
   }
 
   @Override
-  public WritableMap getNativeConfiguration() {
-    return impl.getNativeConfiguration();
+  public WritableMap attachToNativeSDK() {
+    return impl.attachToNativeSDK();
   }
 
   @Override 

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -44,8 +44,8 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  public WritableMap getNativeConfiguration() {
-    return impl.getNativeConfiguration();
+  public WritableMap attachToNativeSDK() {
+    return impl.attachToNativeSDK();
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -42,7 +42,7 @@ export interface Spec extends TurboModule {
   requestEntropy: () => string
   requestEntropyAsync: () => Promise<string>
   isNativePerformanceAvailable: () => boolean
-  getNativeConfiguration: () => NativeConfiguration | null
+  attachToNativeSDK: () => NativeConfiguration | null
   startNativeSpan: (name: string, options: UnsafeObject) => NativeSpan
   endNativeSpan: (spanId: string, traceId: string, endTime: number, attributes: UnsafeObject) => Promise<void>
   markNativeSpanEndTime: (spanId: string, traceId: string, endTime: number) => void

--- a/packages/platforms/react-native/lib/platform-extensions.tsx
+++ b/packages/platforms/react-native/lib/platform-extensions.tsx
@@ -38,7 +38,7 @@ export const platformExtensions = (appStartTime: number, clock: Clock, schema: R
       return
     }
 
-    const nativeConfig = NativeBugsnagPerformance?.getNativeConfiguration()
+    const nativeConfig = NativeBugsnagPerformance?.attachToNativeSDK()
     if (!nativeConfig) {
       logger.warn(`Could not attach to native SDK. Bugsnag ${platform} Performance has not been started.`)
       return

--- a/packages/platforms/react-native/tests/client.test.ts
+++ b/packages/platforms/react-native/tests/client.test.ts
@@ -81,7 +81,7 @@ describe('React Native client tests', () => {
     })
 
     it('logs a warning and noops if native performance has not been started', () => {
-      turboModule.getNativeConfiguration = jest.fn().mockReturnValue(null)
+      turboModule.attachToNativeSDK = jest.fn().mockReturnValue(null)
 
       client = require('../lib/client').default
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
@@ -91,7 +91,7 @@ describe('React Native client tests', () => {
     })
 
     it('starts the client using the native configuration', () => {
-      const nativeConfig = turboModule.getNativeConfiguration()
+      const nativeConfig = turboModule.attachToNativeSDK()
       client = require('../lib/client').default
       const startSpy = jest.spyOn(client, 'start')
 
@@ -124,7 +124,7 @@ describe('React Native client tests', () => {
     })
 
     it('does not overwrite native configuration with JS values', () => {
-      const nativeConfig = turboModule.getNativeConfiguration()
+      const nativeConfig = turboModule.attachToNativeSDK()
       client = require('../lib/client').default
       const startSpy = jest.spyOn(client, 'start')
 


### PR DESCRIPTION
## Goal

The Turbo Module holds references to the native spans it creates so that they can be retrieved and ended later. This has the potential for memory leaks if for some reason the spans are never ended in JS. 

This PR tries to mitigate this by periodically discarding any native spans that have been open for a long time (> 1 hour)

## Design

When attach is called in JS, the Turbo Module schedules a task to run every hour and discard any spans with a start time more than 1 hour in the past.

## Testing

Tested manually as it's not possible to automate