### PR TITLE
Remote / named SpanContext access for ReactNative Android

### DIFF
--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/CallbackState.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/CallbackState.java
@@ -1,0 +1,32 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import android.util.SparseArray;
+
+class CallbackState<T> {
+  private final SparseArray<T> callbacks = new SparseArray<>(4);
+  private int nextCallbackId = 0;
+
+  int registerCallback(@NonNull T callback) {
+    synchronized (callbacks) {
+      int callbackId = nextCallbackId++;
+      callbacks.put(callbackId, callback);
+      return callbackId;
+    }
+  }
+
+  T takeCallback(int callbackId) {
+    synchronized (callbacks) {
+      int index = callbacks.indexOfKey(callbackId);
+      if (index < 0) {
+        return null;
+      }
+
+      T callback = callbacks.valueAt(index);
+      callbacks.removeAt(index);
+      return callback;
+    }
+  }
+}

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControl.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControl.java
@@ -1,5 +1,15 @@
 package com.bugsnag.reactnative.performance.nativespans;
 
+import androidx.annotation.NonNull;
+
 public interface JavascriptSpanControl {
   JavascriptSpanTransaction createUpdateTransaction();
+
+  /**
+   * Request the {@code SpanContext} data represented by the named span. If the span is not currently open,
+   * is not available or the app is not connected: the callback will be invoked with a {@code null} value.
+   *
+   * @param callback the callback that should recieve the remote {@code SpanContext}
+   */
+  void retrieveSpanContext(@NonNull OnSpanContextRetrievedCallback callback);
 }

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControlImpl.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanControlImpl.java
@@ -1,5 +1,14 @@
 package com.bugsnag.reactnative.performance.nativespans;
 
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+
+import static com.bugsnag.reactnative.performance.nativespans.JavascriptSpanTransactionImpl.ID;
+import static com.bugsnag.reactnative.performance.nativespans.JavascriptSpanTransactionImpl.NAME;
+
 class JavascriptSpanControlImpl implements JavascriptSpanControl {
   private final String spanName;
 
@@ -10,5 +19,28 @@ class JavascriptSpanControlImpl implements JavascriptSpanControl {
   @Override
   public JavascriptSpanTransaction createUpdateTransaction() {
     return new JavascriptSpanTransactionImpl(spanName);
+  }
+
+  @Override
+  public void retrieveSpanContext(@NonNull OnSpanContextRetrievedCallback callback) {
+    if (callback == null) {
+      return;
+    }
+
+    BugsnagNativeSpans spans = BugsnagNativeSpans.getInstance();
+
+    if (spans == null) {
+      callback.onSpanContextRetrieved(null);
+    }
+
+    WritableMap retrieveSpanEvent = Arguments.createMap();
+    retrieveSpanEvent.putString(NAME, spanName);
+
+    int callbackId = spans.registerSpanContextCallback(callback);
+    retrieveSpanEvent.putInt(ID, callbackId);
+
+    if (!spans.emitRetrieveSpanContextEvent(retrieveSpanEvent)) {
+      callback.onSpanContextRetrieved(null);
+    }
   }
 }

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransactionImpl.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/JavascriptSpanTransactionImpl.java
@@ -15,12 +15,12 @@ import com.bugsnag.android.performance.internal.BugsnagClock;
 
 class JavascriptSpanTransactionImpl implements JavascriptSpanTransaction {
 
-  private static final String ID = "id";
-  private static final String NAME = "name";
-  private static final String VALUE = "value";
-  private static final String ATTRIBUTES = "attributes";
-  private static final String END_TIME = "endTime";
-  private static final String IS_ENDED = "isEnded";
+  static final String ID = "id";
+  static final String NAME = "name";
+  static final String VALUE = "value";
+  static final String ATTRIBUTES = "attributes";
+  static final String END_TIME = "endTime";
+  static final String IS_ENDED = "isEnded";
 
   private final String spanName;
 

--- a/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/OnSpanContextRetrievedCallback.java
+++ b/packages/plugin-react-native-span-access/android/src/main/java/com/bugsnag/reactnative/performance/nativespans/OnSpanContextRetrievedCallback.java
@@ -1,0 +1,14 @@
+package com.bugsnag.reactnative.performance.nativespans;
+
+import androidx.annotation.Nullable;
+
+import com.bugsnag.android.performance.SpanContext;
+
+public interface OnSpanContextRetrievedCallback {
+  /**
+   * Called with the retrieved remote {@link SpanContext} or {@code null} if the context could not be retrieved.
+   *
+   * @param remoteSpanContext the remote {@link SpanContext} that was requested (or {@code null})
+   */
+  void onSpanContextRetrieved(@Nullable SpanContext remoteSpanContext);
+}

--- a/test/react-native/features/react-native-span-access.feature
+++ b/test/react-native/features/react-native-span-access.feature
@@ -72,7 +72,6 @@ Scenario: Javascript spans can be modified and ended from native
       | 2.2 |
       | 3.3 |
 
-@ios_only
 Scenario: Native spans can be started with a JS parent
   When I run 'JavascriptSpansContextScenario'
   And I wait to receive 2 spans


### PR DESCRIPTION
## Goal

Introduces a new `retrieveSpanContext` method on `JavascriptSpanControl` that allows retrieving the span context for a Javascript span to facilitate cross-layer span parentage.

## Design

Span contexts are returned asynchronously via a callback passed to `retrieveSpanContext`. JS span contexts are transmitted over the wire as traceparent strings which are then used to create a `RemoteSpanContext` object on the native side.

## Testing

Updated the e2e test scenario to also run on Android