### PR TITLE
Fix cdn configuration for test fixture

### DIFF
--- a/test/browser/features/angular.feature
+++ b/test/browser/features/angular.feature
@@ -2,6 +2,7 @@
 @skip_firefox_60
 @skip_safari_11
 @skip_on_cdn_build
+@skip # Skipped pending PLAT-14002
 Feature: Angular
 
     Scenario: Angular route change spans are automatically instrumented

--- a/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
@@ -15,7 +15,7 @@ const cdnConfig = {
   // this stops rollup trying to resolve these modules as we don't run
   // 'npm install' when using the CDN build to avoid accidentally testing
   // against NPM packages
-  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/react-router/src/index.jsx') && !id.endsWith('packages/plugin-react-performance/dist/lib/index.js'),
+  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/react-router/src/index.jsx'),
   output: {
     ...baseConfig.output,
     globals: {

--- a/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
@@ -9,26 +9,6 @@ import baseConfig, { isCdnBuild } from '../rollup.config.mjs'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
-const cdnConfig = {
-  // mark everything other than 'src/index.jsx' as an external module when
-  // using the CDN build
-  // this stops rollup trying to resolve these modules as we don't run
-  // 'npm install' when using the CDN build to avoid accidentally testing
-  // against NPM packages
-  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/react-router/src/index.jsx') && !id.endsWith('packages/plugin-react-performance/dist/lib/index.js'),
-  output: {
-    ...baseConfig.output,
-    globals: {
-      ...baseConfig.output.globals,
-      react: 'React',
-      'react-dom/client': 'ReactDom',
-      'react-router-dom': 'ReactRouterDom',
-      '@bugsnag/react-router-performance': 'BugsnagReactRouterPerformance',
-      '@bugsnag/plugin-react-performance': 'BugsnagPluginReactPerformance',
-    },
-  }
-}
-
 export default {
   ...baseConfig,
   input: 'src/index.jsx',
@@ -46,6 +26,5 @@ export default {
         'process.env.NODE_ENV': JSON.stringify('production'),
       },
     })
-  ],
-  ...(isCdnBuild ? cdnConfig : {})
+  ]
 }

--- a/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
@@ -15,7 +15,7 @@ const cdnConfig = {
   // this stops rollup trying to resolve these modules as we don't run
   // 'npm install' when using the CDN build to avoid accidentally testing
   // against NPM packages
-  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/react-router/src/index.jsx'),
+  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/react-router/src/index.jsx') && !id.endsWith('packages/plugin-react-performance/dist/lib/index.js'),
   output: {
     ...baseConfig.output,
     globals: {
@@ -24,6 +24,7 @@ const cdnConfig = {
       'react-dom/client': 'ReactDom',
       'react-router-dom': 'ReactRouterDom',
       '@bugsnag/react-router-performance': 'BugsnagReactRouterPerformance',
+      '@bugsnag/plugin-react-performance': 'BugsnagPluginReactPerformance',
     },
   }
 }

--- a/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/react-router/rollup.config.mjs
@@ -9,6 +9,26 @@ import baseConfig, { isCdnBuild } from '../rollup.config.mjs'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
+const cdnConfig = {
+  // mark everything other than 'src/index.jsx' as an external module when
+  // using the CDN build
+  // this stops rollup trying to resolve these modules as we don't run
+  // 'npm install' when using the CDN build to avoid accidentally testing
+  // against NPM packages
+  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/react-router/src/index.jsx') && !id.endsWith('packages/plugin-react-performance/dist/lib/index.js'),
+  output: {
+    ...baseConfig.output,
+    globals: {
+      ...baseConfig.output.globals,
+      react: 'React',
+      'react-dom/client': 'ReactDom',
+      'react-router-dom': 'ReactRouterDom',
+      '@bugsnag/react-router-performance': 'BugsnagReactRouterPerformance',
+      '@bugsnag/plugin-react-performance': 'BugsnagPluginReactPerformance',
+    },
+  }
+}
+
 export default {
   ...baseConfig,
   input: 'src/index.jsx',
@@ -26,5 +46,6 @@ export default {
         'process.env.NODE_ENV': JSON.stringify('production'),
       },
     })
-  ]
+  ],
+  ...(isCdnBuild ? cdnConfig : {})
 }

--- a/test/browser/features/fixtures/packages/react/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/react/rollup.config.mjs
@@ -22,8 +22,6 @@ const cdnConfig = {
       ...baseConfig.output.globals,
       react: 'React',
       'react-dom/client': 'ReactDom',
-      'react-router-dom': 'ReactRouterDom',
-      '@bugsnag/react-router-performance': 'BugsnagReactRouterPerformance',
       '@bugsnag/plugin-react-performance': 'BugsnagPluginReactPerformance',
     },
   }

--- a/test/browser/features/fixtures/packages/react/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/react/rollup.config.mjs
@@ -15,13 +15,15 @@ const cdnConfig = {
   // this stops rollup trying to resolve these modules as we don't run
   // 'npm install' when using the CDN build to avoid accidentally testing
   // against NPM packages
-  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/plugin-react-performance/dist/lib/index.js'),
+  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/react/src/index.jsx'),
   output: {
     ...baseConfig.output,
     globals: {
       ...baseConfig.output.globals,
       react: 'React',
       'react-dom/client': 'ReactDom',
+      'react-router-dom': 'ReactRouterDom',
+      '@bugsnag/react-router-performance': 'BugsnagReactRouterPerformance',
       '@bugsnag/plugin-react-performance': 'BugsnagPluginReactPerformance',
     },
   }

--- a/test/browser/features/fixtures/packages/react/rollup.config.mjs
+++ b/test/browser/features/fixtures/packages/react/rollup.config.mjs
@@ -5,9 +5,27 @@ import replace from '@rollup/plugin-replace';
 import path from 'path'
 import url from 'url'
 
-import baseConfig from '../rollup.config.mjs'
+import baseConfig, { isCdnBuild } from '../rollup.config.mjs'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+const cdnConfig = {
+  // mark everything other than 'src/index.jsx' as an external module when
+  // using the CDN build
+  // this stops rollup trying to resolve these modules as we don't run
+  // 'npm install' when using the CDN build to avoid accidentally testing
+  // against NPM packages
+  external: id => id !== 'src/index.jsx' && !id.endsWith('packages/plugin-react-performance/dist/lib/index.js'),
+  output: {
+    ...baseConfig.output,
+    globals: {
+      ...baseConfig.output.globals,
+      react: 'React',
+      'react-dom/client': 'ReactDom',
+      '@bugsnag/plugin-react-performance': 'BugsnagPluginReactPerformance',
+    },
+  }
+}
 
 export default {
   ...baseConfig,
@@ -30,5 +48,6 @@ export default {
         'process.env.NODE_ENV': JSON.stringify('production'),
       },
     })
-  ]
+  ],
+  ...(isCdnBuild ? cdnConfig : {})
 }

--- a/test/browser/features/fixtures/packages/react/src/index.jsx
+++ b/test/browser/features/fixtures/packages/react/src/index.jsx
@@ -39,7 +39,7 @@ BugsnagPerformance.start({
   autoInstrumentNetworkRequests: false,
 })
 
-const container = document.getElementById('root')
+const container = document.getElementById("root")
 const root = createRoot(container)
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Goal

Update cdn rollup configuration causing test fixture build failures
Skip broken angular tests (ticket raised to resolve this)