### PR TITLE
ReactNative: handle background -> foreground startups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (react-native) Added a short debounce during app start to allow backgrounded apps to come to the foreground [#665](https://github.com/bugsnag/bugsnag-js-performance/pull/665)
+
 ## [v2.14.0] (2025-06-25)
 
 ### Added
@@ -20,7 +26,7 @@
 
 This release adds support for React Native 0.77 to `@bugsnag/react-native-performance`
 
-### Added 
+### Added
 
 - (plugin-react-performance) Added new react library with `withInstrumentedComponent` higher order component to instrument component rendering spans [#584](https://github.com/bugsnag/bugsnag-js-performance/pull/584)
 
@@ -162,7 +168,7 @@ This release adds support for React Native 0.77 to `@bugsnag/react-native-perfor
 
 This release adds support for instrumenting navigation spans when using the [react-native-navigation](https://github.com/wix/react-native-navigation) library
 
-### Added 
+### Added
 
 - (react-native-navigation) Added `@bugsnag/react-native-navigation-performance` package [#404](https://github.com/bugsnag/bugsnag-js-performance/pull/404)
 

--- a/packages/platforms/react-native/tests/backgrounding-listener.test.ts
+++ b/packages/platforms/react-native/tests/backgrounding-listener.test.ts
@@ -8,21 +8,29 @@ describe('React Native BackgroundingListener', () => {
     AppState.bugsnagChangeAppStateStatus(status)
   }
 
+  // Mock timers for debouncing tests
   beforeEach(() => {
     setAppState('active')
+    jest.useFakeTimers()
   })
 
-  it('calls the registered callback immediately when app state status is "background" on registration', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('calls the registered callback after debounce when app state status is "background" on registration', () => {
     const onStateChangeCallback = jest.fn()
 
-    const listener = createBrowserBackgroundingListener(AppState)
-
     setAppState('background')
+    const listener = createBrowserBackgroundingListener(AppState)
 
     expect(onStateChangeCallback).not.toHaveBeenCalled()
 
     listener.onStateChange(onStateChangeCallback)
 
+    // Should be called after the 700ms debounce
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(700)
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
   })
@@ -38,6 +46,8 @@ describe('React Native BackgroundingListener', () => {
     listener.onStateChange(onStateChangeCallback)
 
     expect(onStateChangeCallback).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(800) // Advance timers to ensure no debounced calls happen
+    expect(onStateChangeCallback).not.toHaveBeenCalled()
   })
 
   it.each<AppStateStatus>(['background', 'inactive'])('calls the registered callback with "in-foreground" when app state status changes from "%s" to "active"', (status: AppStateStatus) => {
@@ -49,12 +59,12 @@ describe('React Native BackgroundingListener', () => {
     expect(onStateChangeCallback).not.toHaveBeenCalled()
 
     setAppState(status)
-
+    // State changes are immediate (not debounced) after initial setup
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
 
     setAppState('active')
-
+    // Foreground changes happen immediately
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-foreground')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(2)
   })
@@ -68,12 +78,12 @@ describe('React Native BackgroundingListener', () => {
     expect(onStateChangeCallback).not.toHaveBeenCalled()
 
     setAppState(status)
-
+    // State changes are immediate (not debounced) after initial setup
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
   })
 
-  it('does not call the registered callback when the app state changes from from "inactive" to "background"', () => {
+  it('does not call the registered callback when the app state changes from "inactive" to "background"', () => {
     const onStateChangeCallback = jest.fn()
 
     const listener = createBrowserBackgroundingListener(AppState)
@@ -82,9 +92,11 @@ describe('React Native BackgroundingListener', () => {
     expect(onStateChangeCallback).not.toHaveBeenCalled()
 
     setAppState('inactive')
+    // State changes are immediate (not debounced) after initial setup
     expect(onStateChangeCallback).toHaveBeenCalledWith('in-background')
 
     setAppState('background')
+    // Should not call again since we're already in background state
     expect(onStateChangeCallback).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/react-native/features/manual-spans.feature
+++ b/test/react-native/features/manual-spans.feature
@@ -16,7 +16,9 @@ Feature: Manual spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.startTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" is one of:
+      | wifi    |
+      | unknown |
 
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
     And the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "production"


### PR DESCRIPTION
## Goal
Add a short grace period (700ms) if the SDK is started in a reported background state, before we consider the app to be "in background".

## Design
If an app reports a background state during startup and then the AppState becomes "active" we would discard the `AppStart` spans. This was happening most notably on our Android 12 Old Arch tests, but is likely a broader problem.

By always considering an app as being `"in-foreground"` to start with, we don't emit a "change" event if the app is about to appear. Apps now always behave as though they are "probably" launching in the foreground.

## Testing
Updated the unit tests, and the "Android 12 Old Arch" end-to-end tests now pass more reliably.