### PR TITLE
Javascript span context retrieval for iOS

### DIFF
--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpans.java
@@ -95,6 +95,11 @@ class BugsnagNativeSpans {
         promise.resolve(null);
     }
 
+    public void reportSpanContextResult(double eventId, String result, Promise promise) {
+        // TODO: retrieve callback and invoke with the result
+        promise.resolve(null);
+    }
+
     private static void endSpan(ReadableMap updates, Span span) {
         if (updates.hasKey(END_TIME)) {
             double endTime = updates.getDouble(END_TIME);

--- a/packages/plugin-react-native-span-access/android/src/newarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
+++ b/packages/plugin-react-native-span-access/android/src/newarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
@@ -40,6 +40,11 @@ public class BugsnagNativeSpansModule extends NativeBugsnagNativeSpansSpec {
     }
 
     @Override
+    public void reportSpanContextResult(double eventId, String result, Promise promise) {
+        delegate.reportSpanContextResult(eventId, result, promise);
+    }
+
+    @Override
     public void addListener(String eventType) {
         // noop - required for EventEmitter support
     }

--- a/packages/plugin-react-native-span-access/android/src/oldarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
+++ b/packages/plugin-react-native-span-access/android/src/oldarch/java/com/bugsnag/reactnative/performance/nativespans/BugsnagNativeSpansModule.java
@@ -40,6 +40,11 @@ public class BugsnagNativeSpansModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void reportSpanContextResult(double eventId, String result, Promise promise) {
+        delegate.reportSpanContextResult(eventId, result, promise);
+    }
+
+    @ReactMethod
     public void addListener(String eventType) {
         // noop - required for EventEmitter support
     }

--- a/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.h
+++ b/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.h
@@ -24,7 +24,7 @@ typedef void (^RemoteSpanContextCallback)(BugsnagPerformanceSpanContext * _Nulla
 
 - (BugsnagJavascriptSpanTransaction *)createUpdateTransaction;
 
-- (void)getSpanContext:(RemoteSpanContextCallback)callback;
+- (void)retrieveSpanContext:(RemoteSpanContextCallback)callback;
 
 @end
 

--- a/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.h
+++ b/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.h
@@ -1,9 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanControl.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^OnSpanUpdatedCallback)(BOOL result);
+
+typedef void (^RemoteSpanContextCallback)(BugsnagPerformanceSpanContext * _Nullable context);
 
 @interface BugsnagJavascriptSpanTransaction : NSObject
 
@@ -20,6 +23,8 @@ typedef void (^OnSpanUpdatedCallback)(BOOL result);
 @interface BugsnagJavascriptSpanControl : NSObject<BugsnagPerformanceSpanControl>
 
 - (BugsnagJavascriptSpanTransaction *)createUpdateTransaction;
+
+- (void)getSpanContext:(RemoteSpanContextCallback)callback;
 
 @end
 

--- a/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.mm
@@ -127,4 +127,22 @@ NSString *spanName;
 - (BugsnagJavascriptSpanTransaction *)createUpdateTransaction {
     return [[BugsnagJavascriptSpanTransaction alloc] initWithSpanName:spanName];
 }
+
+- (void)getSpanContext:(RemoteSpanContextCallback)callback {
+    BugsnagJavascriptSpansPlugin *plugin = [BugsnagJavascriptSpansPlugin singleton];
+    if (!plugin) {
+        callback(nil);
+        return;
+    }
+
+    int eventId = [plugin registerSpanContextCallback:callback];
+  
+    NSDictionary *contextEvent = @{
+      idTransactionKey: @(eventId),
+      nameTransactionKey: spanName,
+    };
+  
+    [plugin sendSpanContextEvent:contextEvent];
+}
+
 @end

--- a/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpanControl.mm
@@ -128,7 +128,7 @@ NSString *spanName;
     return [[BugsnagJavascriptSpanTransaction alloc] initWithSpanName:spanName];
 }
 
-- (void)getSpanContext:(RemoteSpanContextCallback)callback {
+- (void)retrieveSpanContext:(RemoteSpanContextCallback)callback {
     BugsnagJavascriptSpansPlugin *plugin = [BugsnagJavascriptSpansPlugin singleton];
     if (!plugin) {
         callback(nil);

--- a/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpansPlugin+Private.h
+++ b/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpansPlugin+Private.h
@@ -14,4 +14,11 @@
 - (void)sendSpanUpdateEvent:(NSDictionary *)event;
 
 - (void)onRemoteSpanUpdated:(int)eventId withResult:(BOOL)result;
+
+- (int)registerSpanContextCallback:(RemoteSpanContextCallback)callback;
+
+- (void)sendSpanContextEvent:(NSDictionary *)event;
+
+- (void)onRemoteSpanContextReceived:(int)eventId withContext:(NSString *)context;
+
 @end

--- a/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpansPlugin.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpansPlugin.mm
@@ -2,6 +2,46 @@
 #import "BugsnagJavascriptSpanControlProvider.h"
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 #import <BugsnagPerformance/BugsnagPerformancePluginContext.h>
+#import <BugsnagPerformance/BugsnagPerformanceRemoteSpanContext.h>
+
+@interface CallbackRegistry : NSObject
+- (int)registerCallback:(id)callback;
+- (id)takeCallback:(int)callbackId;
+@end
+
+@implementation CallbackRegistry {
+    NSMutableDictionary *_callbacks;
+    int _nextCallbackId;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _callbacks = [NSMutableDictionary new];
+        _nextCallbackId = 0;
+    }
+    return self;
+}
+
+- (int)registerCallback:(id)callback {
+    @synchronized (_callbacks) {
+        int callbackId = _nextCallbackId++;
+        _callbacks[@(callbackId)] = callback;
+        return callbackId;
+    }
+}
+
+- (id)takeCallback:(int)callbackId {
+    @synchronized (_callbacks) {
+        id callback = [_callbacks objectForKey:@(callbackId)];
+        if (!callback) {
+            return nil;
+        }
+        [_callbacks removeObjectForKey:@(callbackId)];
+        return callback;
+    }
+}
+
+@end
 
 @interface BugsnagJavascriptSpansPlugin ()
 
@@ -13,9 +53,9 @@
 
 static BugsnagJavascriptSpansPlugin *_sharedInstance = nil;
 
-int nextCallbackId = 0;
+CallbackRegistry *_spanUpdateCallbacks;
 
-NSMutableDictionary *spanUpdateCallbacks;
+CallbackRegistry *_spanContextCallbacks;
 
 + (id)singleton {
     return _sharedInstance;
@@ -23,7 +63,8 @@ NSMutableDictionary *spanUpdateCallbacks;
 
 - (void)installWithContext:(BugsnagPerformancePluginContext *)context {
     _sharedInstance = self;
-    spanUpdateCallbacks = [NSMutableDictionary new];
+    _spanUpdateCallbacks = [CallbackRegistry new];
+    _spanContextCallbacks = [CallbackRegistry new];
     BugsnagJavascriptSpanControlProvider *spanControlProvider = [BugsnagJavascriptSpanControlProvider new];
     [context addSpanControlProvider:spanControlProvider];
 }
@@ -36,11 +77,7 @@ NSMutableDictionary *spanUpdateCallbacks;
 }
 
 - (int)registerSpanUpdateCallback:(OnSpanUpdatedCallback)callback {
-    @synchronized (spanUpdateCallbacks) {
-        int callbackId = nextCallbackId++;
-        spanUpdateCallbacks[@(callbackId)] = callback;
-        return callbackId;
-    }
+    return [_spanUpdateCallbacks registerCallback:callback];
 }
 
 - (void)sendSpanUpdateEvent:(NSDictionary *)event {
@@ -52,21 +89,28 @@ NSMutableDictionary *spanUpdateCallbacks;
 }
 
 - (void)onRemoteSpanUpdated:(int)eventId withResult:(BOOL)result {
-    OnSpanUpdatedCallback callback = [self takeSpanUpdateCallback:eventId];
+    OnSpanUpdatedCallback callback = [_spanUpdateCallbacks takeCallback:eventId];
     if (callback) {
         callback(result);
     }
 }
 
-- (OnSpanUpdatedCallback)takeSpanUpdateCallback:(int)eventId {
-    @synchronized (spanUpdateCallbacks) {
-        OnSpanUpdatedCallback callback = [spanUpdateCallbacks objectForKey:@(eventId)];
-        if (!callback) {
-            return nil;
-        }
+- (int)registerSpanContextCallback:(RemoteSpanContextCallback)callback {
+    return [_spanContextCallbacks registerCallback:callback];
+}
 
-        [spanUpdateCallbacks removeObjectForKey:@(eventId)];
-        return callback;
+- (void)sendSpanContextEvent:(NSDictionary *)event {
+    @synchronized (self) {
+      if (_eventEmitter) {
+          [_eventEmitter sendEventWithName:@"bugsnag:spanContext" body:event];
+      }
+    }
+}
+
+- (void)onRemoteSpanContextReceived:(int)eventId withContext:(NSString *)context {
+    RemoteSpanContextCallback callback = [_spanContextCallbacks takeCallback:eventId];
+    if (callback) {
+        callback([BugsnagPerformanceRemoteSpanContext contextWithTraceParentString:context]);
     }
 }
 

--- a/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpansPlugin.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagJavascriptSpansPlugin.mm
@@ -102,7 +102,7 @@ CallbackRegistry *_spanContextCallbacks;
 - (void)sendSpanContextEvent:(NSDictionary *)event {
     @synchronized (self) {
       if (_eventEmitter) {
-          [_eventEmitter sendEventWithName:@"bugsnag:spanContext" body:event];
+          [_eventEmitter sendEventWithName:@"bugsnag:retrieveSpanContext" body:event];
       }
     }
 }

--- a/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.mm
@@ -13,7 +13,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"bugsnag:spanUpdate"];
+  return @[@"bugsnag:spanUpdate", @"bugsnag:spanContext"];
 }
 
 - (void)startObserving
@@ -107,6 +107,18 @@ RCT_EXPORT_METHOD(reportSpanUpdateResult:(double)eventId
     BugsnagJavascriptSpansPlugin *plugin = [BugsnagJavascriptSpansPlugin singleton];
     if (plugin) {
         [plugin onRemoteSpanUpdated:(int)eventId withResult:result];
+    }
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(reportSpanContextResult:(double)eventId
+                  result:(NSString *)result
+                  resolve:(RCTPromiseResolveBlock)resolve
+                   reject:(RCTPromiseRejectBlock)reject)
+{
+    BugsnagJavascriptSpansPlugin *plugin = [BugsnagJavascriptSpansPlugin singleton];
+    if (plugin) {
+        [plugin onRemoteSpanContextReceived:(int)eventId withContext:result];
     }
     resolve(nil);
 }

--- a/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagNativeSpans.mm
@@ -13,7 +13,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"bugsnag:spanUpdate", @"bugsnag:spanContext"];
+  return @[@"bugsnag:spanUpdate", @"bugsnag:retrieveSpanContext"];
 }
 
 - (void)startObserving

--- a/packages/plugin-react-native-span-access/lib/NativeBugsnagNativeSpans.ts
+++ b/packages/plugin-react-native-span-access/lib/NativeBugsnagNativeSpans.ts
@@ -12,6 +12,8 @@ export interface Spec extends TurboModule {
   removeListeners: (count: number) => void
 
   reportSpanUpdateResult: (eventId: number, result: boolean) => Promise<void>
+
+  reportSpanContextResult: (eventId: number, result: string | null) => Promise<void>
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/packages/plugin-react-native-span-access/lib/javascript-spans-plugin.ts
+++ b/packages/plugin-react-native-span-access/lib/javascript-spans-plugin.ts
@@ -36,7 +36,7 @@ export class BugsnagJavascriptSpansPlugin implements Plugin<ReactNativeConfigura
     context.addOnSpanEndCallback(this.onSpanEnd.bind(this))
     const eventEmitter = new NativeEventEmitter(NativeNativeSpansModule)
     eventEmitter.addListener('bugsnag:spanUpdate', this.onNativeSpanUpdate.bind(this))
-    eventEmitter.addListener('bugsnag:spanContext', this.onSpanContextEvent.bind(this))
+    eventEmitter.addListener('bugsnag:retrieveSpanContext', this.onSpanContextEvent.bind(this))
   }
 
   start () {

--- a/packages/plugin-react-native-span-access/tests/javascript-spans-plugin.test.ts
+++ b/packages/plugin-react-native-span-access/tests/javascript-spans-plugin.test.ts
@@ -5,7 +5,7 @@ import { BugsnagJavascriptSpansPlugin } from '../lib/javascript-spans-plugin'
 import { TurboModuleRegistry, NativeEventEmitter } from 'react-native'
 
 const SPAN_UPDATE_EVENT_TYPE = 'bugsnag:spanUpdate'
-const SPAN_CONTEXT_EVENT_TYPE = 'bugsnag:spanContext'
+const SPAN_CONTEXT_EVENT_TYPE = 'bugsnag:retrieveSpanContext'
 
 describe('BugsnagJavascriptSpansPlugin', () => {
   let plugin: BugsnagJavascriptSpansPlugin

--- a/packages/test-utilities/__mocks__/react-native.ts
+++ b/packages/test-utilities/__mocks__/react-native.ts
@@ -192,7 +192,8 @@ const BugsnagNativeSpans = {
   updateSpan: jest.fn((spanId, updates) => {
     return Promise.resolve(false)
   }),
-  reportSpanUpdateResult: jest.fn()
+  reportSpanUpdateResult: jest.fn(),
+  reportSpanContextResult: jest.fn()
 }
 
 export const TurboModuleRegistry = {

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncherImpl.java
@@ -223,4 +223,8 @@ class ScenarioLauncherImpl {
   public void updateJavascriptSpan(String spanName, ReadableArray attributes, Promise promise) {
     promise.resolve(null);
   }
+
+  public void sendNativeSpanWithJsParent(String spanName, Promise promise) {
+    promise.resolve(null);
+  }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/newarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/newarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
@@ -66,5 +66,10 @@ public class ScenarioLauncher extends NativeScenarioLauncherSpec {
   public void updateJavascriptSpan(String spanName, ReadableArray attributes, Promise promise) {
     impl.updateJavascriptSpan(spanName, attributes, promise);
   }
+
+  @Override
+  public void sendNativeSpanWithJsParent(String spanName, Promise promise) {
+    impl.sendNativeSpanWithJsParent(spanName, promise);
+  }
 }
 

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/oldarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/oldarch/java/com/bugsnag/reactnative/scenariolauncher/ScenarioLauncher.java
@@ -68,4 +68,9 @@ public class ScenarioLauncher extends ReactContextBaseJavaModule {
   public void updateJavascriptSpan(String spanName, ReadableArray attributes, Promise promise) {
     impl.updateJavascriptSpan(spanName, attributes, promise);
   }
+
+  @ReactMethod
+  public void sendNativeSpanWithJsParent(String spanName, Promise promise) {
+    impl.sendNativeSpanWithJsParent(spanName, promise);
+  }
 }

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
@@ -208,7 +208,7 @@ RCT_EXPORT_METHOD(sendNativeSpanWithJsParent:(NSString *)spanName resolve:(RCTPr
   BugsnagJavascriptSpanQuery *spanQuery = [BugsnagJavascriptSpanQuery queryWithName:spanName];
   BugsnagJavascriptSpanControl *spanControl = [BugsnagPerformance getSpanControlsWithQuery:spanQuery];
 
-  [spanControl getSpanContext:^(BugsnagPerformanceSpanContext * _Nullable context) {
+  [spanControl retrieveSpanContext:^(BugsnagPerformanceSpanContext * _Nullable context) {
     if (context) {
       BugsnagPerformanceSpanOptions *options = [BugsnagPerformanceSpanOptions new];
       options.parentContext = context;

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
@@ -5,6 +5,7 @@
 #ifdef NATIVE_INTEGRATION
 #import <BugsnagPerformance/BugsnagPerformance.h>
 #import <BugsnagPerformance/BugsnagPerformanceConfiguration+Private.h>
+#import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
 #import "BugsnagNativeSpansPlugin.h"
 #import "BugsnagJavascriptSpansPlugin.h"
 #import "BugsnagJavascriptSpanQuery.h"
@@ -203,6 +204,23 @@ RCT_EXPORT_METHOD(updateJavascriptSpan:(NSString *)spanName attributes:(NSArray<
   resolve(nil);
 }
 
+RCT_EXPORT_METHOD(sendNativeSpanWithJsParent:(NSString *)spanName resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  BugsnagJavascriptSpanQuery *spanQuery = [BugsnagJavascriptSpanQuery queryWithName:spanName];
+  BugsnagJavascriptSpanControl *spanControl = [BugsnagPerformance getSpanControlsWithQuery:spanQuery];
+
+  [spanControl getSpanContext:^(BugsnagPerformanceSpanContext * _Nullable context) {
+    if (context) {
+      BugsnagPerformanceSpanOptions *options = [BugsnagPerformanceSpanOptions new];
+      options.parentContext = context;
+      BugsnagPerformanceSpan *childSpan = [BugsnagPerformance startSpanWithName:@"Native Child Span" options:options];
+      [childSpan end];
+      resolve(nil);
+    } else {
+      reject(@"send_native_span_with_js_parent", @"Failed to get JS span context", nil);
+    }
+  }];
+}
+
 #else
 RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
   NSLog(@"Native performance is not enabled in this build");
@@ -222,6 +240,11 @@ RCT_EXPORT_METHOD(endNativeSpan:(NSString *)traceParent resolve:(RCTPromiseResol
 RCT_EXPORT_METHOD(updateJavascriptSpan:(NSString *)spanName attributes:(NSArray<NSDictionary *> *)attributes resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
   NSLog(@"Native performance is not enabled in this build");
   reject(@"update_javascript_span", @"Native performance is not enabled in this build", nil);
+}
+
+RCT_EXPORT_METHOD(sendNativeSpanWithJsParent:(NSString *)spanName resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  NSLog(@"Native performance is not enabled in this build");
+  reject(@"send_native_span_with_js_parent", @"Native performance is not enabled in this build", nil);
 }
 
 #endif

--- a/test/react-native/features/fixtures/scenario-launcher/lib/NativeScenarioLauncher.ts
+++ b/test/react-native/features/fixtures/scenario-launcher/lib/NativeScenarioLauncher.ts
@@ -10,6 +10,7 @@ export interface Spec extends TurboModule {
   startNativeSpan(options: UnsafeObject): Promise<string>;
   endNativeSpan(traceParent: string): Promise<boolean>;
   updateJavascriptSpan(spanName: string, attributes: Array<{ [key: string]: any }>): Promise<void>;
+  sendNativeSpanWithJsParent(spanName: string): Promise<void>;
 }
 
 export default TurboModuleRegistry.get<Spec>("ScenarioLauncher") as Spec | null;

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/JavascriptSpansContextScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/JavascriptSpansContextScenario.js
@@ -1,0 +1,50 @@
+import React, { useEffect } from 'react'
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import { NativeScenarioLauncher } from '../../lib/native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+import { BugsnagJavascriptSpansPlugin } from '@bugsnag/plugin-react-native-span-access'
+
+export const doNotStartBugsnagPerformance = true
+
+export const initialise = async (config) => {
+  const nativeConfig = {
+    apiKey: config.apiKey,
+    endpoint: config.endpoint
+  }
+
+  await NativeScenarioLauncher.startNativePerformance(nativeConfig)
+
+  BugsnagPerformance.attach({
+    maximumBatchSize: 1,
+    autoInstrumentAppStarts: false,
+    autoInstrumentNetworkRequests: false,
+    plugins: [new BugsnagJavascriptSpansPlugin()]
+  })
+}
+
+export const App = () => {
+  useEffect(() => {
+    (async () => {
+      const span = BugsnagPerformance.startSpan('JavascriptSpansContextScenario')
+      await NativeScenarioLauncher.sendNativeSpanWithJsParent(span.name)
+      span.end()
+    })()
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>Javascript Span Context Scenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/index.js
@@ -4,3 +4,4 @@ export * as RemoteParentContextNativeScenario from './RemoteParentContextNativeS
 export * as RemoteParentContextJSScenario from './RemoteParentContextJSScenario'
 export * as NativeSpansPluginScenario from './NativeSpansPluginScenario'
 export * as JavascriptSpansPluginScenario from './JavascriptSpansPluginScenario'
+export * as JavascriptSpansContextScenario from './JavascriptSpansContextScenario'

--- a/test/react-native/features/react-native-span-access.feature
+++ b/test/react-native/features/react-native-span-access.feature
@@ -72,3 +72,9 @@ Scenario: Javascript spans can be modified and ended from native
       | 1.1 |
       | 2.2 |
       | 3.3 |
+
+@ios_only
+Scenario: Native spans can be started with a JS parent
+  When I run 'JavascriptSpansContextScenario'
+  And I wait to receive 2 spans
+  Then a span named 'Native Child Span' has a parent named 'JavascriptSpansContextScenario'


### PR DESCRIPTION
## Goal

Introduces a new `retrieveSpanContext` method on `BugsnagJavascriptSpanControl` that allows retrieving the span context for a Javascript span to facilitate cross-layer span parentage.

## Design

Span contexts are returned asynchronously via a callback passed to `retrieveSpanContext`. JS span contexts are transmitted over the wire as traceparent strings which are then used to create a `BugsnagPerformanceRemoteSpanContext` object on the native side.

## Testing

Added a new e2e test scenario