### PR TITLE
Native app starts plugin - Android

### DIFF
--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/NativeBugsnagPerformanceImpl.java
@@ -30,9 +30,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import com.bugsnag.android.performance.BugsnagPerformance;
 import com.bugsnag.android.performance.SpanOptions;
-
 import com.bugsnag.android.performance.internal.BugsnagClock;
 import com.bugsnag.android.performance.internal.EncodingUtils;
 import com.bugsnag.android.performance.internal.SpanFactory;
@@ -175,6 +173,14 @@ class NativeBugsnagPerformanceImpl {
       result.putArray("enabledReleaseStages", Arguments.fromArray(enabledReleaseStages.toArray(new String[0])));
     }
 
+    ReactNativeAppStartPlugin appStartPlugin = ReactNativeAppStartPlugin.getInstance();
+    if (appStartPlugin != null) {
+      String appStartParent = appStartPlugin.getAppStartParent();
+      if (appStartParent != null) {
+        result.putString("appStartParentContext", appStartParent);
+      }
+    }
+
     return result;
   }
 
@@ -235,6 +241,13 @@ class NativeBugsnagPerformanceImpl {
       nativeSpan.discard();
     }
 
+    promise.resolve(null);
+  }
+
+  void endNativeAppStart(double endTime, Promise promise) {
+    long nativeEndTime = BugsnagClock.INSTANCE.unixNanoTimeToElapsedRealtime((long)endTime);
+    ReactNativeAppStartPlugin appStartPlugin = ReactNativeAppStartPlugin.getInstance();
+    appStartPlugin.endAppStart(nativeEndTime);
     promise.resolve(null);
   }
 

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeAppStartPlugin.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeAppStartPlugin.java
@@ -1,0 +1,122 @@
+package com.bugsnag.reactnative.performance;
+
+import com.bugsnag.android.performance.Span;
+import com.bugsnag.android.performance.SpanContext;
+import com.bugsnag.android.performance.OnSpanEndCallback;
+import com.bugsnag.android.performance.OnSpanStartCallback;
+import com.bugsnag.android.performance.Plugin;
+import com.bugsnag.android.performance.PluginContext;
+import com.bugsnag.android.performance.RemoteSpanContext;
+
+import com.bugsnag.android.performance.internal.SpanImpl.Condition;
+import com.bugsnag.android.performance.internal.SpanCategory;
+import com.bugsnag.android.performance.internal.SpanImpl;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ReactNativeAppStartPlugin implements Plugin {
+
+  private static final int SPAN_BLOCK_TIMEOUT_MS = 500;
+
+  // Container class to ensure atomic updates of related fields
+  private static class ViewLoadCondition {
+    final String spanId;
+    final Condition condition;
+
+    ViewLoadCondition(String spanId, Condition condition) {
+      this.spanId = spanId;
+      this.condition = condition;
+    }
+  }
+
+  private static ReactNativeAppStartPlugin INSTANCE;
+
+  private final AtomicReference<ViewLoadCondition> viewLoadCondition = new AtomicReference<>(null);
+  private final AtomicBoolean appStartComplete = new AtomicBoolean(false);
+
+  static ReactNativeAppStartPlugin getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void install(PluginContext ctx) {
+    if (INSTANCE == null) {
+      INSTANCE = this;
+    }
+
+    ctx.addOnSpanStartCallback(PluginContext.NORM_PRIORITY + 1, new OnSpanStartCallback() {
+      @Override
+      public void onSpanStart(Span span) {
+        ReactNativeAppStartPlugin.this.onSpanStart(span);
+      }
+    });
+
+    ctx.addOnSpanEndCallback(PluginContext.NORM_PRIORITY - 1, new OnSpanEndCallback() {
+      @Override
+      public boolean onSpanEnd(Span span) {
+        return ReactNativeAppStartPlugin.this.onSpanEnd(span);
+      }
+    });
+  }
+
+  @Override
+  public  void start() {}
+
+  public String getAppStartParent() {
+    ViewLoadCondition currentCondition = viewLoadCondition.get();
+    if (currentCondition != null) {
+      SpanContext nativeParent = currentCondition.condition.upgrade();
+      if (nativeParent != null) {
+        return RemoteSpanContext.encodeAsTraceParent(nativeParent);
+      }
+    }
+
+    return null;
+  }
+
+  public void endAppStart(long endTime) {
+    ViewLoadCondition currentCondition = viewLoadCondition.getAndSet(null);
+    if (currentCondition != null) {
+      currentCondition.condition.close(endTime);
+    }
+
+    appStartComplete.set(true);
+  }
+
+  private void onSpanStart(Span span) {
+    if (appStartComplete.get()) {
+      return;
+    }
+
+    SpanImpl spanImpl = (SpanImpl)span;
+    if (spanImpl.getAttributes().get("bugsnag.span.category") != SpanCategory.CATEGORY_VIEW_LOAD) {
+      return;
+    }
+
+    ViewLoadCondition currentCondition = viewLoadCondition.get();
+    if (currentCondition != null) {
+      currentCondition.condition.cancel();
+    }
+
+    // Only set viewLoadCondition if block() returned a non-null value
+    Condition spanCondition = spanImpl.block(SPAN_BLOCK_TIMEOUT_MS);
+    if (spanCondition != null) {
+      String spanId = RemoteSpanContext.encodeAsTraceParent(spanImpl);
+      viewLoadCondition.set(new ViewLoadCondition(spanId, spanCondition));
+    }
+  }
+
+  private boolean onSpanEnd(Span span) {
+    String spanId = RemoteSpanContext.encodeAsTraceParent(span);
+    ViewLoadCondition currentCondition = viewLoadCondition.get();
+
+    if (currentCondition != null && spanId.equals(currentCondition.spanId)) {
+      if (viewLoadCondition.compareAndSet(currentCondition, null)) {
+        currentCondition.condition.cancel();
+      }
+    }
+
+    return true;
+  }
+}

--- a/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeAppStartPlugin.java
+++ b/packages/platforms/react-native/android/src/main/java/com/bugsnag/android/performance/ReactNativeAppStartPlugin.java
@@ -33,7 +33,7 @@ public class ReactNativeAppStartPlugin implements Plugin {
   private static ReactNativeAppStartPlugin INSTANCE;
 
   private final AtomicReference<ViewLoadCondition> viewLoadCondition = new AtomicReference<>(null);
-  private final AtomicBoolean appStartComplete = new AtomicBoolean(false);
+  private volatile boolean appStartComplete = false;
 
   static ReactNativeAppStartPlugin getInstance() {
     return INSTANCE;
@@ -61,7 +61,7 @@ public class ReactNativeAppStartPlugin implements Plugin {
   }
 
   @Override
-  public  void start() {}
+  public void start() {}
 
   public String getAppStartParent() {
     ViewLoadCondition currentCondition = viewLoadCondition.get();
@@ -81,11 +81,11 @@ public class ReactNativeAppStartPlugin implements Plugin {
       currentCondition.condition.close(endTime);
     }
 
-    appStartComplete.set(true);
+    appStartComplete = true;
   }
 
   private void onSpanStart(Span span) {
-    if (appStartComplete.get()) {
+    if (appStartComplete) {
       return;
     }
 

--- a/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/newarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -105,5 +105,10 @@ public class BugsnagReactNativePerformance extends NativeBugsnagPerformanceSpec 
   public void discardNativeSpan(String spanId, String traceId, Promise promise) {
     impl.discardNativeSpan(spanId, traceId, promise);
   }
+
+  @Override
+  public void endNativeAppStart(double endTime, Promise promise) {
+    impl.endNativeAppStart(endTime, promise);
+  }
 }
 

--- a/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
+++ b/packages/platforms/react-native/android/src/oldarch/java/com/bugsnag/android/performance/BugsnagReactNativePerformance.java
@@ -107,4 +107,9 @@ public class BugsnagReactNativePerformance extends ReactContextBaseJavaModule {
   public void discardNativeSpan(String spanId, String traceId, Promise promise) {
     impl.discardNativeSpan(spanId, traceId, promise);
   }
+
+  @ReactMethod
+  public void endNativeAppStart(double endTime, Promise promise) {
+    impl.endNativeAppStart(endTime, promise);
+  }
 }

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
@@ -400,6 +400,12 @@ RCT_EXPORT_METHOD(discardNativeSpan:(NSString *)spanId
     resolve(nil);
 }
 
+RCT_EXPORT_METHOD(endNativeAppStart:(double)endTime
+                resolve:(RCTPromiseResolveBlock)resolve
+                reject:(RCTPromiseRejectBlock)reject) {
+    resolve(nil);
+}
+
 - (void)discardLongRunningSpans {
     NSDate *oneHourAgo = [NSDate dateWithTimeIntervalSinceNow:-hourInSeconds];
     NSMutableArray *keysToRemove = [NSMutableArray new];

--- a/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
+++ b/packages/platforms/react-native/lib/NativeBugsnagPerformance.ts
@@ -27,6 +27,7 @@ export type NativeConfiguration = {
   attributeCountLimit: number
   attributeStringValueLimit: number
   attributeArrayLengthLimit: number
+  nativeParentContext: string | undefined
 }
 
 export type ParentContext = {
@@ -60,6 +61,7 @@ export interface Spec extends TurboModule {
   endNativeSpan: (spanId: string, traceId: string, endTime: number, attributes: UnsafeObject) => Promise<void>
   markNativeSpanEndTime: (spanId: string, traceId: string, endTime: number) => void
   discardNativeSpan: (spanId: string, traceId: string) => Promise<void>
+  endNativeAppStart: (endTime: number) => Promise<void>
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/packages/platforms/react-native/lib/platform-extensions.tsx
+++ b/packages/platforms/react-native/lib/platform-extensions.tsx
@@ -41,7 +41,7 @@ export const platformExtensions = (appStartTime: number, clock: Clock, spanFacto
       ...nativeConfig
     }
 
-    spanFactory.onAttach()
+    spanFactory.onAttach(nativeConfig.nativeParentContext)
     const client = this as unknown as Client<ReactNativeConfiguration>
     client.start(finalConfig)
   }

--- a/packages/platforms/react-native/lib/span-factory.ts
+++ b/packages/platforms/react-native/lib/span-factory.ts
@@ -1,4 +1,4 @@
-import { runSpanEndCallbacks, SpanFactory, SpanInternal, timeToNumber } from '@bugsnag/core-performance'
+import { RemoteParentContext, runSpanEndCallbacks, SpanFactory, SpanInternal, timeToNumber } from '@bugsnag/core-performance'
 import type { SpanAttributes, SpanOptions } from '@bugsnag/core-performance'
 import type { ReactNativeConfiguration } from './config'
 import NativeBugsnagPerformance from './native'
@@ -18,9 +18,13 @@ export class ReactNativeSpanFactory extends SpanFactory<ReactNativeConfiguration
   private attachedToNative = false
   appStartSpan?: SpanInternal
   private appStartSpanCreated = false
+  private nativeParentContext?: RemoteParentContext
 
-  onAttach () {
+  onAttach (nativeParentContext?: string) {
     this.attachedToNative = true
+    if (nativeParentContext) {
+      this.nativeParentContext = RemoteParentContext.parseTraceParent(nativeParentContext)
+    }
   }
 
   startSpan (name: string, options: ReactNativeSpanOptions) {
@@ -83,7 +87,7 @@ export class ReactNativeSpanFactory extends SpanFactory<ReactNativeConfiguration
   startAppStartSpan (appStartTime: number) {
     // Ensure we only ever create one app start span
     if (!this.appStartSpan && !this.appStartSpanCreated) {
-      this.appStartSpan = this.startSpan(APP_START_BASE_NAME, { startTime: appStartTime, parentContext: null })
+      this.appStartSpan = this.startSpan(APP_START_BASE_NAME, { startTime: appStartTime, parentContext: this.nativeParentContext || null })
       this.appStartSpan.setAttribute('bugsnag.span.category', 'app_start')
       this.appStartSpan.setAttribute('bugsnag.app_start.type', 'ReactNativeInit')
       this.appStartSpanCreated = true
@@ -94,6 +98,10 @@ export class ReactNativeSpanFactory extends SpanFactory<ReactNativeConfiguration
     if (this.appStartSpan?.isValid()) {
       this.endSpan(this.appStartSpan, endTime)
       this.appStartSpan = undefined
+
+      if (this.nativeParentContext) {
+        NativeBugsnagPerformance.endNativeAppStart(endTime)
+      }
     }
   }
 }

--- a/packages/platforms/react-native/tests/span-factory.test.ts
+++ b/packages/platforms/react-native/tests/span-factory.test.ts
@@ -1,7 +1,7 @@
 import { ReactNativeSpanFactory } from '../lib/span-factory'
 import NativeBugsnagPerformance from '../lib/native'
 import { ControllableBackgroundingListener, InMemoryProcessor, spanAttributesSource, IncrementingIdGenerator } from '@bugsnag/js-performance-test-utilities'
-import { DefaultSpanContextStorage, Sampler, DISCARD_END_TIME } from '@bugsnag/core-performance'
+import { DefaultSpanContextStorage, Sampler, DISCARD_END_TIME, RemoteParentContext } from '@bugsnag/core-performance'
 import type { Clock, InternalConfiguration } from '@bugsnag/core-performance'
 import createClock from '../lib/clock'
 import type { ReactNativeConfiguration } from '../lib/config'
@@ -294,6 +294,38 @@ describe('ReactNativeSpanFactory', () => {
       expect(processor.spans[0].startTime).toBe(123)
       expect(processor.spans[0].endTime).toBe(456)
     })
+
+    it('uses the native parent context when set', () => {
+      const nativeParentSpan = { id: '1234567890123456', traceId: 'abcdef1234567890abcdef1234567890' }
+      const nativeParentContext = RemoteParentContext.toTraceParentString(nativeParentSpan)
+      spanFactory.onAttach(nativeParentContext)
+
+      spanFactory.startAppStartSpan(123)
+      spanFactory.endAppStartSpan(321)
+
+      expect(processor.spans[0].parentSpanId).toBe(nativeParentSpan.id)
+      expect(processor.spans[0].traceId).toBe(nativeParentSpan.traceId)
+    })
+
+    it('sets the parent context to null if native context is undefined', () => {
+      spanFactory.onAttach()
+
+      spanFactory.startAppStartSpan(123)
+      spanFactory.endAppStartSpan(321)
+
+      expect(processor.spans[0].parentSpanId).toBeUndefined()
+      expect(processor.spans[0].traceId).toBe('trace ID 1')
+    })
+
+    it('sets the parent context to null if native context is invalid', () => {
+      spanFactory.onAttach('invalid traceparent string')
+
+      spanFactory.startAppStartSpan(123)
+      spanFactory.endAppStartSpan(321)
+
+      expect(processor.spans[0].parentSpanId).toBeUndefined()
+      expect(processor.spans[0].traceId).toBe('trace ID 1')
+    })
   })
 
   describe('endAppStartSpan', () => {
@@ -304,6 +336,30 @@ describe('ReactNativeSpanFactory', () => {
       spanFactory.endAppStartSpan(54321)
       expect(processor.spans[0].endTime).toBe(54321)
       expect(spanFactory.appStartSpan).toBeUndefined()
+    })
+
+    it('calls endNativeAppStart when native context is set', () => {
+      const nativeParentSpan = { id: '1234567890123456', traceId: 'abcdef1234567890abcdef1234567890' }
+      const nativeParentContext = RemoteParentContext.toTraceParentString(nativeParentSpan)
+      spanFactory.onAttach(nativeParentContext)
+
+      spanFactory.startAppStartSpan(123)
+      spanFactory.endAppStartSpan(321)
+      expect(NativeBugsnagPerformance.endNativeAppStart).toHaveBeenCalledWith(321)
+    })
+
+    it('does not call endNativeAppStart when native context is undefined', () => {
+      spanFactory.onAttach()
+      spanFactory.startAppStartSpan(123)
+      spanFactory.endAppStartSpan(321)
+      expect(NativeBugsnagPerformance.endNativeAppStart).not.toHaveBeenCalled()
+    })
+
+    it('does not call endNativeAppStart when native context is invalid', () => {
+      spanFactory.onAttach('invalid traceparent string')
+      spanFactory.startAppStartSpan(123)
+      spanFactory.endAppStartSpan(321)
+      expect(NativeBugsnagPerformance.endNativeAppStart).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/test-utilities/__mocks__/react-native.ts
+++ b/packages/test-utilities/__mocks__/react-native.ts
@@ -170,6 +170,9 @@ const BugsnagReactNativePerformance = {
   discardNativeSpan: jest.fn(() => {
     return Promise.resolve()
   }),
+  endNativeAppStart: jest.fn(() => {
+    return Promise.resolve()
+  }),
   getNativeConstants () {
     return {
       CacheDir: '/mock/CacheDir',


### PR DESCRIPTION
## Goal

Introduces a new `ReactNativeAppStartPlugin` to support linking React Native App Start spans with their corresponding native view load. 

When the plugin is enabled, native view load traces will also include React Native app starts as child spans, and the view load span duration will cover the full time taken to load a React Native view from the native layer through to the React component being rendered.

## Design

The plugin uses span callbacks to track the start and end of view load spans. When a view load span is started, the plugin acquires a span condition with a relatively long (500ms) timeout.

When `attach` is called in the JS layer, the span condition is upgraded and the view load span context is returned to JS as a traceparent string, where it's used as the parent context for the subsequent `AppStart/ReactNativeInit` span.

When the `AppStart/ReactNativeInit` span is ended, the end time is passed back to the native module and the span condition is closed with the updated end time.

## Changeset
- Added `ReactNativeAppStartPlugin`
- Added `endNativeAppStart` method to Turbo Module
- Updated `ReactNativeSpanFactory` to use native parent context when provided

## Testing

Added unit tests for the JS side and tested manually - e2e tests will be added in a separate PR