### PR TITLE
ci(react-native): run android tests on android 13

### DIFF
--- a/.buildkite/expo-pipeline.full.yml
+++ b/.buildkite/expo-pipeline.full.yml
@@ -44,7 +44,7 @@ steps:
       #
       # End-to-end tests
       #
-      - label: ":bitbar: :android: Expo {{matrix}} Android 15 end-to-end tests"
+      - label: ":bitbar: :android: Expo {{matrix}} Android 13 end-to-end tests"
         depends_on: "build-expo-apk-full"
         timeout_in_minutes: 20
         plugins:
@@ -58,7 +58,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/expo/{{matrix}}/test-fixture/output.apk
               - --farm=bb
-              - --device=ANDROID_15
+              - --device=ANDROID_13
               - --a11y-locator
               - --appium-version=1.22
               - --no-tunnel

--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -41,7 +41,7 @@ steps:
       #
       # End-to-end tests
       #
-      - label: ":bitbar: :android: Expo {{matrix}} Android 15 end-to-end tests"
+      - label: ":bitbar: :android: Expo {{matrix}} Android 13 end-to-end tests"
         depends_on: "build-expo-apk"
         timeout_in_minutes: 20
         plugins:
@@ -55,7 +55,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/expo/{{matrix}}/test-fixture/output.apk
               - --farm=bb
-              - --device=ANDROID_15
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -254,7 +254,7 @@ steps:
       #
       # End-to-end tests
       #
-      - label: ":bitbar: :android: RN {{matrix}} Android 12 (Old Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} Android 13 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-old-arch-full"
         timeout_in_minutes: 30
         plugins:
@@ -268,7 +268,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22
@@ -298,7 +298,7 @@ steps:
           - "0.78"
           - "0.79"
 
-      - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch-full"
         timeout_in_minutes: 30
         plugins:
@@ -312,7 +312,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22
@@ -342,7 +342,7 @@ steps:
           - "0.78"
           - "0.79"
 
-      - label: ":bitbar: :android: RN {{matrix}} native integration Android 12 (Old Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-native-integration-old-arch-full"
         timeout_in_minutes: 20
         plugins:
@@ -356,7 +356,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22
@@ -388,7 +388,7 @@ steps:
           - "0.78"
           - "0.79"
 
-      - label: ":bitbar: :android: RN {{matrix}} native integration Android 12 (New Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-native-integration-new-arch-full"
         timeout_in_minutes: 20
         plugins:
@@ -402,7 +402,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/native-integration/new-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -206,7 +206,7 @@ steps:
         #
         # End-to-end tests
         #
-      - label: ":bitbar: :android: RN {{matrix}} Android 12 (Old Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} Android 13 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-old-arch"
         timeout_in_minutes: 20
         plugins:
@@ -220,7 +220,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22
@@ -245,7 +245,7 @@ steps:
         matrix:
           - "0.80"
 
-      - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
         timeout_in_minutes: 20
         plugins:
@@ -259,7 +259,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22
@@ -285,7 +285,7 @@ steps:
         matrix:
           - "0.80"
 
-      - label: ":bitbar: :android: RN {{matrix}} native integration Android 12 (Old Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-native-integration-old-arch"
         timeout_in_minutes: 20
         plugins:
@@ -299,7 +299,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22
@@ -326,7 +326,7 @@ steps:
         matrix:
           - "0.80"
 
-      - label: ":bitbar: :android: RN {{matrix}} native integration Android 12 (New Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-native-integration-new-arch"
         timeout_in_minutes: 20
         plugins:
@@ -340,7 +340,7 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/native-integration/new-arch/{{matrix}}/reactnative.apk
               - --farm=bb
-              - --device=ANDROID_12
+              - --device=ANDROID_13
               - --a11y-locator
               - --fail-fast
               - --appium-version=1.22


### PR DESCRIPTION
## Goal

Moves the Android RN and Expo tests to Android 13 to unblock CI pipelines as there are network infrastructure issues on Android 14+ devices

## Testing

Covered by CI