### PR TITLE
Add end to end tests for system metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ x-common-environment: &common-environment
   MAZE_BUGSNAG_API_KEY:
   MAZE_APPIUM_BUGSNAG_API_KEY:
   MAZE_NO_FAIL_FAST:
+  NATIVE_INTEGRATION:
+  RCT_NEW_ARCH_ENABLED:
 
 services:
   license-finder:
@@ -79,9 +81,7 @@ services:
       BITBAR_ACCESS_KEY:
       RN_VERSION:
       EXPO_VERSION:
-      RCT_NEW_ARCH_ENABLED:
       REACT_NATIVE_NAVIGATION:
-      NATIVE_INTEGRATION:
       MAZE_REPEATER_API_KEY: "${MAZE_REPEATER_API_KEY_RN:-}"
       MAZE_HUB_REPEATER_API_KEY: "${MAZE_HUB_REPEATER_API_KEY_RN:-}"
     ports:

--- a/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/ScenarioLauncher.mm
@@ -150,7 +150,9 @@ RCT_EXPORT_METHOD(startNativePerformance:(NSDictionary *)configuration resolve:(
     config.autoInstrumentAppStarts = NO;
     config.autoInstrumentViewControllers = NO;
     config.autoInstrumentNetworkRequests = NO;
-    config.autoInstrumentRendering = YES;
+    config.enabledMetrics.cpu = YES;
+    config.enabledMetrics.memory = YES;
+    config.enabledMetrics.rendering = YES;
     config.internal.autoTriggerExportOnBatchSize = 1;
     config.internal.clearPersistenceOnStart = YES;
 

--- a/test/react-native/features/native-integration.feature
+++ b/test/react-native/features/native-integration.feature
@@ -148,3 +148,14 @@ Feature: Native Integration
         | 1.1 |
         | 2.2 |
         | 3.3 |
+
+  @ios_only
+  Scenario: System metrics are collected and attached to native spans
+    When I run 'NativeIntegrationJsParentScenario'
+    And I wait to receive 2 sampling requests
+    And I wait to receive 2 traces
+
+    And the "Native child span" span has int attribute named "bugsnag.system.memory.spaces.device.size"
+    And the "Native child span" span has int attribute named "bugsnag.system.memory.spaces.device.mean"
+    And the "Native child span" span has array attribute named "bugsnag.system.memory.spaces.device.used"
+    And the "Native child span" span has array attribute named "bugsnag.system.memory.timestamps"

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -21,6 +21,20 @@ Then('the trace payload field {string} string attribute {string} equals the plat
   end
 end
 
+Then('the {string} span has {word} attribute named {string}') do |span_name, attribute_type, attribute|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  found_spans = spans.find_all { |span| span['name'].eql?(span_name) }
+  raise Test::Unit::AssertionFailedError.new "No spans were found with the name #{span_name}" if found_spans.empty?
+  raise Test::Unit::AssertionFailedError.new "found #{found_spans.size} spans named #{span_name}, expected exactly one" unless found_spans.size == 1
+
+  attributes = found_spans.first['attributes']
+  attribute = attributes.find { |a| a['key'] == attribute }
+
+  value = attribute&.dig 'value', "#{attribute_type}Value"
+
+  Maze.check.not_nil value
+end
+
 When("I relaunch the app after shutdown") do
   max_attempts = 20
   attempts = 0


### PR DESCRIPTION
## Goal

This PR adds end-to-end tests for system metrics in the React Native integration. The changes enable CPU, memory, and rendering metrics collection and provide test infrastructure to verify these metrics are properly captured.

## Changeset

- Added a new test step to validate span attributes in traces
- Updated iOS configuration to enable individual system metrics (CPU, memory, rendering)
- Refactored Docker Compose environment variable placement