### PR TITLE
Calling setAttribute with null/undefined should clear the attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 ### Changed
 
 - Reduce batch time in development environment [#673](https://github.com/bugsnag/bugsnag-js-performance/pull/673)
+- Calling `setAttribute` with a `null` or `undefined` attribute value now clears the attribute from the span [#679](https://github.com/bugsnag/bugsnag-js-performance/pull/679)
 
 ### Fixed
 
 - (react-native) Added a short debounce during app start to allow backgrounded apps to come to the foreground [#665](https://github.com/bugsnag/bugsnag-js-performance/pull/665)
 - (react-native) Fix a crash when refreshing the entropy pool on iOS [#667](https://github.com/bugsnag/bugsnag-js-performance/pull/667)
-- (core) Calling `setAttribute` with `null` now clears the attribute from the span [#679](https://github.com/bugsnag/bugsnag-js-performance/pull/679)
 
 ## [v2.14.0] (2025-06-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - (react-native) Added a short debounce during app start to allow backgrounded apps to come to the foreground [#665](https://github.com/bugsnag/bugsnag-js-performance/pull/665)
 - (react-native) Fix a crash when refreshing the entropy pool on iOS [#667](https://github.com/bugsnag/bugsnag-js-performance/pull/667)
+- (core) Calling `setAttribute` with `null` now clears the attribute from the span [#679](https://github.com/bugsnag/bugsnag-js-performance/pull/679)
 
 ## [v2.14.0] (2025-06-25)
 

--- a/packages/core/lib/attributes.ts
+++ b/packages/core/lib/attributes.ts
@@ -28,7 +28,7 @@ type Attribute = string | number | boolean
 // Array values should always be of the same type, although the trace server will accept mixed types
 type ArrayAttribute = string[] | number[] | boolean[]
 
-export type SpanAttribute = Attribute | ArrayAttribute | null
+export type SpanAttribute = Attribute | ArrayAttribute | null | undefined
 
 export interface SpanAttributesSource <C extends Configuration> {
   configure: (configuration: InternalConfiguration<C>) => void
@@ -81,7 +81,7 @@ export class SpanAttributes {
   }
 
   private isValidAttributeValue (value: SpanAttribute): boolean {
-    return value === null || typeof value === 'string' || typeof value === 'boolean' || isNumber(value) || Array.isArray(value)
+    return value === null || value === undefined || typeof value === 'string' || typeof value === 'boolean' || isNumber(value) || Array.isArray(value)
   }
 
   private isValidAttributeName (name: string): boolean {
@@ -92,7 +92,7 @@ export class SpanAttributes {
   set (name: string, value: SpanAttribute) {
     if (!this.isValidAttributeName(name) || !this.isValidAttributeValue(value)) return
 
-    if (value === null) {
+    if (value === null || value === undefined) {
       this.remove(name)
       return
     }
@@ -104,7 +104,7 @@ export class SpanAttributes {
   setCustom (name: string, value: SpanAttribute) {
     if (!this.isValidAttributeName(name) || !this.isValidAttributeValue(value)) return
 
-    if (value === null) {
+    if (value === null || value === undefined) {
       this.remove(name)
       return
     }

--- a/packages/core/lib/span.ts
+++ b/packages/core/lib/span.ts
@@ -14,7 +14,7 @@ const HOUR_IN_MILLISECONDS = 60 * 60 * 1000
 export interface Span extends SpanContext {
   readonly name: string
   end: (endTime?: Time) => void
-  setAttribute: (name: string, value: SpanAttribute) => void
+  setAttribute: (name: string, value: SpanAttribute | null | undefined) => void
 }
 
 export const enum Kind {
@@ -151,11 +151,11 @@ export class SpanInternal implements SpanContext {
     this.events.add(name, time)
   }
 
-  setAttribute (name: string, value: SpanAttribute) {
+  setAttribute (name: string, value: SpanAttribute | null | undefined) {
     this.attributes.set(name, value)
   }
 
-  setCustomAttribute (name: string, value: SpanAttribute) {
+  setCustomAttribute (name: string, value: SpanAttribute | null | undefined) {
     this.attributes.setCustom(name, value)
   }
 

--- a/packages/core/tests/attributes.test.ts
+++ b/packages/core/tests/attributes.test.ts
@@ -1,14 +1,265 @@
-import { SpanAttributes, attributeToJson } from '../lib/attributes'
+import { SpanAttributes, ResourceAttributes, attributeToJson } from '../lib/attributes'
 import { defaultSpanAttributeLimits } from '../lib/custom-attribute-limits'
 
 describe('SpanAttributes', () => {
-  it('prevents adding span attributes with invalid values', () => {
-    const attributes = new SpanAttributes(new Map(), defaultSpanAttributeLimits, 'test.span', console)
-    attributes.set('test.NaN', NaN)
-    attributes.set('test.Infinity', Infinity)
-    attributes.set('test.-Infinity', -Infinity)
+  describe('set()', () => {
+    const jestLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() }
+    let attributes: SpanAttributes
 
-    expect(attributes.toJson()).toStrictEqual([])
+    beforeEach(() => {
+      jestLogger.warn.mockClear()
+      attributes = new SpanAttributes(new Map(), defaultSpanAttributeLimits, 'test.span', jestLogger)
+    })
+
+    it('allows setting valid attributes with set()', () => {
+      attributes.set('internal.string', 'value')
+      attributes.set('internal.number', 42)
+      attributes.set('internal.boolean', true)
+      attributes.set('internal.array', ['a', 'b'])
+
+      const result = attributes.toObject()
+      expect(result).toEqual({
+        'internal.string': 'value',
+        'internal.number': 42,
+        'internal.boolean': true,
+        'internal.array': ['a', 'b']
+      })
+    })
+
+    it('prevents adding span attributes with invalid values', () => {
+      const attributes = new SpanAttributes(new Map(), defaultSpanAttributeLimits, 'test.span', console)
+      attributes.set('test.NaN', NaN)
+      attributes.set('test.Infinity', Infinity)
+      attributes.set('test.-Infinity', -Infinity)
+
+      expect(attributes.toJson()).toStrictEqual([])
+    })
+
+    it('removes the attribute when value is null', () => {
+      attributes.set('test.key', 'initial-value')
+      expect(attributes.toObject()['test.key']).toBe('initial-value')
+
+      attributes.set('test.key', null)
+      expect(attributes.toObject()).not.toHaveProperty('test.key')
+    })
+
+    it('ignores setting an attribute with an empty key', () => {
+      attributes.set('', 'value')
+      expect(attributes.toJson()).toStrictEqual([])
+    })
+
+    it('ignores setting an attribute with an undefined value', () => {
+      // @ts-expect-error Testing undefined value
+      attributes.set('test.undefined', undefined)
+      expect(attributes.toJson()).toStrictEqual([])
+    })
+
+    it('does not enforce attribute count limits with set() (internal use)', () => {
+      const limitedAttributes = new SpanAttributes(
+        new Map(),
+        { attributeArrayLengthLimit: 5, attributeCountLimit: 2, attributeStringValueLimit: 20 },
+        'test.span',
+        jestLogger
+      )
+
+      // set() should allow exceeding limits for internal attributes
+      limitedAttributes.set('internal.1', 'value1')
+      limitedAttributes.set('internal.2', 'value2')
+      limitedAttributes.set('internal.3', 'value3') // Exceeds limit
+
+      const result = limitedAttributes.toObject()
+      expect(Object.keys(result)).toHaveLength(3)
+      expect(jestLogger.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('setCustom', () => {
+    const jestLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() }
+    let attributes: SpanAttributes
+
+    beforeEach(() => {
+      jestLogger.warn.mockClear()
+      attributes = new SpanAttributes(new Map(), { attributeArrayLengthLimit: 5, attributeCountLimit: 5, attributeStringValueLimit: 20 }, 'test.span', jestLogger)
+    })
+
+    it('allows setting valid attributes with set()', () => {
+      attributes.setCustom('custom.string', 'value')
+      attributes.setCustom('custom.number', 42)
+      attributes.setCustom('custom.boolean', true)
+      attributes.setCustom('custom.array', ['a', 'b'])
+
+      expect(attributes.toJson()).toStrictEqual([
+        { key: 'custom.string', value: { stringValue: 'value' } },
+        { key: 'custom.number', value: { intValue: '42' } },
+        { key: 'custom.boolean', value: { boolValue: true } },
+        { key: 'custom.array', value: { arrayValue: { values: [{ stringValue: 'a' }, { stringValue: 'b' }] } } }
+      ])
+    })
+
+    it('prevents adding span attributes with invalid values', () => {
+      const attributes = new SpanAttributes(new Map(), defaultSpanAttributeLimits, 'test.span', console)
+      attributes.setCustom('test.NaN', NaN)
+      attributes.setCustom('test.Infinity', Infinity)
+      attributes.setCustom('test.-Infinity', -Infinity)
+
+      expect(attributes.toJson()).toStrictEqual([])
+    })
+
+    it('prevents adding an attribute with a key that exceeds the limit', () => {
+      const attributeKey = 'a'.repeat(256)
+      attributes.setCustom(attributeKey, 'value')
+      expect(attributes.toJson()).toStrictEqual([])
+      expect(jestLogger.warn).toHaveBeenCalledWith(`Span attribute ${attributeKey} in span test.span was dropped as the key length exceeds the 128 character fixed limit.`)
+      expect(attributes.droppedAttributesCount).toBe(1)
+    })
+
+    it('prevents adding an attribute when the count limit is reached', () => {
+      attributes.setCustom('test.1', 'value')
+      attributes.setCustom('test.2', 'value')
+      attributes.setCustom('test.3', 'value')
+      attributes.setCustom('test.4', 'value')
+      attributes.setCustom('test.5', 'value')
+
+      // New attribute should be discarded
+      attributes.setCustom('test.6', 'value')
+      expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.6 in span test.span was dropped as the number of attributes exceeds the 5 attribute limit set by attributeCountLimit.')
+      expect(jestLogger.warn).toHaveBeenCalledTimes(1)
+      expect(attributes.droppedAttributesCount).toBe(1)
+      expect(attributes.toJson()).toStrictEqual([
+        { key: 'test.1', value: { stringValue: 'value' } },
+        { key: 'test.2', value: { stringValue: 'value' } },
+        { key: 'test.3', value: { stringValue: 'value' } },
+        { key: 'test.4', value: { stringValue: 'value' } },
+        { key: 'test.5', value: { stringValue: 'value' } }
+      ])
+
+      // Existing attribute can be updated when at the attribute limit
+      attributes.setCustom('test.5', 'new-value')
+      expect(jestLogger.warn).toHaveBeenCalledTimes(1)
+      expect(jestLogger.warn).not.toHaveBeenCalledWith('Span attribute test.5 in span test.span was dropped as the number of attributes exceeds the 5 attribute limit set by attributeCountLimit.')
+      expect(attributes.droppedAttributesCount).toBe(1)
+      expect(attributes.toJson()).toStrictEqual([
+        { key: 'test.1', value: { stringValue: 'value' } },
+        { key: 'test.2', value: { stringValue: 'value' } },
+        { key: 'test.3', value: { stringValue: 'value' } },
+        { key: 'test.4', value: { stringValue: 'value' } },
+        { key: 'test.5', value: { stringValue: 'new-value' } }
+      ])
+
+      // New attributes can be added after removing an existing attribute
+      attributes.remove('test.5')
+      attributes.setCustom('test.7', 'value')
+      expect(jestLogger.warn).toHaveBeenCalledTimes(1)
+      expect(attributes.droppedAttributesCount).toBe(1)
+      expect(attributes.toJson()).toStrictEqual([
+        { key: 'test.1', value: { stringValue: 'value' } },
+        { key: 'test.2', value: { stringValue: 'value' } },
+        { key: 'test.3', value: { stringValue: 'value' } },
+        { key: 'test.4', value: { stringValue: 'value' } },
+        { key: 'test.7', value: { stringValue: 'value' } }
+      ])
+    })
+
+    it('removes the attribute when value is null', () => {
+      attributes.setCustom('test.key', 'initial-value')
+      expect(attributes.toObject()['test.key']).toBe('initial-value')
+
+      attributes.setCustom('test.key', null)
+      expect(attributes.toObject()).not.toHaveProperty('test.key')
+    })
+
+    it('ignores setting an attribute with an empty key', () => {
+      attributes.setCustom('', 'value')
+      expect(attributes.toJson()).toStrictEqual([])
+    })
+
+    it('ignores setting an attribute with an undefined value', () => {
+      // @ts-expect-error Testing undefined value
+      attributes.setCustom('test.undefined', undefined)
+      expect(attributes.toJson()).toStrictEqual([])
+    })
+  })
+
+  describe('toJson()', () => {
+    const jestLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() }
+    let attributes: SpanAttributes
+
+    beforeEach(() => {
+      jestLogger.warn.mockClear()
+      attributes = new SpanAttributes(new Map(), { attributeArrayLengthLimit: 5, attributeCountLimit: 5, attributeStringValueLimit: 20 }, 'test.span', jestLogger)
+    })
+
+    it('truncates an attribute with a string value that exceeds the limit', () => {
+      const attributeValue = 'a'.repeat(256)
+      attributes.setCustom('test.string', attributeValue)
+      expect(attributes.toJson()).toStrictEqual([{ key: 'test.string', value: { stringValue: 'a'.repeat(20) + ' *** 236 CHARS TRUNCATED' } }])
+      expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.string in span test.span was truncated as the string exceeds the 20 character limit set by attributeStringValueLimit.')
+      expect(attributes.droppedAttributesCount).toBe(0)
+    })
+
+    it('truncates an attribute with an array value that exceeds the limit', () => {
+      attributes.setCustom('test.array', Array.from({ length: 10 }, (_, i) => i))
+      expect(attributes.toJson()).toStrictEqual([{
+        key: 'test.array',
+        value: { arrayValue: { values: Array.from({ length: 5 }, (_, i) => ({ intValue: i.toString() })) } }
+      }])
+      expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.array in span test.span was truncated as the array exceeds the 5 element limit set by attributeArrayLengthLimit.')
+      expect(attributes.droppedAttributesCount).toBe(0)
+    })
+  })
+
+  describe('toObject()', () => {
+    let attributes: SpanAttributes
+
+    beforeEach(() => {
+      attributes = new SpanAttributes(new Map(), defaultSpanAttributeLimits, 'test.span', console)
+    })
+
+    it('returns an empty object when no attributes are set', () => {
+      expect(attributes.toObject()).toEqual({})
+    })
+
+    it('returns all attributes as a plain object', () => {
+      attributes.set('string.attr', 'value')
+      attributes.set('number.attr', 123)
+      attributes.set('boolean.attr', false)
+      attributes.set('array.attr', [1, 2, 3])
+
+      const result = attributes.toObject()
+      expect(result).toEqual({
+        'string.attr': 'value',
+        'number.attr': 123,
+        'boolean.attr': false,
+        'array.attr': [1, 2, 3]
+      })
+    })
+
+    it('returns a snapshot that does not affect the internal attributes', () => {
+      attributes.set('test.key', 'original')
+      const obj1 = attributes.toObject()
+
+      // Modify the returned object
+      obj1['test.key'] = 'modified'
+      obj1['new.key'] = 'added'
+
+      // Original attributes should be unchanged
+      const obj2 = attributes.toObject()
+      expect(obj2).toEqual({ 'test.key': 'original' })
+      expect(obj2).not.toHaveProperty('new.key')
+    })
+
+    it('preserves attribute types correctly', () => {
+      attributes.set('zero', 0)
+      attributes.set('false', false)
+      attributes.set('empty.string', '')
+      attributes.set('empty.array', [])
+
+      const result = attributes.toObject()
+      expect(result.zero).toBe(0)
+      expect(result.false).toBe(false)
+      expect(result['empty.string']).toBe('')
+      expect(result['empty.array']).toEqual([])
+    })
   })
 })
 
@@ -96,87 +347,54 @@ describe('attributeToJson', () => {
     const attribute = attributeToJson('test.-Infinity', -Infinity)
     expect(attribute).toBeUndefined()
   })
+
+  it('always converts bugsnag.sampling.p as doubleValue even for integers', () => {
+    // Regular integer should be intValue
+    const regularInt = attributeToJson('regular.int', 1)
+    expect(regularInt).toEqual({
+      key: 'regular.int',
+      value: { intValue: '1' }
+    })
+
+    // bugsnag.sampling.p should always be doubleValue
+    const samplingP = attributeToJson('bugsnag.sampling.p', 1)
+    expect(samplingP).toEqual({
+      key: 'bugsnag.sampling.p',
+      value: { doubleValue: 1 }
+    })
+  })
 })
 
-describe('attribute validation', () => {
+describe('ResourceAttributes', () => {
   const jestLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() }
-  let attributes: SpanAttributes
 
   beforeEach(() => {
     jestLogger.warn.mockClear()
-    attributes = new SpanAttributes(new Map(), { attributeArrayLengthLimit: 5, attributeCountLimit: 5, attributeStringValueLimit: 20 }, 'test.span', jestLogger)
   })
 
-  it('prevents adding an attribute with a key that exceeds the limit', () => {
-    const attributeKey = 'a'.repeat(256)
-    attributes.setCustom(attributeKey, 'value')
-    expect(attributes.toJson()).toStrictEqual([])
-    expect(jestLogger.warn).toHaveBeenCalledWith(`Span attribute ${attributeKey} in span test.span was dropped as the key length exceeds the 128 character fixed limit.`)
-    expect(attributes.droppedAttributesCount).toBe(1)
+  it('creates resource attributes with all required fields', () => {
+    const resourceAttributes = new ResourceAttributes('production', '1.2.3', 'my-service', 'bugsnag-js-performance', '2.0.0', jestLogger)
+
+    const attributes = resourceAttributes.toObject()
+    expect(attributes).toEqual({
+      'deployment.environment': 'production',
+      'telemetry.sdk.name': 'bugsnag-js-performance',
+      'telemetry.sdk.version': '2.0.0',
+      'service.name': 'my-service',
+      'service.version': '1.2.3'
+    })
   })
 
-  it('truncates an attribute with a string value that exceeds the limit', () => {
-    const attributeValue = 'a'.repeat(256)
-    attributes.setCustom('test.string', attributeValue)
-    expect(attributes.toJson()).toStrictEqual([{ key: 'test.string', value: { stringValue: 'a'.repeat(20) + ' *** 236 CHARS TRUNCATED' } }])
-    expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.string in span test.span was truncated as the string exceeds the 20 character limit set by attributeStringValueLimit.')
-    expect(attributes.droppedAttributesCount).toBe(0)
-  })
+  it('creates resource attributes without service.version when appVersion is empty', () => {
+    const resourceAttributes = new ResourceAttributes('staging', '', 'my-service', 'bugsnag-js-performance', '2.0.0', jestLogger)
 
-  it('prevents adding an attribute with an array value that exceeds the limit', () => {
-    attributes.setCustom('test.array', Array.from({ length: 10 }, (_, i) => i))
-    expect(attributes.toJson()).toStrictEqual([{
-      key: 'test.array',
-      value: { arrayValue: { values: Array.from({ length: 5 }, (_, i) => ({ intValue: i.toString() })) } }
-    }])
-    expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.array in span test.span was truncated as the array exceeds the 5 element limit set by attributeArrayLengthLimit.')
-    expect(attributes.droppedAttributesCount).toBe(0)
-  })
-
-  it('prevents adding an attribute when the count limit is reached', () => {
-    attributes.setCustom('test.1', 'value')
-    attributes.setCustom('test.2', 'value')
-    attributes.setCustom('test.3', 'value')
-    attributes.setCustom('test.4', 'value')
-    attributes.setCustom('test.5', 'value')
-
-    // New attribute should be discarded
-    attributes.setCustom('test.6', 'value')
-    expect(jestLogger.warn).toHaveBeenCalledWith('Span attribute test.6 in span test.span was dropped as the number of attributes exceeds the 5 attribute limit set by attributeCountLimit.')
-    expect(jestLogger.warn).toHaveBeenCalledTimes(1)
-    expect(attributes.droppedAttributesCount).toBe(1)
-    expect(attributes.toJson()).toStrictEqual([
-      { key: 'test.1', value: { stringValue: 'value' } },
-      { key: 'test.2', value: { stringValue: 'value' } },
-      { key: 'test.3', value: { stringValue: 'value' } },
-      { key: 'test.4', value: { stringValue: 'value' } },
-      { key: 'test.5', value: { stringValue: 'value' } }
-    ])
-
-    // Existing attribute can be updated when at the attribute limit
-    attributes.setCustom('test.5', 'new-value')
-    expect(jestLogger.warn).toHaveBeenCalledTimes(1)
-    expect(jestLogger.warn).not.toHaveBeenCalledWith('Span attribute test.5 in span test.span was dropped as the number of attributes exceeds the 5 attribute limit set by attributeCountLimit.')
-    expect(attributes.droppedAttributesCount).toBe(1)
-    expect(attributes.toJson()).toStrictEqual([
-      { key: 'test.1', value: { stringValue: 'value' } },
-      { key: 'test.2', value: { stringValue: 'value' } },
-      { key: 'test.3', value: { stringValue: 'value' } },
-      { key: 'test.4', value: { stringValue: 'value' } },
-      { key: 'test.5', value: { stringValue: 'new-value' } }
-    ])
-
-    // New attributes can be added after removing an existing attribute
-    attributes.remove('test.5')
-    attributes.setCustom('test.7', 'value')
-    expect(jestLogger.warn).toHaveBeenCalledTimes(1)
-    expect(attributes.droppedAttributesCount).toBe(1)
-    expect(attributes.toJson()).toStrictEqual([
-      { key: 'test.1', value: { stringValue: 'value' } },
-      { key: 'test.2', value: { stringValue: 'value' } },
-      { key: 'test.3', value: { stringValue: 'value' } },
-      { key: 'test.4', value: { stringValue: 'value' } },
-      { key: 'test.7', value: { stringValue: 'value' } }
-    ])
+    const attributes = resourceAttributes.toObject()
+    expect(attributes).toEqual({
+      'deployment.environment': 'staging',
+      'telemetry.sdk.name': 'bugsnag-js-performance',
+      'telemetry.sdk.version': '2.0.0',
+      'service.name': 'my-service'
+    })
+    expect(attributes).not.toHaveProperty('service.version')
   })
 })

--- a/packages/core/tests/attributes.test.ts
+++ b/packages/core/tests/attributes.test.ts
@@ -43,14 +43,16 @@ describe('SpanAttributes', () => {
       expect(attributes.toObject()).not.toHaveProperty('test.key')
     })
 
-    it('ignores setting an attribute with an empty key', () => {
-      attributes.set('', 'value')
-      expect(attributes.toJson()).toStrictEqual([])
+    it('removes the attribute when value is undefined', () => {
+      attributes.set('test.undefined', 'initial-value')
+      expect(attributes.toObject()['test.undefined']).toBe('initial-value')
+
+      attributes.set('test.undefined', undefined)
+      expect(attributes.toObject()).not.toHaveProperty('test.undefined')
     })
 
-    it('ignores setting an attribute with an undefined value', () => {
-      // @ts-expect-error Testing undefined value
-      attributes.set('test.undefined', undefined)
+    it('ignores setting an attribute with an empty key', () => {
+      attributes.set('', 'value')
       expect(attributes.toJson()).toStrictEqual([])
     })
 
@@ -161,21 +163,23 @@ describe('SpanAttributes', () => {
     })
 
     it('removes the attribute when value is null', () => {
-      attributes.setCustom('test.key', 'initial-value')
-      expect(attributes.toObject()['test.key']).toBe('initial-value')
+      attributes.setCustom('test.null', 'initial-value')
+      expect(attributes.toObject()['test.null']).toBe('initial-value')
 
-      attributes.setCustom('test.key', null)
-      expect(attributes.toObject()).not.toHaveProperty('test.key')
+      attributes.setCustom('test.null', null)
+      expect(attributes.toObject()).not.toHaveProperty('test.null')
+    })
+
+    it('removes the attribute when value is undefined', () => {
+      attributes.setCustom('test.undefined', 'initial-value')
+      expect(attributes.toObject()['test.undefined']).toBe('initial-value')
+
+      attributes.setCustom('test.undefined', undefined)
+      expect(attributes.toObject()).not.toHaveProperty('test.undefined')
     })
 
     it('ignores setting an attribute with an empty key', () => {
       attributes.setCustom('', 'value')
-      expect(attributes.toJson()).toStrictEqual([])
-    })
-
-    it('ignores setting an attribute with an undefined value', () => {
-      // @ts-expect-error Testing undefined value
-      attributes.setCustom('test.undefined', undefined)
       expect(attributes.toJson()).toStrictEqual([])
     })
   })

--- a/test/browser/features/custom-attributes.feature
+++ b/test/browser/features/custom-attributes.feature
@@ -33,6 +33,8 @@ Feature: Custom attributes
             | false  |
             | true   |
 
+        And a span named "Custom/CustomAttributesScenario" does not contain the attribute "custom.removed"
+        And a span named "Custom/CustomAttributesScenario" does not contain the attribute "custom.array.dropped"
         And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" equals 1
 
         # These attributes exceed the limit, but should not be dropped as they are set by us

--- a/test/browser/features/fixtures/packages/custom-attributes/src/index.js
+++ b/test/browser/features/fixtures/packages/custom-attributes/src/index.js
@@ -18,6 +18,10 @@ BugsnagPerformance.start({
 setTimeout(() => {
   const span = BugsnagPerformance.startSpan('Custom/CustomAttributesScenario')
 
+  // Calling setAttribute with null should remove the attribute
+  span.setAttribute('custom.removed', 'This attribute should be removed')
+  span.setAttribute('custom.removed', null)
+
   // 10 custom attributes
   span.setAttribute('custom.string', 'custom attribute')
   span.setAttribute('custom.int', 12345)


### PR DESCRIPTION
## Goal

Previously calls to `setAttribute` with `null` or `undefined` values were ignored, so there was no way to remove span attributes. This PR updates the implementation so that calling `setAttribute` with a `null` or `undefined` attribute value clears the attribute from the span.

## Design

Updated the `SpanAttribute` type to accept null/undefined values and updated the `set` and `setCustom` methods to remove the attribute if the value is `null` or `undefined`

## Testing

Updated the attribute unit tests and updated the maze runner scenario to verify that span attributes can now be removed. 