### PR TITLE
JavaScript span controls for Android

### DIFF
--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -36,5 +36,6 @@ repositories {
 
 dependencies {
   implementation 'com.facebook.react:react-native'
-  compileOnly("com.bugsnag:bugsnag-android-performance:1.16.0")
+  compileOnly("com.bugsnag:bugsnag-android-performance:2.0.0")
+  compileOnly("com.bugsnag:bugsnag-android-performance-impl:2.0.0")
 }

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
@@ -37,6 +37,7 @@ import com.bugsnag.android.performance.internal.BugsnagClock;
 import com.bugsnag.android.performance.internal.EncodingUtils;
 import com.bugsnag.android.performance.internal.SpanFactory;
 import com.bugsnag.android.performance.internal.SpanImpl;
+import com.bugsnag.android.performance.internal.BugsnagPerformanceImpl;
 import com.bugsnag.android.performance.internal.processing.ImmutableConfig;
 
 @SuppressLint("RestrictedApi")
@@ -73,7 +74,7 @@ class NativeBugsnagPerformanceImpl {
     this.reactContext = reactContext;
 
     try {
-      BugsnagPerformance.INSTANCE.getInstrumentedAppState$internal().getConfig$internal();
+      BugsnagPerformanceImpl.INSTANCE.getInstrumentedAppState().getConfig$internal();
       isNativePerformanceAvailable = true;
     }
     catch (LinkageError e) {
@@ -140,7 +141,7 @@ class NativeBugsnagPerformanceImpl {
       return null;
     }
 
-    ImmutableConfig nativeConfig = BugsnagPerformance.INSTANCE.getInstrumentedAppState$internal().getConfig$internal();
+    ImmutableConfig nativeConfig = BugsnagPerformanceImpl.INSTANCE.getInstrumentedAppState().getConfig$internal();
     if (nativeConfig == null) {
       return null;
     }
@@ -149,7 +150,7 @@ class NativeBugsnagPerformanceImpl {
       mainHandler.postDelayed(spanCleanupTask, TimeUnit.HOURS.toMillis(1));
       isCleanupTaskScheduled = true;
     }
-    
+
     WritableMap result = Arguments.createMap();
     result.putString("apiKey", nativeConfig.getApiKey());
     result.putString("endpoint", nativeConfig.getEndpoint());
@@ -184,12 +185,12 @@ class NativeBugsnagPerformanceImpl {
     }
 
     SpanOptions spanOptions = readableMapToSpanOptions(options);
-    SpanFactory spanFactory = BugsnagPerformance.INSTANCE.getInstrumentedAppState$internal().getSpanFactory();
+    SpanFactory spanFactory = BugsnagPerformanceImpl.INSTANCE.getSpanFactory();
     SpanImpl nativeSpan = spanFactory.createCustomSpan(name, spanOptions);
 
     // all span attributes are set from JS, with the exception of the bugsnag.sampling.p attribute
     // this needs to be preserved as it may not be re-populated when the span is processed
-    Iterator<Map.Entry<String, Object>> entries = nativeSpan.getAttributes().getEntries$internal().iterator();
+    Iterator<Map.Entry<String, Object>> entries = nativeSpan.getAttributes().getEntries().iterator();
     while (entries.hasNext()) {
       Map.Entry<String, Object> entry = entries.next();
       if (!entry.getKey().equals("bugsnag.sampling.p")) {

--- a/packages/plugin-react-native-span-access/android/build.gradle
+++ b/packages/plugin-react-native-span-access/android/build.gradle
@@ -38,5 +38,6 @@ android {
 dependencies {
   implementation 'com.facebook.react:react-native'
   implementation project(':bugsnag_react-native-performance')
-  api 'com.bugsnag:bugsnag-android-performance:1.16.0'
+  api 'com.bugsnag:bugsnag-android-performance:2.0.0'
+  implementation 'com.bugsnag:bugsnag-android-performance-impl:2.0.0'
 }

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagJavascriptSpansPlugin.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagJavascriptSpansPlugin.java
@@ -1,0 +1,32 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+import com.bugsnag.android.performance.Span;
+import com.bugsnag.android.performance.OnSpanEndCallback;
+import com.bugsnag.android.performance.OnSpanStartCallback;
+import com.bugsnag.android.performance.Plugin;
+import com.bugsnag.android.performance.PluginContext;
+import com.bugsnag.android.performance.internal.EncodingUtils;
+import com.bugsnag.android.performance.internal.SpanImpl;
+import com.bugsnag.android.performance.internal.processing.Timeout;
+import com.bugsnag.android.performance.internal.processing.TimeoutExecutor;
+
+import android.os.SystemClock;
+
+import java.util.UUID;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class BugsnagJavascriptSpansPlugin implements Plugin {
+
+  @Override
+  public void install(PluginContext ctx) {
+    ctx.addSpanControlProvider(new JavascriptSpanControlProvider());
+  }
+
+  @Override
+  public void start() {
+  }
+
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
@@ -102,7 +102,6 @@ class BugsnagNativeSpans {
   }
 
   public void reportSpanUpdateResult(double eventId, boolean result, Promise promise) {
-    android.util.Log.d("BugsnagNativeSpans", "reportSpanUpdateResult: eventId=" + eventId + ", result=" + result);
     onRemoteSpanUpdated((int) eventId, result);
     promise.resolve(null);
   }

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
@@ -30,7 +30,7 @@ class BugsnagNativeSpans {
   private static final String SPAN_ID = "spanId";
   private static final String TRACE_ID = "traceId";
 
-  private static final String SPAN_UPDATE_EVENT_TYPE = "JavascriptSpanUpdate";
+  private static final String SPAN_UPDATE_EVENT_TYPE = "bugsnag:spanUpdate";
 
   private static volatile BugsnagNativeSpans INSTANCE;
 
@@ -102,13 +102,11 @@ class BugsnagNativeSpans {
   }
 
   public void reportSpanUpdateResult(double eventId, boolean result, Promise promise) {
-    android.util.Log.d(MODULE_NAME, "Reporting span update result: " + result + " for eventId: " + eventId);
     onRemoteSpanUpdated((int) eventId, result);
     promise.resolve(null);
   }
 
   void emitSpanUpdateEvent(ReadableMap updates) {
-    android.util.Log.d(MODULE_NAME, "Emitting span update event: " + updates);
     eventEmitter.emit(SPAN_UPDATE_EVENT_TYPE, updates);
   }
 

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
@@ -102,11 +102,13 @@ class BugsnagNativeSpans {
   }
 
   public void reportSpanUpdateResult(double eventId, boolean result, Promise promise) {
+    android.util.Log.d(MODULE_NAME, "Reporting span update result: " + result + " for eventId: " + eventId);
     onRemoteSpanUpdated((int) eventId, result);
     promise.resolve(null);
   }
 
   void emitSpanUpdateEvent(ReadableMap updates) {
+    android.util.Log.d(MODULE_NAME, "Emitting span update event: " + updates);
     eventEmitter.emit(SPAN_UPDATE_EVENT_TYPE, updates);
   }
 

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
@@ -1,13 +1,8 @@
 package com.bugsnag.reactnative.performance.nativespans;
 
-import java.util.Date;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-
-import android.util.Log;
-
 import androidx.annotation.Nullable;
+
+import android.util.SparseArray;
 
 import com.bugsnag.android.performance.Span;
 import com.bugsnag.android.performance.internal.BugsnagClock;
@@ -20,137 +15,187 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 class BugsnagNativeSpans {
 
-    // Attribute keys
-    private static final String ATTRIBUTES = "attributes";
-    private static final String ATTR_NAME = "name";
-    private static final String ATTR_VALUE = "value";
+  // Attribute keys
+  private static final String ATTRIBUTES = "attributes";
+  private static final String ATTR_NAME = "name";
+  private static final String ATTR_VALUE = "value";
 
-    // Span properties
-    private static final String END_TIME = "endTime";
-    private static final String IS_ENDED = "isEnded";
-    private static final String SPAN_ID = "spanId";
-    private static final String TRACE_ID = "traceId";
+  // Span properties
+  private static final String END_TIME = "endTime";
+  private static final String IS_ENDED = "isEnded";
+  private static final String SPAN_ID = "spanId";
+  private static final String TRACE_ID = "traceId";
 
-    static final String MODULE_NAME = "BugsnagNativeSpans";
+  private static final String SPAN_UPDATE_EVENT_TYPE = "JavascriptSpanUpdate";
 
-    private final ReactApplicationContext reactContext;
+  private static volatile BugsnagNativeSpans INSTANCE;
 
-    public BugsnagNativeSpans(ReactApplicationContext reactContext) {
-        this.reactContext = reactContext;
+  static final String MODULE_NAME = "BugsnagNativeSpans";
+
+  private final ReactApplicationContext reactContext;
+  private final RCTDeviceEventEmitter eventEmitter;
+
+  private final SparseArray<OnRemoteSpanUpdatedCallback> updateCallbacks = new SparseArray<>(4);
+  private int nextCallbackId = 0;
+
+  public BugsnagNativeSpans(ReactApplicationContext reactContext) {
+    this.reactContext = reactContext;
+    this.eventEmitter = reactContext.getJSModule(RCTDeviceEventEmitter.class);
+
+    INSTANCE = this;
+  }
+
+  static @Nullable BugsnagNativeSpans getInstance() {
+    return INSTANCE;
+  }
+
+  @Nullable
+  public WritableMap getSpanIdByName(String spanName) {
+    BugsnagNativeSpansPlugin nativeSpanAccessPlugin = BugsnagNativeSpansPlugin.getInstance();
+
+    if (nativeSpanAccessPlugin == null) {
+      return null;
     }
 
-    @Nullable
-    public WritableMap getSpanIdByName(String spanName) {
-        BugsnagNativeSpansPlugin nativeSpanAccessPlugin = BugsnagNativeSpansPlugin.getInstance();
-
-        if (nativeSpanAccessPlugin == null) {
-            return null;
-        }
-
-        Span span = nativeSpanAccessPlugin.getSpanByName(spanName);
-        if (span == null) {
-            return null;
-        }
-
-        WritableMap map = Arguments.createMap();
-        map.putString(SPAN_ID, EncodingUtils.toHexString(span.getSpanId()));
-        map.putString(TRACE_ID, EncodingUtils.toHexString(span.getTraceId()));
-
-        return map;
+    Span span = nativeSpanAccessPlugin.getSpanByName(spanName);
+    if (span == null) {
+      return null;
     }
 
-    public void updateSpan(ReadableMap spanId, ReadableMap updates, Promise promise) {
-        BugsnagNativeSpansPlugin nativeSpanAccessPlugin = BugsnagNativeSpansPlugin.getInstance();
+    WritableMap map = Arguments.createMap();
+    map.putString(SPAN_ID, EncodingUtils.toHexString(span.getSpanId()));
+    map.putString(TRACE_ID, EncodingUtils.toHexString(span.getTraceId()));
 
-        if (nativeSpanAccessPlugin == null) {
-            promise.resolve(false);
-            return;
-        }
+    return map;
+  }
 
-        String traceIdHex = spanId.getString(TRACE_ID);
-        String spanIdHex = spanId.getString(SPAN_ID);
-        Span span = nativeSpanAccessPlugin.getSpanById(traceIdHex, spanIdHex);
-        if (span == null) {
-            promise.resolve(false);
-            return;
-        }
+  public void updateSpan(ReadableMap spanId, ReadableMap updates, Promise promise) {
+    BugsnagNativeSpansPlugin nativeSpanAccessPlugin = BugsnagNativeSpansPlugin.getInstance();
 
-        ReadableArray attributes = updates.getArray(ATTRIBUTES);
-        if (attributes != null) {
-            updateSpanAttributes(attributes, span);
-        }
-
-        if (updates.getBoolean(IS_ENDED)) {
-            endSpan(updates, span);
-        }
-
-        promise.resolve(true);
+    if (nativeSpanAccessPlugin == null) {
+      promise.resolve(false);
+      return;
     }
 
-    public void reportSpanUpdateResult(double eventId, boolean result, Promise promise) {
-        // TODO: retrieve callback and invoke with the result
-        promise.resolve(null);
+    String traceIdHex = spanId.getString(TRACE_ID);
+    String spanIdHex = spanId.getString(SPAN_ID);
+    Span span = nativeSpanAccessPlugin.getSpanById(traceIdHex, spanIdHex);
+    if (span == null) {
+      promise.resolve(false);
+      return;
     }
 
-    private static void endSpan(ReadableMap updates, Span span) {
-        if (updates.hasKey(END_TIME)) {
-            double endTime = updates.getDouble(END_TIME);
-            span.end(BugsnagClock.INSTANCE.unixNanoTimeToElapsedRealtime((long) endTime));
-        } else {
-            span.end();
-        }
+    ReadableArray attributes = updates.getArray(ATTRIBUTES);
+    if (attributes != null) {
+      updateSpanAttributes(attributes, span);
     }
 
-    private static void updateSpanAttributes(ReadableArray attributeUpdates, Span span) {
-        for (int i = 0; i < attributeUpdates.size(); i++) {
-            ReadableMap attribute = attributeUpdates.getMap(i);
-            String name = attribute.getString(ATTR_NAME);
-            ReadableType type = attribute.getType(ATTR_VALUE);
-
-            switch (type) {
-                case Null:
-                    span.setAttribute(name, (String) null);
-                    break;
-                case Boolean:
-                    span.setAttribute(name, attribute.getBoolean(ATTR_VALUE));
-                    break;
-                case Number:
-                    setNumberAttribute(span, attribute, name);
-                    break;
-                case String:
-                    span.setAttribute(name, attribute.getString(ATTR_VALUE));
-                    break;
-                case Array:
-                    setArrayAttribute(span, attribute, name);
-                    break;
-            }
-        }
+    if (updates.getBoolean(IS_ENDED)) {
+      endSpan(updates, span);
     }
 
-    private static void setArrayAttribute(Span span, ReadableMap attribute, String name) {
-        Object array = ReactNativeSpanAttributes.transformArray(attribute.getArray(ATTR_VALUE));
-        if (array instanceof String[]) {
-            span.setAttribute(name, (String[]) array);
-        } else if (array instanceof long[]) {
-            span.setAttribute(name, (long[]) array);
-        } else if (array instanceof double[]) {
-            span.setAttribute(name, (double[]) array);
-        }
-    }
+    promise.resolve(true);
+  }
 
-    private static void setNumberAttribute(Span span, ReadableMap attribute, String name) {
-        double n = attribute.getDouble(ATTR_VALUE);
-        if (isInteger(n)) {
-            span.setAttribute(name, (long) n);
-        } else {
-            span.setAttribute(name, n);
-        }
-    }
+  public void reportSpanUpdateResult(double eventId, boolean result, Promise promise) {
+    android.util.Log.d("BugsnagNativeSpans", "reportSpanUpdateResult: eventId=" + eventId + ", result=" + result);
+    onRemoteSpanUpdated((int) eventId, result);
+    promise.resolve(null);
+  }
 
-    private static boolean isInteger(double n) {
-        return n % 1 == 0;
+  void emitSpanUpdateEvent(ReadableMap updates) {
+    eventEmitter.emit(SPAN_UPDATE_EVENT_TYPE, updates);
+  }
+
+  private void onRemoteSpanUpdated(int callbackId, boolean updateResult) {
+    OnRemoteSpanUpdatedCallback callback = takeUpdateCallback(callbackId);
+    if (callback != null) {
+      callback.onRemoteSpanUpdated(updateResult);
     }
+  }
+
+  int registerUpdateCallback(OnRemoteSpanUpdatedCallback callback) {
+    synchronized (updateCallbacks) {
+      int callbackId = nextCallbackId++;
+      updateCallbacks.put(callbackId, callback);
+      return callbackId;
+    }
+  }
+
+  @Nullable
+  private OnRemoteSpanUpdatedCallback takeUpdateCallback(int callbackId) {
+    synchronized (updateCallbacks) {
+      int index = updateCallbacks.indexOfKey(callbackId);
+      if (index < 0) {
+        return null;
+      }
+
+      OnRemoteSpanUpdatedCallback callback = updateCallbacks.valueAt(index);
+      updateCallbacks.removeAt(index);
+      return callback;
+    }
+  }
+
+  private static void endSpan(ReadableMap updates, Span span) {
+    if (updates.hasKey(END_TIME)) {
+      double endTime = updates.getDouble(END_TIME);
+      span.end(BugsnagClock.INSTANCE.unixNanoTimeToElapsedRealtime((long) endTime));
+    } else {
+      span.end();
+    }
+  }
+
+  private static void updateSpanAttributes(ReadableArray attributeUpdates, Span span) {
+    for (int i = 0; i < attributeUpdates.size(); i++) {
+      ReadableMap attribute = attributeUpdates.getMap(i);
+      String name = attribute.getString(ATTR_NAME);
+      ReadableType type = attribute.getType(ATTR_VALUE);
+
+      switch (type) {
+        case Null:
+          span.setAttribute(name, (String) null);
+          break;
+        case Boolean:
+          span.setAttribute(name, attribute.getBoolean(ATTR_VALUE));
+          break;
+        case Number:
+          setNumberAttribute(span, attribute, name);
+          break;
+        case String:
+          span.setAttribute(name, attribute.getString(ATTR_VALUE));
+          break;
+        case Array:
+          setArrayAttribute(span, attribute, name);
+          break;
+      }
+    }
+  }
+
+  private static void setArrayAttribute(Span span, ReadableMap attribute, String name) {
+    Object array = ReactNativeSpanAttributes.transformArray(attribute.getArray(ATTR_VALUE));
+    if (array instanceof String[]) {
+      span.setAttribute(name, (String[]) array);
+    } else if (array instanceof long[]) {
+      span.setAttribute(name, (long[]) array);
+    } else if (array instanceof double[]) {
+      span.setAttribute(name, (double[]) array);
+    }
+  }
+
+  private static void setNumberAttribute(Span span, ReadableMap attribute, String name) {
+    double n = attribute.getDouble(ATTR_VALUE);
+    if (isInteger(n)) {
+      span.setAttribute(name, (long) n);
+    } else {
+      span.setAttribute(name, n);
+    }
+  }
+
+  private static boolean isInteger(double n) {
+    return n % 1 == 0;
+  }
 }

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansPlugin.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansPlugin.java
@@ -19,113 +19,113 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class BugsnagNativeSpansPlugin implements Plugin {
-    /**
-     * Default 10 minute validity time
-     */
-    private static final long DEFAULT_VALIDITY_TIME = 10 * 60 * 1000;
+  /**
+   * Default 10 minute validity time
+   */
+  private static final long DEFAULT_VALIDITY_TIME = 10 * 60 * 1000;
 
-    private static BugsnagNativeSpansPlugin INSTANCE;
+  private static BugsnagNativeSpansPlugin INSTANCE;
 
-    private final ConcurrentMap<String, Span> spansByName = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Span> spansById = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Span> spansByName = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Span> spansById = new ConcurrentHashMap<>();
+
+  @Override
+  public void install(PluginContext ctx) {
+    if (INSTANCE == null) {
+      INSTANCE = this;
+    }
+
+    ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, new OnSpanStartCallback() {
+      @Override
+      public void onSpanStart(Span span) {
+        BugsnagNativeSpansPlugin.this.onSpanStart(span);
+      }
+    });
+
+    ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, new OnSpanEndCallback() {
+      @Override
+      public boolean onSpanEnd(Span span) {
+        return BugsnagNativeSpansPlugin.this.onSpanEnd(span);
+      }
+    });
+  }
+
+  private void onSpanStart(Span span) {
+    spansByName.put(span.getName(), span);
+    spansById.put(createSpanId(span), span);
+
+    TimeoutExecutor timeoutExecutor = ((SpanImpl) span).getTimeoutExecutor$internal();
+    if (timeoutExecutor != null) {
+      timeoutExecutor.scheduleTimeout(new SpanLostTimeout(DEFAULT_VALIDITY_TIME, span));
+    }
+  }
+
+  private boolean onSpanEnd(Span span) {
+    spansByName.remove(span.getName(), span);
+    spansById.remove(createSpanId(span));
+    return true;
+  }
+
+  private void removeSpan(Span span) {
+    onSpanEnd(span);
+  }
+
+  private String createSpanId(Span span) {
+    StringBuilder id = new StringBuilder(193);
+    EncodingUtils.appendHexUUID(id, span.getTraceId());
+    id.append(':');
+    EncodingUtils.appendHexLong(id, span.getSpanId());
+    return id.toString();
+  }
+
+  @Override
+  public void start() {
+  }
+
+  Span getSpanByName(String spanName) {
+    return spansByName.get(spanName);
+  }
+
+  Span getSpanById(String traceIdHex, String spanIdHex) {
+    return spansById.get(traceIdHex + ':' + spanIdHex);
+  }
+
+  static BugsnagNativeSpansPlugin getInstance() {
+    return INSTANCE;
+  }
+
+  private class SpanLostTimeout implements Timeout {
+    private final long timeoutMs;
+    private final Span span;
+
+    public SpanLostTimeout(long timeoutMs, Span span) {
+      this.timeoutMs = SystemClock.elapsedRealtime() + timeoutMs;
+      this.span = span;
+    }
 
     @Override
-    public void install(PluginContext ctx) {
-        if (INSTANCE == null) {
-            INSTANCE = this;
-        }
-
-        ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, new OnSpanStartCallback() {
-            @Override
-            public void onSpanStart(Span span) {
-              BugsnagNativeSpansPlugin.this.onSpanStart(span);
-            }
-        });
-
-        ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, new OnSpanEndCallback() {
-            @Override
-            public boolean onSpanEnd(Span span) {
-                return BugsnagNativeSpansPlugin.this.onSpanEnd(span);
-            }
-        });
-    }
-
-    private void onSpanStart(Span span) {
-        spansByName.put(span.getName(), span);
-        spansById.put(createSpanId(span), span);
-
-        TimeoutExecutor timeoutExecutor = ((SpanImpl) span).getTimeoutExecutor$internal();
-        if (timeoutExecutor != null) {
-            timeoutExecutor.scheduleTimeout(new SpanLostTimeout(DEFAULT_VALIDITY_TIME, span));
-        }
-    }
-
-    private boolean onSpanEnd(Span span) {
-        spansByName.remove(span.getName(), span);
-        spansById.remove(createSpanId(span));
-        return true;
-    }
-
-    private void removeSpan(Span span) {
-        onSpanEnd(span);
-    }
-
-    private String createSpanId(Span span) {
-        StringBuilder id = new StringBuilder(193);
-        EncodingUtils.appendHexUUID(id, span.getTraceId());
-        id.append(':');
-        EncodingUtils.appendHexLong(id, span.getSpanId());
-        return id.toString();
+    public long getTarget() {
+      return timeoutMs;
     }
 
     @Override
-    public void start() {
+    public void run() {
+      removeSpan(span);
     }
 
-    Span getSpanByName(String spanName) {
-        return spansByName.get(spanName);
+    @Override
+    public long getRelativeMs() {
+      return Timeout.DefaultImpls.getRelativeMs(this);
     }
 
-    Span getSpanById(String traceIdHex, String spanIdHex) {
-        return spansById.get(traceIdHex + ':' + spanIdHex);
+    @Override
+    public long getDelay(TimeUnit unit) {
+      return Timeout.DefaultImpls.getDelay(this, unit);
     }
 
-    static BugsnagNativeSpansPlugin getInstance() {
-        return INSTANCE;
+    @Override
+    public int compareTo(Delayed other) {
+      return Timeout.DefaultImpls.compareTo(this, other);
     }
-
-    private class SpanLostTimeout implements Timeout {
-        private final long timeoutMs;
-        private final Span span;
-
-        public SpanLostTimeout(long timeoutMs, Span span) {
-            this.timeoutMs = SystemClock.elapsedRealtime() + timeoutMs;
-            this.span = span;
-        }
-
-        @Override
-        public long getTarget() {
-            return timeoutMs;
-        }
-
-        @Override
-        public void run() {
-            removeSpan(span);
-        }
-
-        @Override
-        public long getRelativeMs() {
-            return Timeout.DefaultImpls.getRelativeMs(this);
-        }
-
-        @Override
-        public long getDelay(TimeUnit unit) {
-            return Timeout.DefaultImpls.getDelay(this, unit);
-        }
-
-        @Override
-        public int compareTo(Delayed other) {
-            return Timeout.DefaultImpls.compareTo(this, other);
-        }
-    }
+  }
 }

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanByName.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanByName.java
@@ -1,0 +1,37 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.performance.controls.SpanQuery;
+
+public final class JavascriptSpanByName implements SpanQuery<JavascriptSpanControl> {
+  private final String name;
+
+  public JavascriptSpanByName(@NonNull String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("Span name cannot be null");
+    }
+
+    this.name = name;
+  }
+
+  public String getSpanName() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof JavascriptSpanByName)) return false;
+    return this.name.equals(((JavascriptSpanByName) o).name);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.name.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "JavascriptSpanByName{name='" + name + "'}";
+  }
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControl.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControl.java
@@ -1,0 +1,5 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+public interface JavascriptSpanControl {
+  JavascriptSpanTransaction createUpdateTransaction();
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControlImpl.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControlImpl.java
@@ -1,0 +1,14 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+class JavascriptSpanControlImpl implements JavascriptSpanControl {
+  private final String spanName;
+
+  JavascriptSpanControlImpl(String spanName) {
+    this.spanName = spanName;
+  }
+
+  @Override
+  public JavascriptSpanTransaction createUpdateTransaction() {
+    return new JavascriptSpanTransactionImpl(spanName);
+  }
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControlProvider.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControlProvider.java
@@ -1,0 +1,19 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.performance.controls.SpanQuery;
+import com.bugsnag.android.performance.controls.SpanControlProvider;
+
+class JavascriptSpanControlProvider implements SpanControlProvider<JavascriptSpanControl> {
+  @Nullable
+  @Override
+  public <Q extends SpanQuery<? extends JavascriptSpanControl>> JavascriptSpanControl get(@NonNull Q query) {
+    if (query instanceof JavascriptSpanByName) {
+      String spanName = ((JavascriptSpanByName) query).getSpanName();
+      return new JavascriptSpanControlImpl(spanName);
+    }
+    return null;
+  }
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransaction.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransaction.java
@@ -1,0 +1,13 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public interface JavascriptSpanTransaction {
+    JavascriptSpanTransaction end();
+    JavascriptSpanTransaction end(long endTime);
+
+    JavascriptSpanTransaction setAttribute(@NonNull String key, @Nullable Object value);
+
+    void commit(@Nullable OnRemoteSpanUpdatedCallback callback);
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransactionImpl.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransactionImpl.java
@@ -1,0 +1,149 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+
+import java.util.LinkedHashMap;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class JavascriptSpanTransactionImpl implements JavascriptSpanTransaction {
+
+  private static final String ID = "id";
+  private static final String NAME = "name";
+  private static final String VALUE = "value";
+  private static final String ATTRIBUTES = "attributes";
+  private static final String END_TIME = "endTime";
+  private static final String IS_ENDED = "isEnded";
+
+  private final String spanName;
+
+  private final LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
+
+  private boolean isEnded = false;
+  private long endTime = -1L;
+  private boolean isOpen = true;
+
+  JavascriptSpanTransactionImpl(String spanName) {
+    this.spanName = spanName;
+  }
+
+  @Override
+  public JavascriptSpanTransaction end() {
+    if (!isOpen) {
+      return this;
+    }
+
+    this.isEnded = true;
+    this.endTime = -1L;
+    return this;
+  }
+
+  @Override
+  public JavascriptSpanTransaction end(long endTime) {
+    if (!isOpen) {
+      return this;
+    }
+
+    this.isEnded = true;
+    this.endTime = endTime;
+    return this;
+  }
+
+  @Override
+  public JavascriptSpanTransaction setAttribute(String key, Object value) {
+    if (!isOpen) {
+      return this;
+    }
+
+    attributes.putLast(key, value);
+    return this;
+  }
+
+  @Override
+  public void commit(OnRemoteSpanUpdatedCallback callback) {
+    if (!isOpen) {
+      if (callback != null) callback.onRemoteSpanUpdated(false);
+      return;
+    }
+
+    isOpen = false;
+
+    BugsnagNativeSpans spans = BugsnagNativeSpans.getInstance();
+    if (spans == null) {
+      if (callback != null) callback.onRemoteSpanUpdated(false);
+      return;
+    }
+
+    WritableMap updateTransaction = Arguments.createMap();
+    updateTransaction.putString(NAME, spanName);
+
+    Set<Map.Entry<String, Object>> entries = attributes.entrySet();
+    WritableArray attributesArray = Arguments.createArray();
+    for (Map.Entry<String, Object> entry : entries) {
+      try {
+        WritableMap attributeMap = Arguments.createMap();
+        attributeMap.putString(NAME, entry.getKey());
+        Object value = entry.getValue();
+
+        if (value instanceof String) {
+          attributeMap.putString(VALUE, (String) value);
+        } else if (value instanceof Integer) {
+          attributeMap.putInt(VALUE, (Integer) value);
+        } else if (value instanceof Long) {
+          attributeMap.putLong(VALUE, (Long) value);
+        } else if (value instanceof Number) {
+          attributeMap.putDouble(VALUE, ((Number) value).doubleValue());
+        } else if (value instanceof Boolean) {
+          attributeMap.putBoolean(VALUE, (Boolean) value);
+        } else if (value instanceof int[] ||
+          value instanceof long[] ||
+          value instanceof float[] ||
+          value instanceof double[] ||
+          value instanceof Integer[] ||
+          value instanceof Long[] ||
+          value instanceof Float[] ||
+          value instanceof Double[] ||
+          value instanceof String[] ||
+          value instanceof boolean[] ||
+          value instanceof Boolean[]
+        ) {
+          attributeMap.putArray(VALUE, Arguments.makeNativeArray(value));
+        } else if (value instanceof List) {
+          attributeMap.putArray(VALUE, Arguments.makeNativeArray((List<?>) value));
+        } else if (value instanceof Collection) {
+          attributeMap.putArray(
+            VALUE,
+            Arguments.makeNativeArray(new ArrayList<>((Collection<?>) value))
+          );
+        }
+
+        attributesArray.pushMap(attributeMap);
+      } catch (Exception e) {
+        // If we can't convert the value to a supported type, skip it
+        continue;
+      }
+    }
+
+    updateTransaction.putArray(ATTRIBUTES, attributesArray);
+
+    if (isEnded) {
+      if (endTime >= 0) {
+        updateTransaction.putDouble(END_TIME, endTime);
+      }
+      updateTransaction.putBoolean(IS_ENDED, true);
+    }
+
+    if (callback != null) {
+      // register the callback *last* to avoid memory leaks from earlier exceptions
+      final int callbackId = spans.registerUpdateCallback(callback);
+      updateTransaction.putInt(ID, callbackId);
+    }
+
+    spans.emitSpanUpdateEvent(updateTransaction);
+  }
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransactionImpl.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransactionImpl.java
@@ -60,7 +60,8 @@ class JavascriptSpanTransactionImpl implements JavascriptSpanTransaction {
       return this;
     }
 
-    attributes.putLast(key, value);
+    attributes.remove(key); // Remove any existing attribute, moving the value to the end
+    attributes.put(key, value);
     return this;
   }
 
@@ -94,8 +95,6 @@ class JavascriptSpanTransactionImpl implements JavascriptSpanTransaction {
           attributeMap.putString(VALUE, (String) value);
         } else if (value instanceof Integer) {
           attributeMap.putInt(VALUE, (Integer) value);
-        } else if (value instanceof Long) {
-          attributeMap.putLong(VALUE, (Long) value);
         } else if (value instanceof Number) {
           attributeMap.putDouble(VALUE, ((Number) value).doubleValue());
         } else if (value instanceof Boolean) {

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/OnRemoteSpanUpdatedCallback.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/OnRemoteSpanUpdatedCallback.java
@@ -1,0 +1,5 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+public interface OnRemoteSpanUpdatedCallback {
+  void onRemoteSpanUpdated(boolean updateResult);
+}

--- a/packages/plugin-react-native-span-access/lib/javascript-spans-plugin.ts
+++ b/packages/plugin-react-native-span-access/lib/javascript-spans-plugin.ts
@@ -71,7 +71,9 @@ export class BugsnagJavascriptSpansPlugin implements Plugin<ReactNativeConfigura
 
       result = true
     } finally {
-      NativeNativeSpansModule?.reportSpanUpdateResult(event.id, result)
+      if (event.id !== undefined) {
+        NativeNativeSpansModule?.reportSpanUpdateResult(event.id, result)
+      }
     }
   }
 

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
@@ -21,6 +21,7 @@ import com.bugsnag.reactnative.performance.nativespans.BugsnagNativeSpansPlugin;
 import com.bugsnag.reactnative.performance.nativespans.JavascriptSpanByName;
 import com.bugsnag.reactnative.performance.nativespans.JavascriptSpanControl;
 import com.bugsnag.reactnative.performance.nativespans.JavascriptSpanTransaction;
+import com.bugsnag.reactnative.performance.nativespans.OnRemoteSpanUpdatedCallback;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Dynamic;
@@ -55,42 +56,42 @@ class ScenarioLauncherImpl {
 
       @Override
       public void e(String msg) {
-          Log.e(TAG, msg);
+        Log.e(TAG, msg);
       }
 
       @Override
       public void e(String msg, Throwable throwable) {
-          Log.e(TAG, msg, throwable);
+        Log.e(TAG, msg, throwable);
       }
 
       @Override
       public void w(String msg) {
-          Log.w(TAG, msg);
+        Log.w(TAG, msg);
       }
 
       @Override
       public void w(String msg, Throwable throwable) {
-          Log.w(TAG, msg, throwable);
+        Log.w(TAG, msg, throwable);
       }
 
       @Override
       public void i(String msg) {
-          Log.i(TAG, msg);
+        Log.i(TAG, msg);
       }
 
       @Override
       public void i(String msg, Throwable throwable) {
-          Log.i(TAG, msg, throwable);
+        Log.i(TAG, msg, throwable);
       }
 
       @Override
       public void d(String msg) {
-          Log.d(TAG, msg);
+        Log.d(TAG, msg);
       }
 
       @Override
       public void d(String msg, Throwable throwable) {
-          Log.d(TAG, msg, throwable);
+        Log.d(TAG, msg, throwable);
       }
     });
     Bugsnag.start(reactContext, bugsnagConfig);
@@ -99,13 +100,13 @@ class ScenarioLauncherImpl {
 
   public void clearPersistentData() {
     File deviceIdFile = new File(reactContext.getFilesDir(), "device-id");
-        if (deviceIdFile.exists()) {
-            try {
-                deviceIdFile.delete();
-            } catch (Exception e) {
-                Log.e("Bugsnag", "Failed to delete device id file", e);
-            }
-        }
+    if (deviceIdFile.exists()) {
+      try {
+        deviceIdFile.delete();
+      } catch (Exception e) {
+        Log.e("Bugsnag", "Failed to delete device id file", e);
+      }
+    }
   }
 
   public void saveStartupConfig(ReadableMap configuration) {
@@ -114,27 +115,27 @@ class ScenarioLauncherImpl {
     editor.putBoolean("configured", true);
 
     if (configuration.hasKey("apiKey")) {
-        editor.putString("apiKey", configuration.getString("apiKey"));
+      editor.putString("apiKey", configuration.getString("apiKey"));
     }
 
     if (configuration.hasKey("endpoint")) {
-        editor.putString("endpoint", configuration.getString("endpoint"));
+      editor.putString("endpoint", configuration.getString("endpoint"));
     }
 
     if (configuration.hasKey("autoInstrumentAppStarts")) {
-        editor.putBoolean("autoInstrumentAppStarts", configuration.getBoolean("autoInstrumentAppStarts"));
+      editor.putBoolean("autoInstrumentAppStarts", configuration.getBoolean("autoInstrumentAppStarts"));
     }
 
     if (configuration.hasKey("autoInstrumentNetworkRequests")) {
-        editor.putBoolean("autoInstrumentNetworkRequests", configuration.getBoolean("autoInstrumentNetworkRequests"));
+      editor.putBoolean("autoInstrumentNetworkRequests", configuration.getBoolean("autoInstrumentNetworkRequests"));
     }
 
     if (configuration.hasKey("maximumBatchSize")) {
-        editor.putInt("maximumBatchSize", configuration.getInt("maximumBatchSize"));
+      editor.putInt("maximumBatchSize", configuration.getInt("maximumBatchSize"));
     }
 
     if (configuration.hasKey("useWrapperComponentProvider")) {
-        editor.putBoolean("useWrapperComponentProvider", configuration.getBoolean("useWrapperComponentProvider"));
+      editor.putBoolean("useWrapperComponentProvider", configuration.getBoolean("useWrapperComponentProvider"));
     }
 
 
@@ -142,32 +143,32 @@ class ScenarioLauncherImpl {
   }
 
   public WritableMap readStartupConfig() {
-    SharedPreferences sharedPreferences = this.reactContext.getApplicationContext().getSharedPreferences("StartupConfig", Context.MODE_PRIVATE);;
+    SharedPreferences sharedPreferences = this.reactContext.getApplicationContext().getSharedPreferences("StartupConfig", Context.MODE_PRIVATE);
+    ;
     try {
-        if (!sharedPreferences.getBoolean("configured", false)) {
-            return null;
-        }
+      if (!sharedPreferences.getBoolean("configured", false)) {
+        return null;
+      }
 
-        WritableMap startupConfig = Arguments.createMap();
-        startupConfig.putString("apiKey", sharedPreferences.getString("apiKey", ""));
-        startupConfig.putString("endpoint", sharedPreferences.getString("endpoint", ""));
-        startupConfig.putBoolean("autoInstrumentAppStarts", sharedPreferences.getBoolean("autoInstrumentAppStarts", false));
-        startupConfig.putBoolean("autoInstrumentNetworkRequests", sharedPreferences.getBoolean("autoInstrumentNetworkRequests", false));
-        startupConfig.putInt("maximumBatchSize", sharedPreferences.getInt("maximumBatchSize", 100));
-        startupConfig.putBoolean("useWrapperComponentProvider", sharedPreferences.getBoolean("useWrapperComponentProvider", false));
-        return startupConfig;
-    }
-    finally {
-        // make sure we don't leave this config around for the next startup
-        sharedPreferences.edit()
-            .putBoolean("configured", false)
-            .remove("apiKey")
-            .remove("endpoint")
-            .remove("autoInstrumentAppStarts")
-            .remove("autoInstrumentNetworkRequests")
-            .remove("maximumBatchSize")
-            .remove("useWrapperComponentProvider")
-            .commit();
+      WritableMap startupConfig = Arguments.createMap();
+      startupConfig.putString("apiKey", sharedPreferences.getString("apiKey", ""));
+      startupConfig.putString("endpoint", sharedPreferences.getString("endpoint", ""));
+      startupConfig.putBoolean("autoInstrumentAppStarts", sharedPreferences.getBoolean("autoInstrumentAppStarts", false));
+      startupConfig.putBoolean("autoInstrumentNetworkRequests", sharedPreferences.getBoolean("autoInstrumentNetworkRequests", false));
+      startupConfig.putInt("maximumBatchSize", sharedPreferences.getInt("maximumBatchSize", 100));
+      startupConfig.putBoolean("useWrapperComponentProvider", sharedPreferences.getBoolean("useWrapperComponentProvider", false));
+      return startupConfig;
+    } finally {
+      // make sure we don't leave this config around for the next startup
+      sharedPreferences.edit()
+        .putBoolean("configured", false)
+        .remove("apiKey")
+        .remove("endpoint")
+        .remove("autoInstrumentAppStarts")
+        .remove("autoInstrumentNetworkRequests")
+        .remove("maximumBatchSize")
+        .remove("useWrapperComponentProvider")
+        .commit();
     }
   }
 
@@ -177,56 +178,61 @@ class ScenarioLauncherImpl {
 
   public void startNativePerformance(ReadableMap configuration, Promise promise) {
     try {
-        PerformanceConfiguration config = PerformanceConfiguration.load(reactContext);
-        config.setApiKey(configuration.getString("apiKey"));
-        config.setEndpoint(configuration.getString("endpoint"));
-        config.setAutoInstrumentAppStarts(false);
-        config.setAutoInstrumentActivities(AutoInstrument.OFF);
-        config.setAutoInstrumentRendering(true);
-        config.addPlugin(new BugsnagNativeSpansPlugin());
-        config.addPlugin(new BugsnagJavascriptSpansPlugin());
+      PerformanceConfiguration config = PerformanceConfiguration.load(reactContext);
+      config.setApiKey(configuration.getString("apiKey"));
+      config.setEndpoint(configuration.getString("endpoint"));
+      config.setAutoInstrumentAppStarts(false);
+      config.setAutoInstrumentActivities(AutoInstrument.OFF);
+      config.setAutoInstrumentRendering(true);
+      config.addPlugin(new BugsnagNativeSpansPlugin());
+      config.addPlugin(new BugsnagJavascriptSpansPlugin());
 
-        BugsnagPerformance.start(config);
-        Log.d(MODULE_NAME, "Started Android performance");
+      BugsnagPerformance.start(config);
+      Log.d(MODULE_NAME, "Started Android performance");
 
-        promise.resolve(true);
+      promise.resolve(true);
 
     } catch (Exception e) {
-        Log.d(MODULE_NAME, "Failed to start Android performance", e);
-        promise.reject(e);
+      Log.d(MODULE_NAME, "Failed to start Android performance", e);
+      promise.reject(e);
     }
   }
 
   public void startNativeSpan(ReadableMap options, Promise promise) {
     try {
-        SpanOptions spanOptions = SpanOptions.DEFAULTS;
-        if (options.hasKey("traceParent")) {
-            RemoteSpanContext remoteSpanContext = RemoteSpanContext.parseTraceParent(options.getString("traceParent"));
-            spanOptions = spanOptions.createWithin(remoteSpanContext);
-        }
+      SpanOptions spanOptions = SpanOptions.DEFAULTS;
+      if (options.hasKey("traceParent")) {
+        RemoteSpanContext remoteSpanContext = RemoteSpanContext.parseTraceParent(options.getString("traceParent"));
+        spanOptions = spanOptions.createWithin(remoteSpanContext);
+      }
 
-        Span span = BugsnagPerformance.startSpan(options.getString("name"), spanOptions);
-        String traceParent = RemoteSpanContext.encodeAsTraceParent(span);
-        openSpans.put(traceParent, span);
-        promise.resolve(traceParent);
+      Span span = BugsnagPerformance.startSpan(options.getString("name"), spanOptions);
+      String traceParent = RemoteSpanContext.encodeAsTraceParent(span);
+      openSpans.put(traceParent, span);
+      promise.resolve(traceParent);
     } catch (Exception e) {
-        Log.d(MODULE_NAME, "Failed to start native span", e);
-        promise.reject(e);
+      Log.d(MODULE_NAME, "Failed to start native span", e);
+      promise.reject(e);
     }
   }
 
   public void endNativeSpan(String traceParent, Promise promise) {
     Span span = openSpans.remove(traceParent);
     if (span != null) {
-        span.end();
-        promise.resolve(true);
+      span.end();
+      promise.resolve(true);
     } else {
-        Log.d(MODULE_NAME, "No open span found for traceParent: " + traceParent);
-        promise.resolve(false);
+      Log.d(MODULE_NAME, "No open span found for traceParent: " + traceParent);
+      promise.resolve(false);
     }
   }
 
-  public void updateJavascriptSpan(String spanName, ReadableArray attributes, Promise promise) {
+  public void updateJavascriptSpan(
+    String spanName,
+    ReadableArray attributes,
+    final Promise promise
+  ) {
+    Log.d(MODULE_NAME, "Updating Javascript span: " + spanName);
     JavascriptSpanControl spanControl = BugsnagPerformance.getSpanControls(new JavascriptSpanByName(spanName));
     JavascriptSpanTransaction transaction = spanControl.createUpdateTransaction();
 
@@ -258,10 +264,14 @@ class ScenarioLauncherImpl {
       }
     }
 
+    Log.d(MODULE_NAME, "Ending transaction for span: " + spanName);
     transaction
       .end()
-      .commit(null);
-
-    promise.resolve(null);
+      .commit(new OnRemoteSpanUpdatedCallback() {
+        public void onRemoteSpanUpdated(boolean updateResult) {
+          Log.d(MODULE_NAME, "Span update result: " + updateResult);
+          promise.resolve(null);
+        }
+      });
   }
 }

--- a/test/react-native/features/react-native-span-access.feature
+++ b/test/react-native/features/react-native-span-access.feature
@@ -49,7 +49,6 @@ Scenario: Native spans can be modified and ended from JS
       | 2.2 |
       | 3.3 |
 
-@ios_only
 Scenario: Javascript spans can be modified and ended from native
   When I run 'JavascriptSpansPluginScenario'
   And I wait to receive 1 span


### PR DESCRIPTION
## Goal
Introduce a `BugsnagJavascriptSpansPlugin` implementation for Android, allowing native code to control JavaScript spans by name.

## Design
Created a new public `BugsnagJavascriptSpansPlugin` which adds a new `SpanControlProvider` to `BugsnagPerformance` when used with `PerformanceConfiguration.addPlugin`.

`BugsnagPerformance.getSpanControls(JavascriptSpanByName("...."))` will return a `JavascriptSpanControl` which can create transactions for editing the attributes, or ending the JavaScript span. The success or failure of the update is returned via an `OnRemoteSpanUpdatedCallback` passed to the `commit` function.

## Testing
Updated the end-to-end tests to test the native to JS bridge on Android.