### PR TITLE
Skip SvelteKit tests on Safari 13

### DIFF
--- a/test/browser/features/svelte-kit.feature
+++ b/test/browser/features/svelte-kit.feature
@@ -1,4 +1,4 @@
-@skip_chrome_61 @skip_safari_11 @skip_edge_80 @skip_firefox_60
+@skip_chrome_61 @skip_safari_11 @skip_safari_13 @skip_edge_80 @skip_firefox_60
 Feature: SvelteKit router
     Scenario: SvelteKit route change spans are automatically instrumented
         Given I navigate to the test URL "/docs/svelte-kit/build"

--- a/test/browser/features/svelte-kit.feature
+++ b/test/browser/features/svelte-kit.feature
@@ -1,4 +1,4 @@
-@skip_chrome_61 @skip_safari_11 @skip_safari_13 @skip_edge_80 @skip_firefox_60
+@skip_chrome_61 @skip_safari_11 @skip_on_ios_13 @skip_edge_80 @skip_firefox_60
 Feature: SvelteKit router
     Scenario: SvelteKit route change spans are automatically instrumented
         Given I navigate to the test URL "/docs/svelte-kit/build"


### PR DESCRIPTION
## Goal

Skip testing on platforms not supported by SvelteKit due to ES2020 requirements