### PR TITLE
Java7 / ReactNative 0.64 Compatibility for Span Access

### DIFF
--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansPlugin.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansPlugin.java
@@ -35,8 +35,19 @@ public class BugsnagNativeSpansPlugin implements Plugin {
             INSTANCE = this;
         }
 
-        ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, this::onSpanStart);
-        ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, this::onSpanEnd);
+        ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, new OnSpanStartCallback() {
+            @Override
+            public void onSpanStart(Span span) {
+              BugsnagNativeSpansPlugin.this.onSpanStart(span);
+            }
+        });
+
+        ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, new OnSpanEndCallback() {
+            @Override
+            public boolean onSpanEnd(Span span) {
+                return BugsnagNativeSpansPlugin.this.onSpanEnd(span);
+            }
+        });
     }
 
     private void onSpanStart(Span span) {


### PR DESCRIPTION
## Goal
Fix ReactNative 0.64 compatibility.

## Changes
Replaced the SpanStart/End callback method-refs with anonymous classes.

## Testing
Relied on RN 0.64 tests building & passing