### PR TITLE
Stop using legacy Selenium driver 

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -110,8 +110,8 @@ steps:
         timeout_in_minutes: 30
         plugins:
           docker-compose#v4.12.0:
-            pull: browser-maze-runner
-            run: browser-maze-runner
+            pull: browser-maze-runner-bs
+            run: browser-maze-runner-bs
             use-aliases: true
             command:
               - --farm=bs

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -21,16 +21,16 @@ steps:
             - exit_status: "*"
               limit: 1
 
-      - label: ":docker: Build Legacy Maze Runner image${EXTRA_STEP_LABEL}"
-        key: "browser-maze-runner-legacy-${USE_CDN_BUILD}"
+      - label: ":docker: Build BrowserStack Maze Runner image${EXTRA_STEP_LABEL}"
+        key: "browser-maze-runner-bs-${USE_CDN_BUILD}"
         timeout_in_minutes: 20
         plugins:
           - docker-compose#v4.12.0:
-              build: browser-maze-runner-legacy
+              build: browser-maze-runner-bs
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-              cache-from: browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
+              cache-from: browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
           - docker-compose#v4.12.0:
-              push: browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
+              push: browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:performance-ci-browser-${BRANCH_NAME}-${USE_CDN_BUILD}
         env:
           USE_CDN_BUILD: "${USE_CDN_BUILD}"
         retry:
@@ -74,12 +74,12 @@ steps:
 
       # BrowserStack
       - label: ":browserstack: :{{ matrix.browser }}: {{ matrix.version }} Browser tests${EXTRA_STEP_LABEL}"
-        depends_on: "browser-maze-runner-legacy-${USE_CDN_BUILD}"
+        depends_on: "browser-maze-runner-bs-${USE_CDN_BUILD}"
         timeout_in_minutes: 30
         plugins:
           docker-compose#v4.12.0:
-            pull: browser-maze-runner-legacy
-            run: browser-maze-runner-legacy
+            pull: browser-maze-runner-bs
+            run: browser-maze-runner-bs
             use-aliases: true
             command:
               - --https
@@ -106,12 +106,12 @@ steps:
 
       # BrowserStack non-https
       - label: ":browserstack: :{{ matrix.browser }}: {{ matrix.version }} Browser non-https tests${EXTRA_STEP_LABEL}"
-        depends_on: "browser-maze-runner-legacy-${USE_CDN_BUILD}"
+        depends_on: "browser-maze-runner-bs-${USE_CDN_BUILD}"
         timeout_in_minutes: 30
         plugins:
           docker-compose#v4.12.0:
-            pull: browser-maze-runner-legacy
-            run: browser-maze-runner-legacy
+            pull: browser-maze-runner
+            run: browser-maze-runner
             use-aliases: true
             command:
               - --farm=bs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.browser-feature-builder
       args:
-        MAZE_RUNNER_VERSION: latest-v9-cli
         USE_CDN_BUILD:
     environment:
       <<: *common-environment
@@ -58,7 +57,6 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.browser-feature-builder
       args:
-        MAZE_RUNNER_VERSION: latest-v9-cli
         USE_CDN_BUILD:
     environment: &browser-maze-runner-environment
       <<: *common-environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,27 +75,6 @@ services:
       - ./test/browser/maze_output:/app/test/browser/maze_output
       - ./reports/:/app/test/browser/reports/
 
-  browser-maze-runner-legacy:
-    build:
-      context: .
-      dockerfile: dockerfiles/Dockerfile.browser-feature-builder
-      args:
-        MAZE_RUNNER_VERSION: latest-v9-cli-legacy
-        USE_CDN_BUILD:
-    environment:
-      <<: *common-environment
-      BROWSER_STACK_USERNAME:
-      BROWSER_STACK_ACCESS_KEY:
-      USE_LEGACY_DRIVER: 1
-      MAZE_REPEATER_API_KEY: "${MAZE_REPEATER_API_KEY_JS:-}"
-    networks:
-      default:
-        aliases:
-          - maze-runner
-    volumes:
-      - ./test/browser/maze_output:/app/test/browser/maze_output
-      - ./reports/:/app/test/browser/reports/
-
   react-native-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli
     environment:

--- a/dockerfiles/Dockerfile.browser-feature-builder
+++ b/dockerfiles/Dockerfile.browser-feature-builder
@@ -1,5 +1,4 @@
-ARG MAZE_RUNNER_VERSION
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:$MAZE_RUNNER_VERSION as browser-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-click-element-fix-cli
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs
 

--- a/dockerfiles/Dockerfile.browser-feature-builder
+++ b/dockerfiles/Dockerfile.browser-feature-builder
@@ -1,4 +1,4 @@
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-click-element-fix-cli
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs
 

--- a/test/browser/features/navigation-changes.feature
+++ b/test/browser/features/navigation-changes.feature
@@ -1,3 +1,5 @@
+# Skipped on Edge 80 pending PLAT-14141
+@skip_edge_80
 @requires_fetch_keepalive
 Feature: Navigation changes
     @skip_span_time_validation


### PR DESCRIPTION
## Goal

Stop using the legacy Selenium driver, it's not needed.

## Changeset

As part of working this change, I discovered a bug in Maze Runner that meant we hadn't be running on Edge 80.  Having fixed that, I discovered that the navigation scenarios fail - these are now skipped pending further investigation.

## Testing

Covered by unblocking all browser tests on CI.