### PR TITLE
Bump build steps to macOS 15 where possible

### DIFF
--- a/.buildkite/react-native-navigation-pipeline.full.yml
+++ b/.buildkite/react-native-navigation-pipeline.full.yml
@@ -13,7 +13,7 @@ steps:
         key: "build-react-native-navigation-android-fixture-old-arch-full"
         timeout_in_minutes: 15
         agents:
-          queue: macos-12-arm
+          queue: macos-15
         env:
           BUILD_ANDROID: "true"
           JAVA_VERSION: "17"
@@ -21,7 +21,7 @@ steps:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "0"
           RN_VERSION: "{{matrix.rn_version}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.apk"
         commands:
@@ -40,7 +40,7 @@ steps:
         key: "build-react-native-navigation-android-fixture-new-arch-full"
         timeout_in_minutes: 15
         agents:
-          queue: macos-12-arm
+          queue: macos-15
         env:
           BUILD_ANDROID: "true"
           JAVA_VERSION: "17"
@@ -48,7 +48,7 @@ steps:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "1"
           RN_VERSION: "{{matrix.rn_version}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.apk"
         commands:
@@ -69,7 +69,7 @@ steps:
         key: "build-react-native-navigation-ios-fixture-old-arch-full"
         timeout_in_minutes: 15
         agents:
-          queue: "macos-12-arm"
+          queue: "macos-15"
         env:
           BUILD_IOS: "true"
           NODE_VERSION: "18"
@@ -77,7 +77,8 @@ steps:
           RCT_NEW_ARCH_ENABLED: "0"
           RN_VERSION: "{{matrix.rn_version}}"
           DEVELOPER_DIR: "/Applications/Xcode14.app"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
+          XCODE_VERSION: "16.2.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.ipa"
         commands:
@@ -98,7 +99,7 @@ steps:
       #   key: "build-react-native-navigation-ios-fixture-new-arch-full"
       #   timeout_in_minutes: 15
       #   agents:
-      #     queue: "macos-12-arm"
+      #     queue: "macos-15"
       #   env:
       #     BUILD_IOS: "true"
       #     NODE_VERSION: "18"
@@ -106,7 +107,8 @@ steps:
       #     RCT_NEW_ARCH_ENABLED: "1"
       #     RN_VERSION: "{{matrix.rn_version}}"
       #     DEVELOPER_DIR: "/Applications/Xcode14.app"
-      #     NOTIFIER_VERSION: '8.0.0'
+      #     NOTIFIER_VERSION: "8.0.0"
+      #     XCODE_VERSION: "16.2.0"
       #   artifact_paths:
       #     - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.ipa"
       #   commands:

--- a/.buildkite/react-native-navigation-pipeline.yml
+++ b/.buildkite/react-native-navigation-pipeline.yml
@@ -12,7 +12,7 @@ steps:
         key: "build-react-native-navigation-android-fixture-old-arch"
         timeout_in_minutes: 15
         agents:
-          queue: macos-12-arm
+          queue: macos-15
         env:
           BUILD_ANDROID: "true"
           JAVA_VERSION: "17"
@@ -20,7 +20,7 @@ steps:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "0"
           RN_VERSION: "{{matrix.rn_version}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.apk"
         commands:
@@ -39,7 +39,7 @@ steps:
         key: "build-react-native-navigation-android-fixture-new-arch"
         timeout_in_minutes: 15
         agents:
-          queue: macos-12-arm
+          queue: macos-15
         env:
           BUILD_ANDROID: "true"
           JAVA_VERSION: "17"
@@ -47,7 +47,7 @@ steps:
           REACT_NATIVE_NAVIGATION: "true"
           RCT_NEW_ARCH_ENABLED: "1"
           RN_VERSION: "{{matrix.rn_version}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.apk"
         commands:
@@ -68,7 +68,7 @@ steps:
         key: "build-react-native-navigation-ios-fixture-old-arch"
         timeout_in_minutes: 15
         agents:
-          queue: "macos-12-arm"
+          queue: "macos-15"
         env:
           BUILD_IOS: "true"
           NODE_VERSION: "18"
@@ -76,7 +76,8 @@ steps:
           RCT_NEW_ARCH_ENABLED: "0"
           RN_VERSION: "{{matrix.rn_version}}"
           DEVELOPER_DIR: "/Applications/Xcode14.app"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
+          XCODE_VERSION: "16.2.0"
         artifact_paths:
           - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.ipa"
         commands:
@@ -97,7 +98,7 @@ steps:
       #   key: "build-react-native-navigation-ios-fixture-new-arch"
       #   timeout_in_minutes: 15
       #   agents:
-      #     queue: "macos-12-arm"
+      #     queue: "macos-15"
       #   env:
       #     BUILD_IOS: "true"
       #     NODE_VERSION: "18"
@@ -105,7 +106,8 @@ steps:
       #     RCT_NEW_ARCH_ENABLED: "1"
       #     RN_VERSION: "{{matrix.rn_version}}"
       #     DEVELOPER_DIR: "/Applications/Xcode14.app"
-      #     NOTIFIER_VERSION: '8.0.0'
+      #     NOTIFIER_VERSION: "8.0.0"
+      #     XCODE_VERSION: "16.2.0"
       #   artifact_paths:
       #     - "test/react-native/features/fixtures/generated/react-native-navigation/**/reactnative.ipa"
       #   commands:

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -16,7 +16,7 @@ steps:
           JAVA_VERSION: "{{matrix.java}}"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix.reactnative}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "0"
           BUILD_ANDROID: "true"
         artifact_paths:
@@ -51,7 +51,7 @@ steps:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_ANDROID: "true"
         artifact_paths:
@@ -78,7 +78,7 @@ steps:
           JAVA_VERSION: "{{matrix.java}}"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix.reactnative}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_ANDROID: "true"
           RCT_NEW_ARCH_ENABLED: "0"
           NATIVE_INTEGRATION: "1"
@@ -115,7 +115,7 @@ steps:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_ANDROID: "true"
           NATIVE_INTEGRATION: "1"
@@ -143,7 +143,7 @@ steps:
         env:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
           RCT_NEW_ARCH_ENABLED: "0"
           XCODE_VERSION: "16.2.0"
@@ -172,7 +172,7 @@ steps:
         env:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
@@ -200,7 +200,7 @@ steps:
         env:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
           RCT_NEW_ARCH_ENABLED: "0"
           XCODE_VERSION: "16.2.0"
@@ -231,7 +231,7 @@ steps:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
           NATIVE_INTEGRATION: "1"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -16,7 +16,7 @@ steps:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "0"
           BUILD_ANDROID: "true"
         artifact_paths:
@@ -40,7 +40,7 @@ steps:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_ANDROID: "true"
         artifact_paths:
@@ -64,7 +64,7 @@ steps:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "0"
           BUILD_ANDROID: "true"
           NATIVE_INTEGRATION: "1"
@@ -89,7 +89,7 @@ steps:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_ANDROID: "true"
           NATIVE_INTEGRATION: "1"
@@ -114,7 +114,7 @@ steps:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "0"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
         artifact_paths:
@@ -138,7 +138,7 @@ steps:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
         artifact_paths:
@@ -162,7 +162,7 @@ steps:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "0"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
           NATIVE_INTEGRATION: "1"
@@ -187,7 +187,7 @@ steps:
           NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
-          NOTIFIER_VERSION: '8.0.0'
+          NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
           NATIVE_INTEGRATION: "1"


### PR DESCRIPTION
## Goal

Bump build steps to macOS 15 where possible.  This change removes the pipeline's dependency of our macOS 12 build servers.

## Changeset

I've also changed some single quotes to double for the sake of consistency.

## Testing

Covered by a full CI run.