### PR TITLE
Improve span timoeut handling in BugsnagNativeSpansPlugin

### DIFF
--- a/packages/plugin-react-native-span-access/ios/BugsnagNativeSpansPlugin.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagNativeSpansPlugin.mm
@@ -10,7 +10,7 @@ static NSString *createNativeSpanId(BugsnagPerformanceSpan *span);
 
 @implementation BugsnagNativeSpansPlugin {
     // Private instance variable for span timeout timers
-    std::map<void *, NSTimer *> _spanTimeoutTimers;
+    std::map<void *, dispatch_source_t> _spanTimeoutTimers;
 }
 
 static BugsnagNativeSpansPlugin *_sharedInstance = nil;
@@ -20,11 +20,23 @@ static BugsnagNativeSpansPlugin *_sharedInstance = nil;
 }
 
 // Create a timeout timer for a span
-- (NSTimer *)createSpanTimeoutTimer:(BugsnagPerformanceSpan *)span {
+- (dispatch_source_t)createSpanTimeoutTimer:(BugsnagPerformanceSpan *)span {
     __weak BugsnagNativeSpansPlugin *weakSelf = self;
-    return [NSTimer scheduledTimerWithTimeInterval:kSpanTimeoutInterval repeats:NO block:^(NSTimer * _Nonnull timer) {
+
+    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
+                                                     dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0));
+    
+    dispatch_source_set_timer(timer,
+                             dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kSpanTimeoutInterval * NSEC_PER_SEC)),
+                             DISPATCH_TIME_FOREVER,
+                             0);
+    
+    dispatch_source_set_event_handler(timer, ^{
         [weakSelf endNativeSpan:span];
-    }];
+    });
+    
+    dispatch_resume(timer);
+    return timer;
 }
 
 // remove the spans from the caches and clean up timer
@@ -43,7 +55,7 @@ static BugsnagNativeSpansPlugin *_sharedInstance = nil;
         auto& timerMap = _spanTimeoutTimers;
         auto it = timerMap.find(key);
         if (it != timerMap.end()) {
-            [it->second invalidate];
+            dispatch_source_cancel(it->second);
             timerMap.erase(it);
         }
     }
@@ -66,7 +78,7 @@ static BugsnagNativeSpansPlugin *_sharedInstance = nil;
 
             // Add a 10 minute timeout to remove the span from caches if not ended
             void *key = (__bridge void *)span;
-            NSTimer *timer = [blockSelf createSpanTimeoutTimer:span];
+            dispatch_source_t timer = [blockSelf createSpanTimeoutTimer:span];
             blockSelf->_spanTimeoutTimers[key] = timer;
         }
     };

--- a/packages/plugin-react-native-span-access/ios/BugsnagNativeSpansPlugin.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagNativeSpansPlugin.mm
@@ -73,6 +73,12 @@ static BugsnagNativeSpansPlugin *_sharedInstance = nil;
         NSString *spanId = createNativeSpanId(span);
 
         @synchronized (blockSelf) {
+            BugsnagPerformanceSpan *existingSpan = blockSelf.spansByName[span.name];
+            if (existingSpan) {
+                // If a span with the same name already exists, remove it from the cache and clean up its timer
+                [blockSelf endNativeSpan:existingSpan];
+            }
+
             blockSelf.spansByName[span.name] = span;
             blockSelf.spansById[spanId] = span;
 


### PR DESCRIPTION
## Goal

Improves the handling of span timoeut timers in `BugsnagNativeSpansPlugin`

- Ensure that span references and associated timers are removed when the tracked span is overwritten by a new span with the same name.
- Fixes a memory leak related to the usage of `NSTimer` for handling span timeouts in `BugsnagNativeSpansPlugin`

## Design

the `NSTimer` based span timeout timers were occasionally not firing for some tracked spans (network spans) that are not ended, due to run loop issues. This was causing memory leaks due to timeout timers not firing being removed. This PR switches to using GCD for span timeout timers, which avoids the issue and also has lower overheads

In addition, span timeout timers for a given span are now removed if a new span with the same name is started, avoiding holding references to untracked spans unnecessarily

## Testing

Tested manually