### PR TITLE
BugsnagNativeSpans NativeEventEmitter support

### DIFF
--- a/packages/plugin-react-native-span-access/android/src/newarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
+++ b/packages/plugin-react-native-span-access/android/src/newarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
@@ -33,4 +33,14 @@ public class BugsnagNativeSpansModule extends NativeBugsnagNativeSpansSpec {
     public void updateSpan(ReadableMap spanId, ReadableMap updates, Promise promise) {
         delegate.updateSpan(spanId, updates, promise);
     }
+
+    @Override
+    public void addListener(String eventType) {
+        // noop - required for EventEmitter support
+    }
+
+    @Override
+    public void removeListeners(double count) {
+        // noop - required for EventEmitter support
+    }
 }

--- a/packages/plugin-react-native-span-access/android/src/oldarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
+++ b/packages/plugin-react-native-span-access/android/src/oldarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
@@ -33,4 +33,14 @@ public class BugsnagNativeSpansModule extends ReactContextBaseJavaModule {
     public void updateSpan(ReadableMap spanId, ReadableMap updates, Promise promise) {
         delegate.updateSpan(spanId, updates, promise);
     }
+
+    @ReactMethod
+    public void addListener(String eventType) {
+        // noop - required for EventEmitter support
+    }
+
+    @ReactMethod
+    public void removeListeners(double count) {
+        // noop - required for EventEmitter support
+    }
 }

--- a/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.h
+++ b/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.h
@@ -1,4 +1,5 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <BugsnagNativeSpansSpec/BugsnagNativeSpansSpec.h>
@@ -6,7 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BugsnagNativeSpans : NSObject <RCTBridgeModule>
+@interface BugsnagNativeSpans : RCTEventEmitter <RCTBridgeModule>
 
 @end
 

--- a/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.mm
@@ -12,6 +12,11 @@
 
 RCT_EXPORT_MODULE()
 
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[];
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSpanIdByName:(NSString *)spanName) {
     BugsnagNativeSpansPlugin *plugin = [BugsnagNativeSpansPlugin singleton];
     if (!plugin) {

--- a/packages/plugin-react-native-span-access/lib/NativeBugsnagNativeSpans.ts
+++ b/packages/plugin-react-native-span-access/lib/NativeBugsnagNativeSpans.ts
@@ -6,6 +6,10 @@ export interface Spec extends TurboModule {
   getSpanIdByName: (spanName: string) => UnsafeObject | undefined
 
   updateSpan: (spanId: UnsafeObject, updates: UnsafeObject) => Promise<boolean>
+
+  addListener: (eventType: string) => void
+
+  removeListeners: (count: number) => void
 }
 
 export default TurboModuleRegistry.get<Spec>(


### PR DESCRIPTION
## Goal

Adds `NativeEventEmitter` support to the `BugsnagNativeSpans` module as a precursor to JS span access support.

## Design

This is just the boilerplate required in the Turbo Module spec and native implementations to support emitting events from native to JS - no actual events have been implemented as of yet.

## Testing

Manually tested events can be sent and received on both old and new arch, across all supported versions.