### PR TITLE
fix(react-native): ensure iOS native span and trace IDs are correctly…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - (react-native) Added a short debounce during app start to allow backgrounded apps to come to the foreground [#665](https://github.com/bugsnag/bugsnag-js-performance/pull/665)
 - (react-native) Fix a crash when refreshing the entropy pool on iOS [#667](https://github.com/bugsnag/bugsnag-js-performance/pull/667)
+- (ract-native) Fix span and trace ID encoding in the iOS native integration [#683](https://github.com/bugsnag/bugsnag-js-performance/pull/683)
 
 ## [v2.14.0] (2025-06-25)
 

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
@@ -318,8 +318,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(startNativeSpan:(NSString *)name
     BugsnagPerformanceSpan *nativeSpan = [BugsnagReactNativePerformanceCrossTalkAPIClient.sharedInstance startSpan:name options:spanOptions];
     [nativeSpan.attributes removeAllObjects];
     
-    NSString *spanId = [NSString stringWithFormat:@"%llx", nativeSpan.spanId];
-    NSString *traceId = [NSString stringWithFormat:@"%llx%llx", nativeSpan.traceIdHi, nativeSpan.traceIdLo];
+    NSString *spanId = [NSString stringWithFormat:@"%016llx", nativeSpan.spanId];
+    NSString *traceId = [NSString stringWithFormat:@"%016llx%016llx", nativeSpan.traceIdHi, nativeSpan.traceIdLo];
 
     @synchronized (openSpans) {
         openSpans[[spanId stringByAppendingString:traceId]] = nativeSpan;
@@ -331,7 +331,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(startNativeSpan:(NSString *)name
     span[@"traceId"] = traceId;
     span[@"startTime"] = [NSNumber numberWithDouble: [nativeSpan.startTime timeIntervalSince1970] * NSEC_PER_SEC];
     if (nativeSpan.parentId > 0) {
-        span[@"parentSpanId"] = [NSString stringWithFormat:@"%llx", nativeSpan.parentId];
+        span[@"parentSpanId"] = [NSString stringWithFormat:@"%016llx", nativeSpan.parentId];
     }
     
     return span;

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/NativeIntegrationJsParentScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/NativeIntegrationJsParentScenario.js
@@ -45,7 +45,7 @@ export const App = () => {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.scenario}>
-        <Text>Native Integration Scenario</Text>
+        <Text>Native Integration JS Parent Scenario</Text>
       </View>
     </SafeAreaView>
   )

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/NativeIntegrationNativeParentScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/NativeIntegrationNativeParentScenario.js
@@ -1,0 +1,61 @@
+import React, { useEffect } from 'react'
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native'
+import { NativeScenarioLauncher } from '../../lib/native'
+import BugsnagPerformance from '@bugsnag/react-native-performance'
+
+export const doNotStartBugsnagPerformance = true
+
+export const initialise = async (config) => {
+  const nativeConfig = {
+    apiKey: config.apiKey,
+    endpoint: config.endpoint
+  }
+
+  const onSpanStart = [
+    (span) => {
+      span.setAttribute('custom.string.attribute', 'test')
+      span.setAttribute('custom.int.attribute', 12345)
+    }
+  ]
+
+  const onSpanEnd = [
+    async (span) => {
+      span.setAttribute('custom.double.attribute', 123.45)
+      span.setAttribute('custom.boolean.attribute', true)
+      span.setAttribute('custom.stringarray.attribute', ['a', 'b', 'c'])
+      span.setAttribute('custom.intarray.attribute', [1, 2, 3])
+      span.setAttribute('custom.doublearray.attribute', [1.1, 2.2, 3.3])
+      return true
+    }
+  ]
+
+  await NativeScenarioLauncher.startNativePerformance(nativeConfig)
+
+  BugsnagPerformance.attach({ onSpanStart, onSpanEnd, maximumBatchSize: 1, autoInstrumentAppStarts: false, autoInstrumentNetworkRequests: false })
+}
+
+export const App = () => {
+  useEffect(() => {
+    const parentSpan = BugsnagPerformance.startSpan('Native parent span', { isFirstClass: true, parentContext: null })
+    const childSpan = BugsnagPerformance.startSpan('JS child span', { parentContext: parentSpan })
+    childSpan.end()
+    parentSpan.end()
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.scenario}>
+        <Text>Native Integration Native Parent Scenario</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  scenario: {
+    flex: 1
+  }
+})

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/native-integration/index.js
@@ -1,5 +1,6 @@
 // Native Integration Scenarios
-export * as NativeIntegrationScenario from './NativeIntegrationScenario'
+export * as NativeIntegrationJsParentScenario from './NativeIntegrationJsParentScenario'
+export * as NativeIntegrationNativeParentScenario from './NativeIntegrationNativeParentScenario'
 export * as RemoteParentContextNativeScenario from './RemoteParentContextNativeScenario'
 export * as RemoteParentContextJSScenario from './RemoteParentContextJSScenario'
 export * as NativeSpansPluginScenario from './NativeSpansPluginScenario'

--- a/test/react-native/features/native-integration.feature
+++ b/test/react-native/features/native-integration.feature
@@ -1,12 +1,86 @@
 @native_integration
 Feature: Native Integration
 
-  Scenario: First class custom spans are delegated to the native SDK
-    When I run 'NativeIntegrationScenario'
+  Scenario: First class custom spans are processed and sent by the native SDK 
+    When I run 'NativeIntegrationNativeParentScenario'
     And I wait to receive 2 sampling requests
     And I wait to receive 2 traces
 
-    # JS trace
+    # JS trace (non-first-class child span)
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
+    
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "JS child span"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 1.0
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "custom.string.attribute" equals "test"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "custom.int.attribute" equals 12345
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "custom.double.attribute" equals 123.45
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "custom.boolean.attribute" is true
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string array attribute "custom.stringarray.attribute" equals the array:
+        | a |
+        | b |
+        | c |
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer array attribute "custom.intarray.attribute" equals the array:
+        | 1 |
+        | 2 |
+        | 3 |
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "custom.doublearray.attribute" equals the array:
+        | 1.1 |
+        | 2.2 |
+        | 3.3 |
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" is stored as the value "nativeParentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "nativeParentTraceId"
+
+    Then I discard the oldest trace
+
+    # Native trace (first-class parent span)
+    And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
+    And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals the platform-dependent string:
+        | ios     | bugsnag.performance.cocoa   |
+        | android | bugsnag.performance.android |
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Native parent span"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" is null
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" equals the stored value "nativeParentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" equals the stored value "nativeParentTraceId"
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 1.0
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "custom.string.attribute" equals "test"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "custom.int.attribute" equals 12345
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "custom.double.attribute" equals 123.45
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "custom.boolean.attribute" is true
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string array attribute "custom.stringarray.attribute" equals the array:
+        | a |
+        | b |
+        | c |
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer array attribute "custom.intarray.attribute" equals the array:
+        | 1 |
+        | 2 |
+        | 3 |
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "custom.doublearray.attribute" equals the array:
+        | 1.1 |
+        | 2.2 |
+        | 3.3 |
+
+  Scenario: JS parent context is propagated to native child spans
+    When I run 'NativeIntegrationJsParentScenario'
+    And I wait to receive 2 sampling requests
+    And I wait to receive 2 traces
+
+    # JS trace (non-first-class parent span)
     And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.reactnative"
     
@@ -31,20 +105,28 @@ Feature: Native Integration
         | 2.2 |
         | 3.3 |
 
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" is stored as the value "parentSpanId"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "traceId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" is null
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" is stored as the value "JSParentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "JSParentTraceId"
 
     Then I discard the oldest trace
 
-    # Native trace
+    # Native trace (first-class child span)
     And the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.fixtures.reactnative.performance"
     And the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals the platform-dependent string:
         | ios     | bugsnag.performance.cocoa   |
         | android | bugsnag.performance.android |
 
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Native child span"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "parentSpanId"
-    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" equals the stored value "traceId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.parentSpanId" equals the stored value "JSParentSpanId"
+    And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" equals the stored value "JSParentTraceId"
 
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.sampling.p" equals 1.0
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"


### PR DESCRIPTION
## Goal

Fixes an issue with span and trace ID encoding in the iOS native integration where invalid span and trace IDs (with fewer characters than expected) could be propagated from native to JS.

## Design

Updates the encoding of span and trace IDs in the native iOS implementation to always use zero-padded, fixed-length hexadecimal strings (16 characters for span IDs, 32 for trace IDs), ensuring that span and trace IDs sent from native to JS are always valid.

## Testing

This issue wasn't picked up by existing tests as the existing maze runner scenario creates a JS (non-first-class) parent span, so the span and trace IDs are generated in the tests are always valid. 

Added a new e2e test scenario with a native parent span and child JS span, covering trace ID propagation and parent-child span relationships in both directions.

Also added extra regex test assertions to both scenarios to check the spanId, traceId and parentSpanId values are valid.