### PR TITLE
Use Maze Runner v10 for RN tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,8 +116,9 @@ verdaccio-config.yml
 #rbenv
 .ruby-version
 
-# Maze runner output
+# Maze runner
 maze_output.zip
+Gemfile.lock
 
 # React Native test fixure
 test/react-native/features/fixtures/generated/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - ./reports/:/app/reports/
 
   react-native-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v10-cli
     environment:
       <<: *common-environment
       BITBAR_USERNAME:

--- a/test/react-native/Gemfile
+++ b/test/react-native/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 # gem 'bugsnag-maze-runner', path: '../../../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', '~>9.0'
+gem 'bugsnag-maze-runner', '~>10.0'
 
 # Or a branch
 # gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'integration/v8'

--- a/test/react-native/features/app-start-spans.feature
+++ b/test/react-native/features/app-start-spans.feature
@@ -6,7 +6,7 @@ Feature: App Start spans
     When I run 'AppStartScenario'
     And I relaunch the app after shutdown
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
@@ -25,15 +25,15 @@ Feature: App Start spans
   Scenario: A wrapper component provider can be provided as a config option
     When I run 'WrapperComponentProviderScenario'
     And I relaunch the app after shutdown
-    Then the element "wrapper-component" is present within 60 seconds 
-    And the element "app-component" is present within 60 seconds 
+    Then the element "wrapper-component" is present within 60 seconds
+    And the element "app-component" is present within 60 seconds
 
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
-    
+
     And the trace "Bugsnag-Span-Sampling" header equals "1:1"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[AppStart/ReactNativeInit]"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.kind" equals 3
@@ -47,7 +47,7 @@ Feature: App Start spans
   Scenario: App start span is created when using the withInstrumentedAppStarts wrapper
     When I run 'WithInstrumentedAppStartsScenario'
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
@@ -62,12 +62,12 @@ Feature: App Start spans
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "app_start"
     And the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.app_start.type" equals "ReactNativeInit"
 
-  @skip_expo  
+  @skip_expo
   Scenario: Automatic app start spans can be customized
     When I run 'AutomaticCustomAppStartScenario'
     And I relaunch the app after shutdown
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
@@ -86,7 +86,7 @@ Feature: App Start spans
   Scenario: Manual app start spans can be customized
     When I run 'ManualCustomAppStartScenario'
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"

--- a/test/react-native/features/callbacks.feature
+++ b/test/react-native/features/callbacks.feature
@@ -3,7 +3,7 @@ Feature: Span callbacks
   Scenario: Span attributes can be modified in callbacks
     When I run 'SpanCallbacksScenario'
     And I wait to receive a sampling request
-    And I wait for 2 spans
+    And I wait to receive at least 2 spans
 
     Then a span named "Span 1" contains the attributes:
       | attribute                         | type        | value                                        |

--- a/test/react-native/features/expo-router.feature
+++ b/test/react-native/features/expo-router.feature
@@ -4,7 +4,7 @@ Feature: Navigation spans with Expo Router
   Scenario: Navigation Spans are automatically instrumented
     When I run 'ExpoRouterScenario'
     And I wait to receive a sampling request
-    And I wait for 4 spans
+    And I wait to receive at least 4 spans
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"

--- a/test/react-native/features/manual-spans.feature
+++ b/test/react-native/features/manual-spans.feature
@@ -3,7 +3,7 @@ Feature: Manual spans
   Scenario: Manual Spans can be logged
     When I run 'ManualSpanScenario'
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"
@@ -44,7 +44,7 @@ Feature: Manual spans
   Scenario: Native resource attributes are recorded
     When I run 'ManualSpanScenario'
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
     Then the trace payload field "resourceSpans.0.resource" string attribute "service.name" is one of:
       | com.bugsnag.fixtures.reactnative.performance |
       | com.bugsnag.expo.fixture                     |

--- a/test/react-native/features/named-spans.feature
+++ b/test/react-native/features/named-spans.feature
@@ -3,9 +3,9 @@ Feature: Named span access plugin
   Scenario: Spans can be queried by name
     When I run 'NamedSpansPluginScenario'
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
-    Then a span named "NamedSpansPluginScenario" contains the attributes: 
-    | attribute             | type         | value  | 
+    Then a span named "NamedSpansPluginScenario" contains the attributes:
+    | attribute             | type         | value  |
     | bugsnag.span.category | stringValue  | custom |
     | custom_attribute      | boolValue    | true   |

--- a/test/react-native/features/navigation-spans.feature
+++ b/test/react-native/features/navigation-spans.feature
@@ -3,7 +3,7 @@ Feature: Navigation spans
   Scenario: Manual Navigation Spans can be logged
     When I run 'NavigationSpanScenario'
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"

--- a/test/react-native/features/network-spans.feature
+++ b/test/react-native/features/network-spans.feature
@@ -3,7 +3,7 @@ Feature: Network spans
     Scenario: Network spans are automatically instrumented for completed fetch and xhr requests
         When I run 'NetworkRequestScenario'
         And I wait to receive a sampling request
-        And I wait for 2 spans
+        And I wait to receive at least 2 spans
 
         Then a span named "[HTTP/GET]" contains the attributes:
             | attribute             | type        | value                             |

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -4,7 +4,7 @@ Feature: React native navigation support
   Scenario: Navigation spans are automatically instrumented
     When I run 'ReactNativeNavigationScenario'
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     Then a span named "[Navigation]Screen 1" contains the attributes:
       | attribute                       | type        | value                                               |
@@ -15,7 +15,7 @@ Feature: React native navigation support
 
     When I discard the oldest trace
     And I navigate to "Screen 2"
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     Then a span named "[Navigation]Screen 2" contains the attributes:
       | attribute                         | type        | value                                               |
@@ -28,7 +28,7 @@ Feature: React native navigation support
 
     When I discard the oldest trace
     And I navigate to "Screen 3"
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     Then a span named "[Navigation]Screen 3" contains the attributes:
       | attribute                         | type        | value                                               |
@@ -40,7 +40,7 @@ Feature: React native navigation support
 
     When I discard the oldest trace
     And I navigate to "Screen 4"
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     Then a span named "[Navigation]Screen 4" contains the attributes:
       | attribute                         | type        | value                                               |
@@ -54,7 +54,7 @@ Feature: React native navigation support
     When I run 'AppStartScenario'
     And I relaunch the app after shutdown
     And I wait to receive a sampling request
-    And I wait for 1 span
+    And I wait to receive at least 1 span
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"

--- a/test/react-native/features/react-navigation.feature
+++ b/test/react-native/features/react-navigation.feature
@@ -5,7 +5,7 @@ Feature: Navigation spans with React Navigation
   Scenario: Navigation Spans are automatically instrumented
     When I run 'ReactNavigationScenario'
     And I wait to receive a sampling request
-    And I wait for 5 spans
+    And I wait to receive at least 5 spans
 
     # Check the initial probability request
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1.0:0"

--- a/test/react-native/features/traceparent.feature
+++ b/test/react-native/features/traceparent.feature
@@ -4,8 +4,8 @@ Feature: Trace propagation headers
         When I run 'TracePropagationScenario'
 
         And I wait to receive 5 reflections
-        
-        And I wait for 5 spans
+
+        And I wait to receive at least 5 spans
         Then every span string attribute "http.url" matches the regex "^http(s)?:\/\/.+:\d{4}\/reflect$"
 
         And the reflection request method equals "GET"


### PR DESCRIPTION
## Goal

Use Maze Runner v10 for RN tests.

## Design

Updates for the Browser side are not included at this stage as some extra work is needed on the Cucumber steps to
avoid some heavily flaking tests.

## Testing

Covered by a CI run with the RN and Expo pipelines triggered.