### PR TITLE
Move Expo build steps to macos-15 queue

### DIFF
--- a/.buildkite/expo-pipeline.full.yml
+++ b/.buildkite/expo-pipeline.full.yml
@@ -11,7 +11,7 @@ steps:
         key: "build-expo-apk-full"
         timeout_in_minutes: 20
         agents:
-          queue: "macos-14"
+          queue: "macos-15"
         env:
           JAVA_VERSION: "17"
           EXPO_VERSION: "{{matrix}}"
@@ -28,9 +28,10 @@ steps:
         key: "build-expo-ipa-full"
         timeout_in_minutes: 20
         agents:
-          queue: "macos-14"
+          queue: "macos-15"
         env:
           EXPO_VERSION: "{{matrix}}"
+          XCODE_VERSION: "16.2.0"
           BUILD_IOS: 1
         artifact_paths: test/react-native/features/fixtures/generated/expo/**/test-fixture/output.ipa
         commands:

--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -11,7 +11,7 @@ steps:
         key: "build-expo-apk"
         timeout_in_minutes: 20
         agents:
-          queue: "macos-14"
+          queue: "macos-15"
         env:
           JAVA_VERSION: "17"
           EXPO_VERSION: "{{matrix}}"
@@ -27,7 +27,7 @@ steps:
         key: "build-expo-ipa"
         timeout_in_minutes: 20
         agents:
-          queue: "macos-14"
+          queue: "macos-15"
         env:
           EXPO_VERSION: "{{matrix}}"
           BUILD_IOS: 1


### PR DESCRIPTION
## Goal

Move Expo build steps to macos-15 queue.

## Changeset

Xcode version is pinned to 16.2.0 where dictated by the version of Expo.

## Testing

Covered by CI with both Expo arms triggered.