### PR TITLE
Fix iOS crash from requestEntropyAsync

### DIFF
--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
@@ -124,7 +124,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(requestEntropy) {
 }
 
 RCT_EXPORT_METHOD(requestEntropyAsync:(RCTPromiseResolveBlock)resolve
-                   rejecter:(RCTPromiseRejectBlock)reject) {
+                   reject:(RCTPromiseRejectBlock)reject) {
     NSString *hexStr = getRandomBytes();
     resolve(hexStr);
 }


### PR DESCRIPTION
## Goal

When calling `startSpan` the `requestEntropy` function is called once to generate values for the span IDs. After the first 1000 spans the values are regenerated using the `requestEntropyAsync` function but the objc file has a typo which causes it to crash when called.

**Bug sample:** 
[link](https://github.com/maxphillipsdev/bugsnag-js-performance/tree/startSpan-crash-repro)

**Sample instructions:** 
I lowered the `CALLS_BEFORE_POOL_REFRESH ` value from 1000 to 10. 
Just click send on "Navigation Span" 10 times and look in the console to see each time the id generator function is called. After 10 times it will crash from a missing selector.

<img width="1236" height="713" alt="image" src="https://github.com/user-attachments/assets/7f3f8883-0421-487e-960e-c2a5d2273f75" />


## Changeset

Just fixed the typo in the argument name.

## Testing

Ran unit tests and manually tested in sample app.