### PR TITLE
(core) make core configuration optional and support default api keys in schemas

### DIFF
--- a/packages/core/lib/config.ts
+++ b/packages/core/lib/config.ts
@@ -46,7 +46,7 @@ export type OnSpanStartCallback = (span: Span) => void
 export type OnSpanStartCallbacks = OnSpanStartCallback[]
 
 export interface Configuration {
-  apiKey: string
+  apiKey?: string
   endpoint?: string
   releaseStage?: string
   logger?: Logger
@@ -200,7 +200,15 @@ if (typeof __ENABLE_BUGSNAG_TEST_CONFIGURATION__ !== 'undefined' && __ENABLE_BUG
 }
 
 export function validateConfig<S extends CoreSchema, C extends Configuration> (config: unknown, schema: S, isDevelopment = false): InternalConfiguration<C> {
-  if (typeof config === 'string') { config = { apiKey: config } }
+  // Normalize config to an object with an apiKey property
+  // If no api key is set, try to use the default value from the provided schema
+  if (typeof config === 'string') {
+    config = { apiKey: config }
+  } else if (config === null || config === undefined) {
+    config = { apiKey: schema.apiKey.defaultValue }
+  } else if (isObject(config) && config.apiKey === undefined) {
+    config.apiKey = schema.apiKey.defaultValue
+  }
 
   if (!isObject(config) || !isString(config.apiKey) || config.apiKey.length === 0) {
     throw new Error('No Bugsnag API Key set')

--- a/packages/core/lib/core.ts
+++ b/packages/core/lib/core.ts
@@ -34,7 +34,7 @@ interface Constructor<T> { new(): T, prototype: T }
 
 export interface Client<C extends Configuration> {
   appState: AppState
-  start: (config: C | string) => void
+  start: (config?: C | string) => void
   startSpan: (name: string, options?: SpanOptions) => Span
   startNetworkSpan: (options: NetworkSpanOptions) => NetworkSpan
   readonly currentSpanContext: SpanContext | undefined

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -110,6 +110,82 @@ describe('Schema validation', () => {
       jest.restoreAllMocks()
     })
 
+    describe('apiKey', () => {
+      it('accepts a valid value (string)', () => {
+        const validConfig = validateConfig(VALID_API_KEY, coreSchema)
+        expect(validConfig.apiKey).toBe(VALID_API_KEY)
+      })
+
+      it('accepts a valid value (object)', () => {
+        const validConfig = validateConfig({ apiKey: VALID_API_KEY }, coreSchema)
+        expect(validConfig.apiKey).toBe(VALID_API_KEY)
+      })
+
+      it.each([
+        { type: 'undefined', apiKey: undefined },
+        { type: 'null', apiKey: null }
+      ])('throws an error when apiKey is $type and no default value in schema', ({ apiKey }) => {
+        expect(() => { validateConfig(apiKey, coreSchema) }).toThrow('No Bugsnag API Key set')
+      })
+
+      it('throws an error when apiKey is an empty string', () => {
+        expect(() => { validateConfig('', coreSchema) }).toThrow('No Bugsnag API Key set')
+      })
+
+      it.each([
+        { type: 'undefined', apiKey: undefined },
+        { type: 'null', apiKey: null },
+        { type: 'empty string', apiKey: '' }
+      ])('throws an error when config.apiKey is $type and no default value in schema', ({ apiKey }) => {
+        expect(() => { validateConfig({ apiKey }, coreSchema) }).toThrow('No Bugsnag API Key set')
+      })
+
+      it.each([
+        { type: 'null', config: { apiKey: null } },
+        { type: 'empty string', config: { apiKey: '' } }
+      ])('throws an error when config.apiKey is $type (even with default value)', ({ config }) => {
+        const schema = {
+          ...coreSchema,
+          apiKey: {
+            ...coreSchema.apiKey,
+            defaultValue: VALID_API_KEY
+          }
+        }
+
+        expect(() => { validateConfig(config, schema) }).toThrow('No Bugsnag API Key set')
+      })
+
+      it.each([
+        { type: 'undefined', config: undefined },
+        { type: 'null', config: null },
+        { type: 'empty object', config: {} }
+      ])('uses the default value when config is $type', ({ config }) => {
+        const schema = {
+          ...coreSchema,
+          apiKey: {
+            ...coreSchema.apiKey,
+            defaultValue: VALID_API_KEY
+          }
+        }
+
+        const validConfig = validateConfig(config, schema)
+        expect(validConfig.apiKey).toBe(VALID_API_KEY)
+      })
+
+      it('uses the default value when config.apiKey is undefined', () => {
+        const schema = {
+          ...coreSchema,
+          apiKey: {
+            ...coreSchema.apiKey,
+            defaultValue: VALID_API_KEY
+          }
+        }
+
+        const validConfig = validateConfig({ apiKey: undefined }, schema)
+        expect(validConfig.apiKey).toBe(VALID_API_KEY)
+      })
+    })
+
     describe('appVersion', () => {
       it('accepts a valid value', () => {
         const config = {

--- a/packages/core/tests/core.test.ts
+++ b/packages/core/tests/core.test.ts
@@ -132,10 +132,9 @@ describe('Core', () => {
           expect(logger.warn).toHaveBeenCalledWith(`Invalid configuration\n  - endpoint should be a string, got ${type}\n  - releaseStage should be a string, got ${type}`)
         })
 
-        it('throws if no configuration is provided', () => {
+        it('throws if no API key is set', () => {
           const client = createTestClient()
 
-          // @ts-expect-error no configuration provided
           expect(() => { client.start() }).toThrow('No Bugsnag API Key set')
         })
 


### PR DESCRIPTION
## Goal

Updates how the core client configuration is validated and normalized, especially around the handling of the `apiKey` property, to allow clients to provide a default apiKey value via the schema

## Design

The `start` method of the `Client` interface now accepts an optional configuration parameter, allowing for more flexible usage.

The `apiKey` property in the `Configuration` interface is now optional, and the validation logic in `validateConfig` has been updated to normalize configuration objects and use default values from the schema when `apiKey` is missing or undefined. 

An error is still thrown if the `apiKey` is invalid after normalization. 

## Testing

Added unit tests for config validation to ensure correct error handling and defaulting behavior for `apiKey`, and fixed some typescript errors in the batch processor tests resulting from the change to an optional `apiKey` in `Configuration`