### PR TITLE
ci: fix pipeline detection script when pipeline is undefined

### DIFF
--- a/.buildkite/scripts/pipeline-trigger.js
+++ b/.buildkite/scripts/pipeline-trigger.js
@@ -28,10 +28,10 @@ packages.reverse().forEach(({ paths, block, pipeline, environment, skip }) => {
   }
 
   // Upload all pipelines if specified in the commit message
-  if (pipeline && commitMessage.includes("[full ci]") ||
+  if (pipeline && (commitMessage.includes("[full ci]") ||
     isFullBuild ||
     currentBranch === "main" ||
-    baseBranch === "main") {
+    baseBranch === "main")) {
     console.log(`Upload pipeline file: ${pipeline} with environment: '${env}'`);
     execSync(`${env} buildkite-agent pipeline upload ${pipeline}`);
     return;


### PR DESCRIPTION
## Goal

A missing parentheses in the pipeline detection script means we're trying to upload pipelines when they are undefined (as is the case for RN benchmarks)

## Testing

Tested 'manually' with a full build