### PR TITLE
Fix iOS crash from requestEntropyAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - (react-native) Added a short debounce during app start to allow backgrounded apps to come to the foreground [#665](https://github.com/bugsnag/bugsnag-js-performance/pull/665)
+- (react-native) Fix a crash when refreshing the entropy pool on iOS [#667](https://github.com/bugsnag/bugsnag-js-performance/pull/667)
 
 ## [v2.14.0] (2025-06-25)
 

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
@@ -124,7 +124,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(requestEntropy) {
 }
 
 RCT_EXPORT_METHOD(requestEntropyAsync:(RCTPromiseResolveBlock)resolve
-                   rejecter:(RCTPromiseRejectBlock)reject) {
+                   reject:(RCTPromiseRejectBlock)reject) {
     NSString *hexStr = getRandomBytes();
     resolve(hexStr);
 }


### PR DESCRIPTION
## Goal

When calling `startSpan` the `requestEntropy` function is called once to generate values for the span IDs. After the first 1000 spans the values are regenerated using the `requestEntropyAsync` function but the objc file has a typo which causes it to crash when called.

(see the original PR from @maxphillipsdev for more details: https://github.com/bugsnag/bugsnag-js-performance/pull/662)

## Changeset

Just fixed the typo in the argument name.

## Testing

Tested manually