### PR TITLE
Android remote spans

### DIFF
--- a/packages/plugin-react-native-remote-spans/android/build.gradle
+++ b/packages/plugin-react-native-remote-spans/android/build.gradle
@@ -21,5 +21,6 @@ android {
 
 dependencies {
   implementation 'com.facebook.react:react-native'
+  implementation project(':bugsnag_react-native-performance')
   api 'com.bugsnag:bugsnag-android-performance:1.14.0'
 }

--- a/packages/plugin-react-native-remote-spans/android/src/main/java/com/bugsnag/reactnative/performance/remotespans/BugsnagRemoteSpans.java
+++ b/packages/plugin-react-native-remote-spans/android/src/main/java/com/bugsnag/reactnative/performance/remotespans/BugsnagRemoteSpans.java
@@ -1,24 +1,172 @@
 package com.bugsnag.reactnative.performance.remotespans;
 
+import java.util.Date;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import android.util.Log;
 import androidx.annotation.Nullable;
-import com.bugsnag.reactnative.performance.remotespans.NativeRemoteSpansSpec;
+
+import com.bugsnag.android.performance.Span;
+import com.bugsnag.android.performance.internal.BugsnagClock;
+import com.bugsnag.android.performance.internal.EncodingUtils;
+import com.bugsnag.reactnative.performance.ReactNativeSpanAttributes;
+import com.bugsnag.reactnative.performance.remotespans.NativeBugsnagRemoteSpansSpec;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 
-public class BugsnagRemoteSpans extends NativeRemoteSpansSpec {
+public class BugsnagRemoteSpans extends NativeBugsnagRemoteSpansSpec {
 
-  static final String MODULE_NAME = "BugsnagRemoteSpans";
+    // Date-related constants
+    private static final DateFormat ISO_DATEFORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
-  public BugsnagRemoteSpans(ReactApplicationContext reactContext) {
-    super(reactContext);
-  }
+    // Attribute keys
+    private static final String ATTRIBUTES = "attributes";
+    private static final String ATTR_NAME = "name";
+    private static final String ATTR_VALUE = "value";
 
-  @Override
-  public @Nullable WritableMap getSpanIdByName(String spanName) {
-    return null;
-  }
+    // Span properties
+    private static final String END_DATETIME = "endDatetime";
+    private static final String END_TIMESTAMP = "endTimestamp";
+    private static final String IS_ENDED = "isEnded";
+    private static final String SPAN_ID = "spanId";
+    private static final String TRACE_ID = "traceId";
 
+    static final String MODULE_NAME = "BugsnagRemoteSpans";
+
+    public BugsnagRemoteSpans(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public @Nullable WritableMap getSpanIdByName(String spanName) {
+        NativeSpanAccessPlugin nativeSpanAccessPlugin = NativeSpanAccessPlugin.getInstance();
+
+        if (nativeSpanAccessPlugin == null) {
+            return null;
+        }
+
+        Span span = nativeSpanAccessPlugin.getSpanByName(spanName);
+        if (span == null) {
+            return null;
+        }
+
+        WritableMap map = Arguments.createMap();
+        map.putString(SPAN_ID, EncodingUtils.toHexString(span.getSpanId()));
+        map.putString(TRACE_ID, EncodingUtils.toHexString(span.getTraceId()));
+
+        return map;
+    }
+
+    @Override
+    public void updateSpan(ReadableMap spanId, ReadableMap updates, Promise promise) {
+        NativeSpanAccessPlugin nativeSpanAccessPlugin = NativeSpanAccessPlugin.getInstance();
+
+        if (nativeSpanAccessPlugin == null) {
+            promise.resolve(false);
+            return;
+        }
+
+        String traceIdHex = spanId.getString(TRACE_ID);
+        String spanIdHex = spanId.getString(SPAN_ID);
+        Span span = nativeSpanAccessPlugin.getSpanById(traceIdHex, spanIdHex);
+        if (span == null) {
+            promise.resolve(false);
+            return;
+        }
+
+        ReadableArray attributes = updates.getArray(ATTRIBUTES);
+        if (attributes != null) {
+            updateSpanAttributes(attributes, span);
+        }
+
+        if (updates.getBoolean(IS_ENDED)) {
+            endSpan(updates, span);
+        }
+
+        promise.resolve(true);
+    }
+
+    private static void endSpan(ReadableMap updates, Span span) {
+        String timestampString = updates.getString(END_TIMESTAMP);
+        if (timestampString != null) {
+            try {
+                long endTimestamp = Long.parseLong(timestampString);
+                span.end(BugsnagClock.INSTANCE.unixNanoTimeToElapsedRealtime(endTimestamp));
+            } catch (NumberFormatException nfe) {
+                // ignore these, the span will be ended "now" instead
+            }
+        } else {
+            String datetime = updates.getString(END_DATETIME);
+            if (datetime != null) {
+                try {
+                    synchronized (ISO_DATEFORMAT) {
+                        Date endDate = ISO_DATEFORMAT.parse(datetime);
+                        span.end(BugsnagClock.INSTANCE.fromDate(endDate));
+                    }
+                } catch (ParseException e) {
+                    // ignore these, the span will be ended "now" instead
+                }
+            }
+        }
+
+        // ending an ended span is a no-op, so we make certain the span is ended if it's been flagged for ending
+        span.end();
+    }
+
+    private static void updateSpanAttributes(ReadableArray attributeUpdates, Span span) {
+        for (int i = 0; i < attributeUpdates.size(); i++) {
+            ReadableMap attribute = attributeUpdates.getMap(i);
+            String name = attribute.getString(ATTR_NAME);
+            ReadableType type = attribute.getType(ATTR_VALUE);
+
+            switch (type) {
+                case Null:
+                    span.setAttribute(name, (String) null);
+                    break;
+                case Boolean:
+                    span.setAttribute(name, attribute.getBoolean(ATTR_VALUE));
+                    break;
+                case Number:
+                    setNumberAttribute(span, attribute, name);
+                    break;
+                case String:
+                    span.setAttribute(name, attribute.getString(ATTR_VALUE));
+                    break;
+                case Array:
+                    setArrayAttribute(span, attribute, name);
+                    break;
+            }
+        }
+    }
+
+    private static void setArrayAttribute(Span span, ReadableMap attribute, String name) {
+        Object array = ReactNativeSpanAttributes.transformArray(attribute.getArray(ATTR_VALUE));
+        if (array instanceof String[]) {
+            span.setAttribute(name, (String[]) array);
+        } else if (array instanceof long[]) {
+            span.setAttribute(name, (long[]) array);
+        } else if (array instanceof double[]) {
+            span.setAttribute(name, (double[]) array);
+        }
+    }
+
+    private static void setNumberAttribute(Span span, ReadableMap attribute, String name) {
+        double n = attribute.getDouble(ATTR_VALUE);
+        if (isInteger(n)) {
+            span.setAttribute(name, (long) n);
+        } else {
+            span.setAttribute(name, n);
+        }
+    }
+
+    private static boolean isInteger(double n) {
+        return n % 1 == 0;
+    }
 }
-

--- a/packages/plugin-react-native-remote-spans/android/src/main/java/com/bugsnag/reactnative/performance/remotespans/NativeSpanAccessPlugin.java
+++ b/packages/plugin-react-native-remote-spans/android/src/main/java/com/bugsnag/reactnative/performance/remotespans/NativeSpanAccessPlugin.java
@@ -1,0 +1,120 @@
+package com.bugsnag.reactnative.performance.remotespans;
+
+import com.bugsnag.android.performance.Span;
+import com.bugsnag.android.performance.OnSpanEndCallback;
+import com.bugsnag.android.performance.OnSpanStartCallback;
+import com.bugsnag.android.performance.Plugin;
+import com.bugsnag.android.performance.PluginContext;
+import com.bugsnag.android.performance.internal.EncodingUtils;
+import com.bugsnag.android.performance.internal.SpanImpl;
+import com.bugsnag.android.performance.internal.processing.Timeout;
+import com.bugsnag.android.performance.internal.processing.TimeoutExecutor;
+
+import android.os.SystemClock;
+
+import java.util.UUID;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NativeSpanAccessPlugin implements Plugin {
+  /**
+   * Default 10 minute validity time
+   */
+  private static final long DEFAULT_VALIDITY_TIME = 10 * 60 * 1000;
+
+  private static NativeSpanAccessPlugin INSTANCE;
+
+  private final ConcurrentMap<String, Span> spansByName = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Span> spansById = new ConcurrentHashMap<>();
+
+  @Override
+  public void install(PluginContext ctx) {
+    if (INSTANCE == null) {
+      INSTANCE = this;
+    }
+
+    ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, this::onSpanStart);
+    ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, this::onSpanEnd);
+  }
+
+  private void onSpanStart(Span span) {
+    spansByName.put(span.getName(), span);
+    spansById.put(createSpanId(span), span);
+
+    TimeoutExecutor timeoutExecutor = ((SpanImpl) span).getTimeoutExecutor$internal();
+    if (timeoutExecutor != null) {
+      timeoutExecutor.scheduleTimeout(new SpanLostTimeout(DEFAULT_VALIDITY_TIME, span));
+    }
+  }
+
+  private boolean onSpanEnd(Span span) {
+    spansByName.remove(span.getName(), span);
+    spansById.remove(createSpanId(span));
+    return true;
+  }
+
+  private void removeSpan(Span span) {
+    onSpanEnd(span);
+  }
+
+  private String createSpanId(Span span) {
+    StringBuilder id = new StringBuilder(193);
+    EncodingUtils.appendHexUUID(id, span.getTraceId());
+    id.append(':');
+    EncodingUtils.appendHexLong(id, span.getSpanId());
+    return id.toString();
+  }
+
+  @Override
+  public void start() {
+  }
+
+  Span getSpanByName(String spanName) {
+    return spansByName.get(spanName);
+  }
+
+  Span getSpanById(String traceIdHex, String spanIdHex) {
+    return spansById.get(traceIdHex + ':' + spanIdHex);
+  }
+
+  static NativeSpanAccessPlugin getInstance() {
+    return INSTANCE;
+  }
+
+  private class SpanLostTimeout implements Timeout {
+    private final long timeoutMs;
+    private final Span span;
+
+    public SpanLostTimeout(long timeoutMs, Span span) {
+      this.timeoutMs = SystemClock.elapsedRealtime() + timeoutMs;
+      this.span = span;
+    }
+
+    @Override
+    public long getTarget() {
+      return timeoutMs;
+    }
+
+    @Override
+    public void run() {
+      removeSpan(span);
+    }
+
+    @Override
+    public long getRelativeMs() {
+      return Timeout.DefaultImpls.getRelativeMs(this);
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+      return Timeout.DefaultImpls.getDelay(this, unit);
+    }
+
+    @Override
+    public int compareTo(Delayed other) {
+      return Timeout.DefaultImpls.compareTo(this, other);
+    }
+  }
+}

--- a/packages/plugin-react-native-remote-spans/babel.config.cjs
+++ b/packages/plugin-react-native-remote-spans/babel.config.cjs
@@ -1,9 +1,0 @@
-module.exports = api => {
-  const isTest = api.env('test')
-
-  if (isTest) {
-    return {
-      plugins: [['@babel/plugin-transform-private-methods', { loose: true }]]
-    }
-  }
-}

--- a/packages/plugin-react-native-remote-spans/lib/NativeBugsnagRemoteSpans.ts
+++ b/packages/plugin-react-native-remote-spans/lib/NativeBugsnagRemoteSpans.ts
@@ -1,14 +1,29 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 import type { TurboModule } from 'react-native/Libraries/TurboModule/RCTExport'
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes'
 import { TurboModuleRegistry } from 'react-native'
 
 export type SpanId = {
-  id: string
+  spanId: string
   traceId: string
+}
+
+type SpanAttribute = {
+  name: string
+  value: UnsafeObject
+}
+
+export type SpanUpdateTransaction = {
+  attributes: SpanAttribute[]
+  isEnded: boolean
+  endTimestamp: string | undefined
+  endDatetime: string | undefined
 }
 
 export interface Spec extends TurboModule {
   getSpanIdByName: (spanName: string) => SpanId | undefined
+
+  updateSpan: (spanId: SpanId, updates: SpanUpdateTransaction) => Promise<boolean>
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/packages/plugin-react-native-remote-spans/lib/index.ts
+++ b/packages/plugin-react-native-remote-spans/lib/index.ts
@@ -1,32 +1,70 @@
 import { TurboModuleRegistry } from 'react-native'
-import type { Spec } from './NativeBugsnagRemoteSpans'
-import type { ParentContext } from '@bugsnag/core-performance'
+import { SpanQuery } from '@bugsnag/core-performance/lib/span-control-provider'
+import type { SpanUpdateTransaction, Spec } from './NativeBugsnagRemoteSpans'
+import type { ParentContext, SpanAttribute, Time } from '@bugsnag/core-performance'
+import type { SpanControlProvider } from '@bugsnag/core-performance/lib/span-control-provider'
 
-export class NativeSpanQuery {
+export class NativeSpanQuery extends SpanQuery<NativeSpanControl> {
   constructor (public readonly name: string) {
+    super()
   }
 }
 
+export interface NativeSpanMutator {
+  end: (endTime?: Time) => void
+  setAttribute: (name: string, value: SpanAttribute) => void
+}
+
 export interface NativeSpanControl extends ParentContext {
+  updateSpan: (update: (mutator: NativeSpanMutator) => void) => Promise<boolean>
 }
 
 const NativeRemoteSpansModule = TurboModuleRegistry.get<Spec>('BugsnagRemoteSpans')
 
 class NativeSpanControlImpl implements NativeSpanControl {
-  constructor (public readonly id: string,
+  constructor (
+    public readonly id: string,
     public readonly traceId: string) {
+  }
+
+  updateSpan (update: (mutator: NativeSpanMutator) => void): Promise<boolean> {
+    const transaction: SpanUpdateTransaction = {
+      attributes: [],
+      isEnded: false,
+      endTimestamp: undefined,
+      endDatetime: undefined
+    }
+
+    update({
+      end: (endTime?: Time) => {
+        if (endTime instanceof Date) {
+          transaction.endDatetime = endTime.toISOString()
+        } else {
+          // FIXME: This needs to be clock.toUnixTimestampNanoseconds(endTime)
+          transaction.endTimestamp = endTime?.toString()
+        }
+
+        transaction.isEnded = true
+      },
+      setAttribute: (name: string, value: SpanAttribute) => {
+        transaction.attributes.push({ name, value: value as any })
+      }
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return NativeRemoteSpansModule!.updateSpan({ spanId: this.id, traceId: this.traceId }, transaction)
   }
 }
 
-export class NativeSpanControlProvider {
-  get (query: any): NativeSpanControl | undefined {
+export class NativeSpanControlProvider implements SpanControlProvider<NativeSpanControl> {
+  getSpanControls<Q> (query: Q): NativeSpanControl | null {
     if (query instanceof NativeSpanQuery && NativeRemoteSpansModule) {
       const spanId = NativeRemoteSpansModule.getSpanIdByName(query.name)
       if (spanId) {
-        return new NativeSpanControlImpl(spanId.id, spanId.traceId)
+        return new NativeSpanControlImpl(spanId.spanId, spanId.traceId)
       }
     }
 
-    return undefined
+    return null
   }
 }

--- a/packages/plugin-react-native-remote-spans/rollup.config.mjs
+++ b/packages/plugin-react-native-remote-spans/rollup.config.mjs
@@ -19,7 +19,6 @@ function reactNativeSpecPlugin() {
 const config = createRollupConfig({
   external: [
     '@bugsnag/react-native-performance',
-    'react-native-navigation',
     'react-native',
     'react'
   ]


### PR DESCRIPTION
## Goal
Allow ReactNative apps to remotely control selected native spans based on the name of the span. Changes are batched up into a single "transactions" before being executed natively.

## Design
The `NativeSpanControlProvider` now implements `SpanControlProvider<NativeSpanControl>` allowing users to retrieve span references by name, resulting in an object that can be used to both update the span or parent JS spans under the native span.

## Note
This PR does not expose a `Plugin` for the JavaScript (as this will be added later), and as a consequence also does not correctly send `performance.now()` derived timestamps to the native layer (as this requires access to the JS `Clock`).

## Testing
Tested manually using a modified example app. Further testing to follow in a later PR.