### PR TITLE
React Native: fix linker error when plugin-react-native-span-access is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - (browser) Fix TLS PageLoadPhase span start times when `secureConnectionStart` is 0 [#781](https://github.com/bugsnag/bugsnag-js-performance/pull/781)
 
+- (react-native) Fix linker error when `plugin-react-native-span-access` is not installed [#787](https://github.com/bugsnag/bugsnag-js-performance/pull/787)
+
 ## [v3.4.0] (2026-01-27)
 
 ### Added

--- a/packages/platforms/react-native/ios/BugsnagPerformanceAppStartProvider.h
+++ b/packages/platforms/react-native/ios/BugsnagPerformanceAppStartProvider.h
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Protocol for providing app start span context and handling app start completion.
+ * This allows the optional plugin-react-native-span-access package to register itself
+ * without creating a circular dependency or linker error.
+ */
+@protocol BugsnagPerformanceAppStartProvider <NSObject>
+
+/**
+ * Returns the app start parent context as a trace parent string, or nil if not available.
+ */
+- (NSString * _Nullable)getAppStartParent;
+
+/**
+ * Ends the app start span at the specified time.
+ * @param endTime the end time
+ */
+- (void)endAppStart:(NSDate *)endTime;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/platforms/react-native/ios/BugsnagPerformanceAppStartRegistry.h
+++ b/packages/platforms/react-native/ios/BugsnagPerformanceAppStartRegistry.h
@@ -1,0 +1,28 @@
+#import <Foundation/Foundation.h>
+#import "BugsnagPerformanceAppStartProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Registry for managing the AppStartProvider instance.
+ * This allows the optional plugin-react-native-span-access package to register itself
+ * without creating a circular dependency or linker error.
+ */
+@interface BugsnagPerformanceAppStartRegistry : NSObject
+
+/**
+ * Registers an AppStartProvider to handle app start span operations.
+ * This should be called by the BugsnagReactNativeAppStartPlugin during its install phase.
+ * @param provider the provider to register, or nil to unregister
+ */
++ (void)registerProvider:(nullable id<BugsnagPerformanceAppStartProvider>)provider;
+
+/**
+ * Gets the currently registered provider, or nil if none is registered.
+ * @return the registered provider, or nil
+ */
++ (nullable id<BugsnagPerformanceAppStartProvider>)provider;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/platforms/react-native/ios/BugsnagPerformanceAppStartRegistry.mm
+++ b/packages/platforms/react-native/ios/BugsnagPerformanceAppStartRegistry.mm
@@ -1,0 +1,15 @@
+#import "BugsnagPerformanceAppStartRegistry.h"
+
+@implementation BugsnagPerformanceAppStartRegistry
+
+static id<BugsnagPerformanceAppStartProvider> _Nullable _registeredProvider = nil;
+
++ (void)registerProvider:(nullable id<BugsnagPerformanceAppStartProvider>)provider {
+    _registeredProvider = provider;
+}
+
++ (nullable id<BugsnagPerformanceAppStartProvider>)provider {
+    return _registeredProvider;
+}
+
+@end

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.mm
@@ -7,13 +7,7 @@
 #import "BugsnagReactNativePerformanceSpec.h"
 #endif
 
-// Forward declaration for optional dependency on plugin-react-native-span-access
-// Declare the class and methods we need without importing the header
-@interface BugsnagReactNativeAppStartPlugin : NSObject
-+ (id _Nullable)singleton;
-- (NSString * _Nullable)getAppStartParent;
-- (void)endAppStart:(NSDate *)endTime;
-@end
+#import "BugsnagPerformanceAppStartRegistry.h"
 
 @implementation BugsnagReactNativePerformance
 
@@ -294,9 +288,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(attachToNativeSDK) {
         config[@"enabledReleaseStages"] = [nativeConfig.enabledReleaseStages allObjects];
     }
 
-    BugsnagReactNativeAppStartPlugin *plugin = [BugsnagReactNativeAppStartPlugin singleton];
-    if (plugin != nil) {
-        NSString *appStartParent = [plugin getAppStartParent];
+    id<BugsnagPerformanceAppStartProvider> appStartProvider = [BugsnagPerformanceAppStartRegistry provider];
+    if (appStartProvider != nil) {
+        NSString *appStartParent = [appStartProvider getAppStartParent];
         if (appStartParent != nil) {
             config[@"appStartParentContext"] = appStartParent;
         }
@@ -419,10 +413,10 @@ RCT_EXPORT_METHOD(discardNativeSpan:(NSString *)spanId
 RCT_EXPORT_METHOD(endNativeAppStart:(double)endTime
                 resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject) {
-    BugsnagReactNativeAppStartPlugin *plugin = [BugsnagReactNativeAppStartPlugin singleton];
-    if (plugin != nil) {
+    id<BugsnagPerformanceAppStartProvider> appStartProvider = [BugsnagPerformanceAppStartRegistry provider];
+    if (appStartProvider != nil) {
         NSDate *nativeEndTime = [NSDate dateWithTimeIntervalSince1970: endTime / NSEC_PER_SEC];
-        [plugin endAppStart:nativeEndTime];
+        [appStartProvider endAppStart:nativeEndTime];
     }
     resolve(nil);
 }

--- a/packages/platforms/react-native/ios/BugsnagReactNativePerformance.xcodeproj/project.pbxproj
+++ b/packages/platforms/react-native/ios/BugsnagReactNativePerformance.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		DAC36AB22D0CA66E0076A039 /* ReactNativeSpanAttributes.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAC36AB12D0CA66E0076A039 /* ReactNativeSpanAttributes.mm */; };
 		DAE18DD42C58DF2500D52529 /* BugsnagReactNativePerformance.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAE18DD32C58DF2500D52529 /* BugsnagReactNativePerformance.mm */; };
 		DAE18DD72C58E02C00D52529 /* BugsnagReactNativePerformance.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DAE18DD22C58DF2500D52529 /* BugsnagReactNativePerformance.h */; };
+		DAF7A51A2F4473510021ABE1 /* BugsnagPerformanceAppStartRegistry.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAF7A5192F4473510021ABE1 /* BugsnagPerformanceAppStartRegistry.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -38,6 +39,9 @@
 		DAC36AB12D0CA66E0076A039 /* ReactNativeSpanAttributes.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ReactNativeSpanAttributes.mm; sourceTree = "<group>"; };
 		DAE18DD22C58DF2500D52529 /* BugsnagReactNativePerformance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagReactNativePerformance.h; sourceTree = "<group>"; };
 		DAE18DD32C58DF2500D52529 /* BugsnagReactNativePerformance.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagReactNativePerformance.mm; sourceTree = "<group>"; };
+		DAF7A5172F4473510021ABE1 /* BugsnagPerformanceAppStartProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceAppStartProvider.h; sourceTree = "<group>"; };
+		DAF7A5182F4473510021ABE1 /* BugsnagPerformanceAppStartRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagPerformanceAppStartRegistry.h; sourceTree = "<group>"; };
+		DAF7A5192F4473510021ABE1 /* BugsnagPerformanceAppStartRegistry.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BugsnagPerformanceAppStartRegistry.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +66,9 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				DAF7A5172F4473510021ABE1 /* BugsnagPerformanceAppStartProvider.h */,
+				DAF7A5182F4473510021ABE1 /* BugsnagPerformanceAppStartRegistry.h */,
+				DAF7A5192F4473510021ABE1 /* BugsnagPerformanceAppStartRegistry.mm */,
 				DAC36AB12D0CA66E0076A039 /* ReactNativeSpanAttributes.mm */,
 				DAC36AB02D0CA64F0076A039 /* ReactNativeSpanAttributes.h */,
 				DA434CE02D09ACE000C62B2F /* BugsnagPerformanceSpanOptions.h */,
@@ -135,6 +142,7 @@
 			files = (
 				DAC36AB22D0CA66E0076A039 /* ReactNativeSpanAttributes.mm in Sources */,
 				DA396E142CCFD327009B37C2 /* BugsnagReactNativePerformanceCrossTalkAPIClient.mm in Sources */,
+				DAF7A51A2F4473510021ABE1 /* BugsnagPerformanceAppStartRegistry.mm in Sources */,
 				DAE18DD42C58DF2500D52529 /* BugsnagReactNativePerformance.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/packages/plugin-react-native-span-access/BugsnagNativeSpans.podspec
+++ b/packages/plugin-react-native-span-access/BugsnagNativeSpans.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency 'BugsnagPerformance'
+  s.dependency 'BugsnagReactNativePerformance'
 
   if ENV["RCT_NEW_ARCH_ENABLED"] == "1"
     install_modules_dependencies(s)

--- a/packages/plugin-react-native-span-access/ios/BugsnagReactNativeAppStartPlugin.h
+++ b/packages/plugin-react-native-span-access/ios/BugsnagReactNativeAppStartPlugin.h
@@ -1,9 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <BugsnagPerformance/BugsnagPerformancePlugin.h>
+#import <BugsnagReactNativePerformance/BugsnagPerformanceAppStartProvider.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BugsnagReactNativeAppStartPlugin: NSObject <BugsnagPerformancePlugin>
+@interface BugsnagReactNativeAppStartPlugin: NSObject <BugsnagPerformancePlugin, BugsnagPerformanceAppStartProvider>
 
 - (instancetype)init;
 - (instancetype)initWithTimeout:(NSTimeInterval)timeout;

--- a/packages/plugin-react-native-span-access/ios/BugsnagReactNativeAppStartPlugin.mm
+++ b/packages/plugin-react-native-span-access/ios/BugsnagReactNativeAppStartPlugin.mm
@@ -4,6 +4,7 @@
 #import <BugsnagPerformance/BugsnagPerformanceSpan.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanCondition.h>
 #import <BugsnagPerformance/BugsnagPerformanceSpanContext.h>
+#import <BugsnagReactNativePerformance/BugsnagPerformanceAppStartRegistry.h>
 
 static const NSTimeInterval kDefaultSpanBlockTimeoutInterval = 5; // 5s default timeout
 
@@ -22,8 +23,6 @@ static const NSTimeInterval kDefaultSpanBlockTimeoutInterval = 5; // 5s default 
 
 @implementation BugsnagReactNativeAppStartPlugin
 
-static BugsnagReactNativeAppStartPlugin *_sharedInstance = nil;
-
 - (instancetype)init {
     return [self initWithTimeout:kDefaultSpanBlockTimeoutInterval];
 }
@@ -35,12 +34,9 @@ static BugsnagReactNativeAppStartPlugin *_sharedInstance = nil;
     return self;
 }
 
-+ (id)singleton {
-    return _sharedInstance;
-}
-
 - (void)installWithContext:(BugsnagPerformancePluginContext *)context {
-     _sharedInstance = self;
+    // Register this plugin as the AppStartProvider with the core React Native Performance module
+    [BugsnagPerformanceAppStartRegistry registerProvider:self];
     __weak BugsnagReactNativeAppStartPlugin *weakSelf = self;
     
     // Add span start callback with high priority (equivalent to NORM_PRIORITY + 1)


### PR DESCRIPTION
## Goal

The `BugsnagReactNativeAppStartPlugin` implementation is provided by the optional `plugin-react-native-span-access` module, but we still had a direct reference to the plugin in the main React Native SDK, causing linker errors when the optional module is not installed (as reported in #785)

This PR fixes the issue by removing the plugin reference and implementing a `BugsnagPerformanceAppStartProvider` and `BugsnagPerformanceAppStartRegistry` similar to the Android implementation.

## Design

The `BugsnagReactNativeAppStartPlugin` now registers itself with the `BugsnagPerformanceAppStartRegistry` during the install phase, and the main SDK now looks for a registered `BugsnagPerformanceAppStartProvider` instead of calling the plugin instance directly.

## Testing

Existing app start tests covered by CI, plus some additional manual testing to ensure that projects still build and run successfully when the optional module is not installed.