### PR TITLE
Bump Android Performance dependencies to 1.16.0 and fix compatibility issues

### DIFF
--- a/.buildkite/scripts/packages.json
+++ b/.buildkite/scripts/packages.json
@@ -52,14 +52,12 @@
             "packages/request-tracker",
             "packages/plugin-react-native-navigation",
             "packages/plugin-react-native-span-access"
-        ],
-        "skip": true
+        ]
     },
     {
         "pipeline": ".buildkite/react-native-navigation-pipeline.full.yml",
         "block": ".buildkite/react-native-navigation-pipeline.full.block.yml",
-        "paths": [],
-        "skip": true
+        "paths": []
     },
     {
         "pipeline": ".buildkite/expo-pipeline.yml",
@@ -72,13 +70,11 @@
             "packages/request-tracker",
             "packages/plugin-react-navigation",
             "packages/plugin-react-native-span-access"
-        ],
-        "skip": true
+        ]
     },
     {
         "pipeline": ".buildkite/expo-pipeline.full.yml",
         "block": ".buildkite/expo-pipeline.full.block.yml",
-        "paths": [],
-        "skip": true
+        "paths": []
     }
 ]

--- a/bin/generate-expo-fixture
+++ b/bin/generate-expo-fixture
@@ -34,6 +34,7 @@ const PACKAGE_NAMES = [
   '@bugsnag/react-native-performance',
   '@bugsnag/request-tracker-performance',
   '@bugsnag/plugin-named-spans',
+  '@bugsnag/plugin-react-native-span-access',
 ]
 
 const PACKAGE_DIRECTORIES = [
@@ -44,6 +45,7 @@ const PACKAGE_DIRECTORIES = [
   `${ROOT_DIR}/packages/plugin-react-navigation`,
   `${ROOT_DIR}/packages/request-tracker`,
   `${ROOT_DIR}/packages/plugin-named-spans`,
+  `${ROOT_DIR}/packages/plugin-react-native-span-access`,
   `${ROOT_DIR}/test/react-native/features/fixtures/scenario-launcher`
 ]
 

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -149,6 +149,12 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
   // link react-native-navigation using rnn-link tool
   if (process.env.REACT_NATIVE_NAVIGATION === 'true' || process.env.REACT_NATIVE_NAVIGATION === '1') {
     execSync('npx rnn-link', { cwd: fixtureDir, stdio: 'inherit' })
+
+    // update the kotlin version to 1.8.0 in the android build.gradle file (required for Android Performance)
+    const gradlePath = resolve(fixtureDir, 'android/build.gradle')
+    let gradle = fs.readFileSync(gradlePath, 'utf8')
+    gradle = gradle.replace(/RNNKotlinVersion = "[^"]+"/, 'RNNKotlinVersion = "1.8.0"')
+    fs.writeFileSync(gradlePath, gradle)
   }
 }
 

--- a/bin/generate-react-native-fixture
+++ b/bin/generate-react-native-fixture
@@ -154,12 +154,6 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
 
 // generate Android Fixture
 if (process.env.BUILD_ANDROID === 'true' || process.env.BUILD_ANDROID === '1') {
-  // build and publish bugsnag-android-performance to local maven repo
-  // this is required even if we're not building the native integration fixture because
-  // @bugsnag/react-native-performance has a compileOnly dependency on bugsnag-android-performance
-  // TODO: remove this once changes have been released in bugsnag-android-performance
-  publishLocalAndroidPerformance()
-
   execFileSync('./gradlew', ['assembleRelease'], { cwd: `${fixtureDir}/android`, stdio: 'inherit' })
   fs.copyFileSync(`${fixtureDir}/android/app/build/outputs/apk/release/app-release.apk`, `${fixtureDir}/reactnative.apk`)
 }
@@ -394,7 +388,7 @@ function installAndroidPerformance() {
   const appGradlePath = resolve(fixtureDir, 'android/app/build.gradle')
   let appGradle = fs.readFileSync(appGradlePath, 'utf8')
 
-  const performanceDependency = 'implementation("com.bugsnag:bugsnag-android-performance:9.9.9")'
+  const performanceDependency = 'implementation("com.bugsnag:bugsnag-android-performance:1.16.0")'
   const dependenciesSection = 'dependencies {'
 
   appGradle = appGradle.replace(dependenciesSection, `${dependenciesSection}\n    ${performanceDependency}`)
@@ -455,24 +449,3 @@ class MainActivity : ReactActivity() {
   fs.writeFileSync(mainActivityPath, mainActivityContents)
 }
 
-function publishLocalAndroidPerformance() {
-  // add bugsnag-android-performance as a git submodule
-  execSync(`git submodule add -b integration/appstart-type https://github.com/bugsnag/bugsnag-android-performance`, { cwd: fixtureDir, stdio: 'inherit' })
-
-  // build and publish bugsnag-android-performance to maven local
-  execSync(`./gradlew -PVERSION_NAME=9.9.9 clean publishToMavenLocal`, { cwd: `${fixtureDir}/bugsnag-android-performance`, stdio: 'inherit' })
-
-  // add mavenLocal() to the repositories section in the android/build.gradle file
-  const buildGradlePath = resolve(fixtureDir, 'android/build.gradle')
-  let buildGradle = fs.readFileSync(buildGradlePath, 'utf8')
-  const repositoriesBlock = `allprojects {
-  repositories {
-    mavenLocal()
-    mavenCentral()
-    google()
-  }
-}`
-
-  buildGradle = `${repositoriesBlock}\n${buildGradle}`
-  fs.writeFileSync(buildGradlePath, buildGradle)
-}

--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -36,5 +36,5 @@ repositories {
 
 dependencies {
   implementation 'com.facebook.react:react-native'
-  compileOnly("com.bugsnag:bugsnag-android-performance:9.9.9")
+  compileOnly("com.bugsnag:bugsnag-android-performance:1.16.0")
 }

--- a/packages/plugin-react-native-span-access/android/build.gradle
+++ b/packages/plugin-react-native-span-access/android/build.gradle
@@ -38,5 +38,5 @@ android {
 dependencies {
   implementation 'com.facebook.react:react-native'
   implementation project(':bugsnag_react-native-performance')
-  api 'com.bugsnag:bugsnag-android-performance:9.9.9'
+  api 'com.bugsnag:bugsnag-android-performance:1.16.0'
 }

--- a/packages/plugin-react-native-span-access/android/src/main/AndroidManifest.xml
+++ b/packages/plugin-react-native-span-access/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.bugsnag.reactnative.performance.nativespans">
+</manifest>

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansPlugin.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansPlugin.java
@@ -35,8 +35,19 @@ public class BugsnagNativeSpansPlugin implements Plugin {
             INSTANCE = this;
         }
 
-        ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, this::onSpanStart);
-        ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, this::onSpanEnd);
+        ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, new OnSpanStartCallback() {
+            @Override
+            public void onSpanStart(Span span) {
+              BugsnagNativeSpansPlugin.this.onSpanStart(span);
+            }
+        });
+
+        ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, new OnSpanEndCallback() {
+            @Override
+            public boolean onSpanEnd(Span span) {
+                return BugsnagNativeSpansPlugin.this.onSpanEnd(span);
+            }
+        });
     }
 
     private void onSpanStart(Span span) {

--- a/packages/plugin-react-native-span-access/android/src/newarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
+++ b/packages/plugin-react-native-span-access/android/src/newarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
@@ -1,5 +1,6 @@
 package com.bugsnag.reactnative.performance.nativespans;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -15,6 +16,12 @@ public class BugsnagNativeSpansModule extends NativeBugsnagNativeSpansSpec {
     public BugsnagNativeSpansModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.delegate = new BugsnagNativeSpans(reactContext);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return BugsnagNativeSpans.MODULE_NAME;
     }
 
     @Override

--- a/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.xcodeproj/project.pbxproj
+++ b/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.xcodeproj/project.pbxproj
@@ -1,0 +1,296 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		DA3192AA2E0AE8B7009B1271 /* BugsnagNativeSpans.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA3192A62E0AE8B7009B1271 /* BugsnagNativeSpans.mm */; };
+		DA3192AB2E0AE8B7009B1271 /* BugsnagNativeSpansPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA3192A82E0AE8B7009B1271 /* BugsnagNativeSpansPlugin.mm */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		DA3192922E0AE7D4009B1271 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		DA3192942E0AE7D4009B1271 /* libBugsnagNativeSpans.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugsnagNativeSpans.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA3192A52E0AE8B7009B1271 /* BugsnagNativeSpans.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagNativeSpans.h; sourceTree = "<group>"; };
+		DA3192A62E0AE8B7009B1271 /* BugsnagNativeSpans.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagNativeSpans.mm; sourceTree = "<group>"; };
+		DA3192A72E0AE8B7009B1271 /* BugsnagNativeSpansPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagNativeSpansPlugin.h; sourceTree = "<group>"; };
+		DA3192A82E0AE8B7009B1271 /* BugsnagNativeSpansPlugin.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagNativeSpansPlugin.mm; sourceTree = "<group>"; };
+		DA3192A92E0AE8B7009B1271 /* BugsnagNativeSpansPlugin+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagNativeSpansPlugin+Private.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		DA3192912E0AE7D4009B1271 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		DA31928B2E0AE7D4009B1271 = {
+			isa = PBXGroup;
+			children = (
+				DA3192A52E0AE8B7009B1271 /* BugsnagNativeSpans.h */,
+				DA3192A62E0AE8B7009B1271 /* BugsnagNativeSpans.mm */,
+				DA3192A72E0AE8B7009B1271 /* BugsnagNativeSpansPlugin.h */,
+				DA3192A82E0AE8B7009B1271 /* BugsnagNativeSpansPlugin.mm */,
+				DA3192A92E0AE8B7009B1271 /* BugsnagNativeSpansPlugin+Private.h */,
+				DA3192952E0AE7D4009B1271 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		DA3192952E0AE7D4009B1271 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DA3192942E0AE7D4009B1271 /* libBugsnagNativeSpans.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		DA3192932E0AE7D4009B1271 /* BugsnagNativeSpans */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA31929E2E0AE7D4009B1271 /* Build configuration list for PBXNativeTarget "BugsnagNativeSpans" */;
+			buildPhases = (
+				DA3192902E0AE7D4009B1271 /* Sources */,
+				DA3192912E0AE7D4009B1271 /* Frameworks */,
+				DA3192922E0AE7D4009B1271 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BugsnagNativeSpans;
+			packageProductDependencies = (
+			);
+			productName = BugsnagNativeSpans;
+			productReference = DA3192942E0AE7D4009B1271 /* libBugsnagNativeSpans.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		DA31928C2E0AE7D4009B1271 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					DA3192932E0AE7D4009B1271 = {
+						CreatedOnToolsVersion = 16.2;
+					};
+				};
+			};
+			buildConfigurationList = DA31928F2E0AE7D4009B1271 /* Build configuration list for PBXProject "BugsnagNativeSpans" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = DA31928B2E0AE7D4009B1271;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = DA3192952E0AE7D4009B1271 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				DA3192932E0AE7D4009B1271 /* BugsnagNativeSpans */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		DA3192902E0AE7D4009B1271 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA3192AA2E0AE8B7009B1271 /* BugsnagNativeSpans.mm in Sources */,
+				DA3192AB2E0AE8B7009B1271 /* BugsnagNativeSpansPlugin.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		DA31929C2E0AE7D4009B1271 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		DA31929D2E0AE7D4009B1271 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		DA31929F2E0AE7D4009B1271 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DA3192A02E0AE7D4009B1271 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		DA31928F2E0AE7D4009B1271 /* Build configuration list for PBXProject "BugsnagNativeSpans" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA31929C2E0AE7D4009B1271 /* Debug */,
+				DA31929D2E0AE7D4009B1271 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA31929E2E0AE7D4009B1271 /* Build configuration list for PBXNativeTarget "BugsnagNativeSpans" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA31929F2E0AE7D4009B1271 /* Debug */,
+				DA3192A02E0AE7D4009B1271 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = DA31928C2E0AE7D4009B1271 /* Project object */;
+}

--- a/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
+++ b/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
   compileOnly "com.bugsnag:bugsnag-android:6.+"
-  compileOnly("com.bugsnag:bugsnag-android-performance:9.9.9")
+  compileOnly("com.bugsnag:bugsnag-android-performance:1.16.0")
   implementation 'com.facebook.react:react-native'
   implementation project(':bugsnag_plugin-react-native-span-access')
 }


### PR DESCRIPTION
## Goal

Switch the Android Performance dependencies to the latest version (1.16.0), reinstate skipped tests and fix last remaining compatibility issues in plugin-react-native-span-access for older versions of React Native

## Testing

Covered by CI