### PR TITLE
test(react-native): switch to published version of Cocoa Performance …

### DIFF
--- a/test/react-native/scripts/utils/ios-utils.js
+++ b/test/react-native/scripts/utils/ios-utils.js
@@ -62,7 +62,7 @@ function installNativeTestUtilsIOS(fixtureDir) {
  */
 function installCocoaPerformance (fixtureDir) {
   const podfilePath = resolve(fixtureDir, 'ios/Podfile')
-  const performancePod = "pod 'BugsnagPerformance', :git => 'https://github.com/bugsnag/bugsnag-cocoa-performance.git', :branch => 'integration/v2'"
+  const performancePod = "pod 'BugsnagPerformance'"
   const targetSection = 'target \'reactnative\' do'
 
   replaceInFile(podfilePath, targetSection, `${targetSection}\n  ${performancePod}`)


### PR DESCRIPTION
## Goal

Updates the react native test fixtures to use the published version of Cocoa Performance now that v2 has been released, prior to merging down the integration branch

## Testing

Covered by CI