### PR TITLE
Fix TLS pageload phase timings when `secureConnectionStart` is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (browser) Fix TLS PageLoadPhase span start times when `secureConnectionStart` is 0 [#781](https://github.com/bugsnag/bugsnag-js-performance/pull/781)
+
 ## [v3.4.0] (2026-01-27)
 
 ### Added

--- a/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
+++ b/packages/platforms/browser/lib/auto-instrumentation/page-load-phase-spans.ts
@@ -50,7 +50,7 @@ export const instrumentPageLoadPhaseSpans = (
     const TCPHandshakeEnd = entry.secureConnectionStart || entry.connectEnd
     createPageLoadPhaseSpan('TCPHandshake', entry.connectStart, TCPHandshakeEnd)
 
-    createPageLoadPhaseSpan('TLS', entry.secureConnectionStart, entry.connectEnd)
+    createPageLoadPhaseSpan('TLS', TCPHandshakeEnd, entry.connectEnd)
     createPageLoadPhaseSpan('HTTPRequest', entry.requestStart, entry.responseStart)
     createPageLoadPhaseSpan('HTTPResponse', entry.responseStart, entry.responseEnd)
     createPageLoadPhaseSpan('DomContentLoadedEvent', entry.domContentLoadedEventStart, entry.domContentLoadedEventEnd)


### PR DESCRIPTION
## Goal

For the `TCPHandshake` phase, we have some logic to fall back to using `connectEnd` for the endTime when `secureConnectionStart` is 0. However the `TLS` phase doesn't use this for it's start time and just uses `secureConnectionStart` directly - this means that when `secureConnectionStart` is 0 the resulting span ends up using `clock.now()` for the start time, so you end up with invalid spans where startTime  > endTime. 

This was picked up in CI on iOS 18 tests, which started failing when maze runner was updated to validate all spans in a trace. 

## Design

Updates the TLS PageLoadPhase span to use the `TCPHandshake` endTime as it's start time - this means the fall back logic is applied, so when `secureConnectionStart > 0`, it'll be used as before, otherwise it'll use `entryConnectEnd` - so we'll get a zero-duration span as opposed to startTime  > endTime.

## Testing

covered by CI