### PR TITLE
RemoteParentContext e2e tests

### DIFF
--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -384,7 +384,7 @@ function installAndroidPerformance() {
   const appGradlePath = resolve(fixtureDir, 'android/app/build.gradle')
   let appGradle = fs.readFileSync(appGradlePath, 'utf8')
 
-  const performanceDependency = 'implementation("com.bugsnag:bugsnag-android-performance:1.+")'
+  const performanceDependency = 'implementation("com.bugsnag:bugsnag-android-performance:1.14.0")'
   const dependenciesSection = 'dependencies {'
 
   appGradle = appGradle.replace(dependenciesSection, `${dependenciesSection}\n    ${performanceDependency}`)

--- a/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
+++ b/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 
 dependencies {
   compileOnly "com.bugsnag:bugsnag-android:6.+"
-  compileOnly("com.bugsnag:bugsnag-android-performance:1.11.0")
+  compileOnly("com.bugsnag:bugsnag-android-performance:1.14.0")
   implementation 'com.facebook.react:react-native'
 }

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
@@ -12,7 +12,9 @@ import com.bugsnag.android.Logger;
 import com.bugsnag.android.performance.AutoInstrument;
 import com.bugsnag.android.performance.BugsnagPerformance;
 import com.bugsnag.android.performance.PerformanceConfiguration;
+import com.bugsnag.android.performance.RemoteSpanContext;
 import com.bugsnag.android.performance.Span;
+import com.bugsnag.android.performance.SpanOptions;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -180,5 +182,19 @@ class ScenarioLauncherImpl {
         Log.d(MODULE_NAME, "Failed to start Android performance", e);
         promise.reject(e);
     }
+  }
+
+  public void sendNativeChildSpan(String traceParent, Promise promise) {
+    RemoteSpanContext remoteSpanContext = RemoteSpanContext.parseTraceParent(traceParent);
+    Span span = BugsnagPerformance.startSpan("Native child span", SpanOptions.createWithin(remoteSpanContext));
+    span.end();
+    promise.resolve(true);
+  }
+
+  public void getNativeTraceParent(Promise promise) {
+    Span span = BugsnagPerformance.startSpan("Native parent span");
+    String traceParent = RemoteSpanContext.encodeAsTraceParent(span);
+    promise.resolve(traceParent);
+    span.end();
   }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/newarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/newarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
@@ -50,5 +50,15 @@ public class ScenarioLauncher extends NativeScenarioLauncherSpec {
   public void startNativePerformance(ReadableMap configuration, Promise promise) {
     impl.startNativePerformance(configuration, promise);
   }
+
+  @Override
+  public void sendNativeChildSpan(String traceParent, Promise promise) {
+    impl.sendNativeChildSpan(traceParent, promise);
+  }
+
+  @Override
+  public void getNativeTraceParent(Promise promise) {
+    impl.getNativeTraceParent(promise);
+  }
 }
 

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/oldarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/oldarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
@@ -52,4 +52,14 @@ public class ScenarioLauncher extends ReactContextBaseJavaModule {
   public void startNativePerformance(ReadableMap configuration, Promise promise) {
     impl.startNativePerformance(configuration, promise);
   }
+
+  @ReactMethod
+  public void sendNativeChildSpan(String traceParent, Promise promise) {
+    impl.sendNativeChildSpan(traceParent, promise);
+  }
+
+  @ReactMethod
+  public void getNativeTraceParent(Promise promise) {
+    impl.getNativeTraceParent(promise);
+  }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.h
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.h
@@ -14,6 +14,8 @@
     - (NSDictionary *) readStartupConfig;
     - (id) exitApp;
     - (void) startNativePerformance:(NSDictionary *)configuration resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+    - (void) sendNativeChildSpan:(NSString *)traceParent resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+    - (void) getNativeTraceParent:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 @end
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
@@ -131,6 +131,7 @@ RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(
     config.autoInstrumentNetworkRequests = NO;
     config.autoInstrumentRendering = YES;
     config.internal.autoTriggerExportOnBatchSize = 1;
+    config.internal.clearPersistenceOnStart = YES;
 
     [BugsnagPerformance startWithConfiguration:config];
     resolve(nil);

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
@@ -136,11 +136,40 @@ RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(
     resolve(nil);
   });    
 }
+
+RCT_EXPORT_METHOD(sendNativeChildSpan:(NSString *)traceParent resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  BugsnagPerformanceRemoteSpanContext *parentContext = [BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:traceParent];
+  BugsnagPerformanceSpanOptions *options = [BugsnagPerformanceSpanOptions new];
+  options.parentContext = parentContext;
+
+  BugsnagPerformanceSpan *nativeSpan = [BugsnagPerformance startSpanWithName:@"Native child span" options:options];
+  [nativeSpan end];
+  resolve(nil);
+}
+
+RCT_EXPORT_METHOD(getNativeTraceParent:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  BugsnagPerformanceSpan *span = [BugsnagPerformance startSpanWithName:@"Native parent span"];
+  NSString *traceParent = [span encodedAsTraceParent];
+  resolve(traceParent);
+  [span end];
+}
+
 #else
 RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
   NSLog(@"Native performance is not enabled in this build");
   resolve(nil);
 }
+
+RCT_EXPORT_METHOD(sendNativeChildSpan:(NSString *)traceParent resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  NSLog(@"Native performance is not enabled in this build");
+  resolve(nil);
+}
+
+RCT_EXPORT_METHOD(getNativeTraceParent:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  NSLog(@"Native performance is not enabled in this build");
+  resolve(nil);
+}
+
 #endif
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/test/react-native/features/fixtures/scenario-launcher/lib/NativeScenarioLauncher.ts
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/NativeScenarioLauncher.ts
@@ -8,6 +8,8 @@ export interface Spec extends TurboModule {
   readStartupConfig(): UnsafeObject | null | undefined;
   exitApp(): void;
   startNativePerformance(configuration: UnsafeObject): Promise<void>;
+  sendNativeChildSpan(traceParent: string): Promise<void>;
+  getNativeTraceParent(): Promise<string>;
 }
 
 export default TurboModuleRegistry.get<Spec>("ScenarioLauncher") as Spec | null;

--- a/test/react-native/features/fixtures/scenario-launcher/lib/Persistence.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/Persistence.js
@@ -2,9 +2,13 @@ import { Platform } from 'react-native'
 import { Dirs, FileSystem } from 'react-native-file-access'
 
 const PERSISTED_STATE_VERSION = 1
-const PERSISTED_STATE_DIRECTORY = `${Dirs.CacheDir}/bugsnag-performance-react-native/v${PERSISTED_STATE_VERSION}`
-const PERSISTED_STATE_PATH = `${PERSISTED_STATE_DIRECTORY}/persisted-state.json`
-const RETRY_QUEUE_DIRECTORY = `${PERSISTED_STATE_DIRECTORY}/retry-queue`
+const RN_PERSISTED_STATE_DIRECTORY = `${Dirs.CacheDir}/bugsnag-performance-react-native/v${PERSISTED_STATE_VERSION}`
+const RN_PERSISTED_STATE_PATH = `${RN_PERSISTED_STATE_DIRECTORY}/persisted-state.json`
+const RN_RETRY_QUEUE_DIRECTORY = `${RN_PERSISTED_STATE_DIRECTORY}/retry-queue`
+
+const ANDROID_PERSISTED_STATE_DIRECTORY = `${Dirs.CacheDir}/bugsnag-performance/v${PERSISTED_STATE_VERSION}`
+const ANDROID_PERSISTED_STATE_PATH = `${ANDROID_PERSISTED_STATE_DIRECTORY}/persistent-state.json`
+const ANDROID_RETRY_QUEUE_DIRECTORY = `${ANDROID_PERSISTED_STATE_DIRECTORY}/retry-queue`
 
 function getNativeDeviceIdFilePath () {
     const nativeDeviceIdFilePath = Platform.select({
@@ -17,19 +21,19 @@ function getNativeDeviceIdFilePath () {
 }
 
 async function writePersistedStateFile(contents) {
-    if (!await FileSystem.exists(PERSISTED_STATE_DIRECTORY)) {
-        console.error(`[BugsnagPerformance] creating persisted state directory: ${PERSISTED_STATE_DIRECTORY}`)
-        await FileSystem.mkdir(PERSISTED_STATE_DIRECTORY)
+    if (!await FileSystem.exists(RN_PERSISTED_STATE_DIRECTORY)) {
+        console.error(`[BugsnagPerformance] creating persisted state directory: ${RN_PERSISTED_STATE_DIRECTORY}`)
+        await FileSystem.mkdir(RN_PERSISTED_STATE_DIRECTORY)
     }
 
-    console.error(`[BugsnagPerformance] writing to: ${PERSISTED_STATE_PATH}`)
+    console.error(`[BugsnagPerformance] writing to: ${RN_PERSISTED_STATE_PATH}`)
 
     await FileSystem.writeFile(
-        PERSISTED_STATE_PATH,
+        RN_PERSISTED_STATE_PATH,
         JSON.stringify(contents)
     )
 
-    console.error(`[BugsnagPerformance] finished writing to: ${PERSISTED_STATE_PATH}`)
+    console.error(`[BugsnagPerformance] finished writing to: ${RN_PERSISTED_STATE_PATH}`)
 }
 
 export async function setSamplingProbability(value, time = Date.now()) {
@@ -43,17 +47,32 @@ export async function setDeviceId(deviceId) {
 }
 
 export async function clearPersistedState() {
-    if (await FileSystem.exists(PERSISTED_STATE_PATH)) {
-        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${PERSISTED_STATE_PATH}`)
-        await FileSystem.unlink(PERSISTED_STATE_PATH)
+    // React Native Performance SDK persistence
+    if (await FileSystem.exists(RN_PERSISTED_STATE_PATH)) {
+        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${RN_PERSISTED_STATE_PATH}`)
+        await FileSystem.unlink(RN_PERSISTED_STATE_PATH)
     }
-    if (await FileSystem.exists(RETRY_QUEUE_DIRECTORY)) {
-        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${RETRY_QUEUE_DIRECTORY}`)
-        const files = await FileSystem.ls(RETRY_QUEUE_DIRECTORY)
+    if (await FileSystem.exists(RN_RETRY_QUEUE_DIRECTORY)) {
+        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${RN_RETRY_QUEUE_DIRECTORY}`)
+        const files = await FileSystem.ls(RN_RETRY_QUEUE_DIRECTORY)
         for (const file of files) {
-            await FileSystem.unlink(`${RETRY_QUEUE_DIRECTORY}/${file}`)
+            await FileSystem.unlink(`${RN_RETRY_QUEUE_DIRECTORY}/${file}`)
         }
     }
+
+    // Android Performance SDK persistence (For Cocoa Performance we set the clearPersistenceOnStart config option)
+    if (await FileSystem.exists(ANDROID_PERSISTED_STATE_PATH)) {
+        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${ANDROID_PERSISTED_STATE_PATH}`)
+        await FileSystem.unlink(ANDROID_PERSISTED_STATE_PATH)
+    }
+    if (await FileSystem.exists(ANDROID_RETRY_QUEUE_DIRECTORY)) {
+        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${ANDROID_RETRY_QUEUE_DIRECTORY}`)
+        const files = await FileSystem.ls(ANDROID_RETRY_QUEUE_DIRECTORY)
+        for (const file of files) {
+            await FileSystem.unlink(`${ANDROID_RETRY_QUEUE_DIRECTORY}/${file}`)
+        }
+    }
+
     const nativeDeviceIdFilePath = getNativeDeviceIdFilePath()
     if (await FileSystem.exists(nativeDeviceIdFilePath)) {
         console.error(`[BugsnagPerformance] Clearing persisted data at path: ${nativeDeviceIdFilePath}`)

--- a/test/react-native/features/fixtures/scenario-launcher/lib/Persistence.js
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/Persistence.js
@@ -20,6 +20,23 @@ function getNativeDeviceIdFilePath () {
     return nativeDeviceIdFilePath
 }
 
+async function clearDirectory(directory) {
+    if (await FileSystem.exists(directory)) {
+        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${directory}`)
+        const files = await FileSystem.ls(directory)
+        for (const file of files) {
+            await FileSystem.unlink(`${directory}/${file}`)
+        }
+    }
+}
+
+async function deleteFile(filePath) {
+    if (await FileSystem.exists(filePath)) {
+        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${filePath}`)
+        await FileSystem.unlink(filePath)
+    }
+}
+
 async function writePersistedStateFile(contents) {
     if (!await FileSystem.exists(RN_PERSISTED_STATE_DIRECTORY)) {
         console.error(`[BugsnagPerformance] creating persisted state directory: ${RN_PERSISTED_STATE_DIRECTORY}`)
@@ -48,34 +65,14 @@ export async function setDeviceId(deviceId) {
 
 export async function clearPersistedState() {
     // React Native Performance SDK persistence
-    if (await FileSystem.exists(RN_PERSISTED_STATE_PATH)) {
-        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${RN_PERSISTED_STATE_PATH}`)
-        await FileSystem.unlink(RN_PERSISTED_STATE_PATH)
-    }
-    if (await FileSystem.exists(RN_RETRY_QUEUE_DIRECTORY)) {
-        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${RN_RETRY_QUEUE_DIRECTORY}`)
-        const files = await FileSystem.ls(RN_RETRY_QUEUE_DIRECTORY)
-        for (const file of files) {
-            await FileSystem.unlink(`${RN_RETRY_QUEUE_DIRECTORY}/${file}`)
-        }
-    }
+    await deleteFile(RN_PERSISTED_STATE_PATH)
+    await clearDirectory(RN_RETRY_QUEUE_DIRECTORY)
 
     // Android Performance SDK persistence (For Cocoa Performance we set the clearPersistenceOnStart config option)
-    if (await FileSystem.exists(ANDROID_PERSISTED_STATE_PATH)) {
-        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${ANDROID_PERSISTED_STATE_PATH}`)
-        await FileSystem.unlink(ANDROID_PERSISTED_STATE_PATH)
-    }
-    if (await FileSystem.exists(ANDROID_RETRY_QUEUE_DIRECTORY)) {
-        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${ANDROID_RETRY_QUEUE_DIRECTORY}`)
-        const files = await FileSystem.ls(ANDROID_RETRY_QUEUE_DIRECTORY)
-        for (const file of files) {
-            await FileSystem.unlink(`${ANDROID_RETRY_QUEUE_DIRECTORY}/${file}`)
-        }
-    }
+    await deleteFile(ANDROID_PERSISTED_STATE_PATH)
+    await clearDirectory(ANDROID_RETRY_QUEUE_DIRECTORY)
 
     const nativeDeviceIdFilePath = getNativeDeviceIdFilePath()
-    if (await FileSystem.exists(nativeDeviceIdFilePath)) {
-        console.error(`[BugsnagPerformance] Clearing persisted data at path: ${nativeDeviceIdFilePath}`)
-        await FileSystem.unlink(nativeDeviceIdFilePath)
-    }
+    await deleteFile(nativeDeviceIdFilePath)
 }
+ 

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/RemoteParentContextJSScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/RemoteParentContextJSScenario.js
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react'
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import { NativeScenarioLauncher } from '../lib/native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+import { RemoteParentContext } from '@bugsnag/core-performance'
+
+export const doNotStartBugsnagPerformance = true
+
+export const initialise = async (config) => {
+  const nativeConfig = {
+    apiKey: config.apiKey,
+    endpoint: config.endpoint
+  }
+
+  await NativeScenarioLauncher.startNativePerformance(nativeConfig)
+
+  BugsnagPerformance.attach({ maximumBatchSize: 1, autoInstrumentAppStarts: false, autoInstrumentNetworkRequests: false })
+}
+
+export const App = () => {
+
+    useEffect(() => {
+    (async () => {
+      const parentSpan = BugsnagPerformance.startSpan('JS parent span')
+      const traceParentString = RemoteParentContext.toTraceParentString(parentSpan)
+      await NativeScenarioLauncher.sendNativeChildSpan(traceParentString)
+      parentSpan.end()
+    })()
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>Remote Parent Context (JS) Scenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/RemoteParentContextNativeScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/RemoteParentContextNativeScenario.js
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react'
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import { NativeScenarioLauncher } from '../lib/native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+import { RemoteParentContext } from '@bugsnag/core-performance'
+
+export const doNotStartBugsnagPerformance = true
+
+export const initialise = async (config) => {
+  const nativeConfig = {
+    apiKey: config.apiKey,
+    endpoint: config.endpoint
+  }
+
+  await NativeScenarioLauncher.startNativePerformance(nativeConfig)
+
+  BugsnagPerformance.attach({ maximumBatchSize: 1, autoInstrumentAppStarts: false, autoInstrumentNetworkRequests: false })
+}
+
+export const App = () => {
+
+    useEffect(() => {
+    (async () => {
+      const traceParentString = await NativeScenarioLauncher.getNativeTraceParent()
+      const remoteParentContext = RemoteParentContext.parseTraceParent(traceParentString)
+      const span = BugsnagPerformance.startSpan('JS child span', { parentContext: remoteParentContext })
+      span.end()
+    })()
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>Remote Parent Context (Native) Scenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/index.js
@@ -21,3 +21,5 @@ export * as ReactNavigationScenario from './ReactNavigationScenario'
 
 // Native Integration Scenarios
 export * as NativeIntegrationScenario from './NativeIntegrationScenario'
+export * as RemoteParentContextNativeScenario from './RemoteParentContextNativeScenario'
+export * as RemoteParentContextJSScenario from './RemoteParentContextJSScenario'

--- a/test/react-native/features/remote-parent-context.feature
+++ b/test/react-native/features/remote-parent-context.feature
@@ -1,0 +1,60 @@
+@native_integration
+Feature: Remote Parent Context
+
+  Scenario: JS spans can be encoded as traceparent strings
+    When I run 'RemoteParentContextJSScenario'
+    And I wait to receive 2 sampling requests
+    And I wait to receive 2 traces
+
+    # JS trace
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
+    
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "JS parent span"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 1.0
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" is stored as the value "parentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "traceId"
+
+    Then I discard the oldest trace
+
+    # Native trace
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals the platform-dependent string:
+        | ios     | bugsnag.performance.cocoa   |
+        | android | bugsnag.performance.android |
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Native child span"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" equals the stored value "traceId"
+
+  Scenario: Native spans can be encoded as traceparent strings
+    When I run 'RemoteParentContextNativeScenario'
+    And I wait to receive 2 sampling requests
+    And I wait to receive 2 traces
+
+    # JS trace
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
+    
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "JS child span"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 1.0
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" is stored as the value "parentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "traceId"
+
+    Then I discard the oldest trace
+
+    # Native trace
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals the platform-dependent string:
+        | ios     | bugsnag.performance.cocoa   |
+        | android | bugsnag.performance.android |
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Native parent span"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" equals the stored value "parentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" equals the stored value "traceId"
+
+


### PR DESCRIPTION
## Goal

Add e2e tests for RemoteParentContext

## Design

These tests cover encoding and decoding of traceparent strings for both the React Native and native Android and Cocoa SDKs, utilizing the exiting native integration fixture to test the cross-layer functionality

## Testing

Covered by CI