### PR TITLE
Fix release script

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -33,7 +33,8 @@ BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/platf
 
 # increment package version numbers
 if [ -z "${RETRY_PUBLISH:-}" ]; then
-  npx lerna version "$VERSION"  --no-push --no-private
+  # ensure we don't use legacy peer deps when bumping versions (https://github.com/nrwl/nx/issues/22066)
+  npm_config_legacy_peer_deps=false npx lerna version "$VERSION"  --no-push --no-private
 fi
 
 # build packages


### PR DESCRIPTION
## Goal

Fixes an issue with the release script where the `lerna version` command was causing unwanted changes to the `package-lock.json`

## Design

the `lerna version` command runs npm install with `legacy_peer_deps` internally, which result sin changes to the lockfile, so we explicitly set this to false to work around the issue.