### PR TITLE
Add proguard rules to React Native Android project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - (plugin-react-navigation) Ensure navigation container is ready before initializing tracking [#755](https://github.com/bugsnag/bugsnag-js-performance/pull/755)
 
+- (react-native) Add proguard rules for React Native Android module [#766](https://github.com/bugsnag/bugsnag-js-performance/pull/766)
+
 ## [v3.3.0] (2025-11-24)
 
 ### Changed

--- a/packages/platforms/react-native/android/build.gradle
+++ b/packages/platforms/react-native/android/build.gradle
@@ -14,6 +14,10 @@ if (isNewArchitectureEnabled()) {
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 29)
 
+  defaultConfig {
+    consumerProguardFiles 'proguard-rules.pro'
+  }
+
   if (android.hasProperty('namespace')) {
     namespace 'com.bugsnag.reactnative.performance'
   }

--- a/packages/platforms/react-native/android/proguard-rules.pro
+++ b/packages/platforms/react-native/android/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Ignore warnings about unresolved references
+-dontwarn com.bugsnag.android.performance.**
+-dontwarn com.bugsnag.reactnative.performance.**


### PR DESCRIPTION
## Goal

Adds `-dontwarn` proguard rules to the React Native Android project to address potential compilation error such as those reported in #761 

## Testing

Covered by a full CI run, although I wasn't been able to reproduce the specific compilation error in the issue