### PR TITLE
Bugsnag performance SDK support react native updated version 0.84

### DIFF
--- a/.buildkite/react-native-pipeline.benchmark.yml
+++ b/.buildkite/react-native-pipeline.benchmark.yml
@@ -14,7 +14,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
@@ -39,7 +39,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           NOTIFIER_VERSION: "8.0.0"

--- a/.buildkite/react-native-pipeline.benchmark.yml
+++ b/.buildkite/react-native-pipeline.benchmark.yml
@@ -27,7 +27,7 @@ steps:
           - bundle install
           - node test/react-native/scripts/generate-react-native-fixture.js
         matrix:
-          - "0.80"
+          - "0.84"
         retry:
           automatic:
             - exit_status: "*"
@@ -53,7 +53,7 @@ steps:
           - bundle install
           - node test/react-native/scripts/generate-react-native-fixture.js
         matrix:
-          - "0.80"
+          - "0.84"
         retry:
           automatic:
             - exit_status: "*"
@@ -106,7 +106,7 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.84"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS Benchmarks"
         depends_on: "build-react-native-ios-fixture-benchmark-new-arch"
@@ -152,4 +152,4 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.84"

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -41,6 +41,7 @@ steps:
             - with:
                 reactnative: "0.64"
                 java: "11"
+                node: "18"
         retry:
           automatic:
             - exit_status: "*"
@@ -120,6 +121,7 @@ steps:
             - with:
                 reactnative: "0.64"
                 java: "11"
+                node: "18"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -14,7 +14,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "{{matrix.java}}"
-          NODE_VERSION: "18"
+          NODE_VERSION: "{{matrix.node}}"
           RN_VERSION: "{{matrix.reactnative}}"
           NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "0"
@@ -35,6 +35,8 @@ steps:
               - "0.81"
             java:
               - "17"
+            node:
+              - "22"
           adjustments:
             - with:
                 reactnative: "0.64"
@@ -51,7 +53,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix.reactnative}}"
           NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
@@ -88,7 +90,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "{{matrix.java}}"
-          NODE_VERSION: "18"
+          NODE_VERSION: {{matrix.node}}
           RN_VERSION: "{{matrix.reactnative}}"
           NOTIFIER_VERSION: "8.0.0"
           BUILD_ANDROID: "true"
@@ -112,6 +114,8 @@ steps:
              
             java:
               - "17"
+            node:
+              - "22"
           adjustments:
             - with:
                 reactnative: "0.64"
@@ -128,7 +132,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
@@ -159,7 +163,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
@@ -190,7 +194,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix.reactnative}}"
           NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
@@ -228,7 +232,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           NOTIFIER_VERSION: "8.0.0"
           BUILD_IOS: "true"
@@ -260,7 +264,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           NOTIFIER_VERSION: "8.0.0"

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -31,7 +31,8 @@ steps:
               - "0.74"
               - "0.76"
               - "0.78"
-              - "0.79"
+              - "0.80"
+              - "0.81"
             java:
               - "17"
           adjustments:
@@ -66,7 +67,9 @@ steps:
               - "0.74"
               - "0.76"
               - "0.78"
-              - "0.79"
+              - "0.80"
+              - "0.82"
+              - "0.83"
             reactnavigation:
               - "true"
           adjustments:
@@ -104,7 +107,9 @@ steps:
               - "0.74"
               - "0.76"
               - "0.78"
-              - "0.79"
+              - "0.80"
+              - "0.81"
+             
             java:
               - "17"
           adjustments:
@@ -140,7 +145,9 @@ steps:
             - "0.74"
             - "0.76"
             - "0.78"
-            - "0.79"
+            - "0.80"
+            - "0.82"
+            - "0.83"
         retry:
           automatic:
             - exit_status: "*"
@@ -170,7 +177,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
         retry:
           automatic:
             - exit_status: "*"
@@ -200,7 +208,9 @@ steps:
               - "0.74"
               - "0.76"
               - "0.78"
-              - "0.79"
+              - "0.80"
+              - "0.82"
+              - "0.83"
             reactnavigation:
               - "true"
           adjustments:
@@ -237,7 +247,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
         retry:
           automatic:
             - exit_status: "*"
@@ -267,7 +278,9 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.82"
+          - "0.83"
         retry:
           automatic:
             - exit_status: "*"
@@ -321,7 +334,9 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
+             
 
       - label: ":bitbar: :android: RN {{matrix.reactnative}} Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch-full"
@@ -369,7 +384,9 @@ steps:
               - "0.74"
               - "0.76"
               - "0.78"
-              - "0.79"
+              - "0.80"
+              - "0.82"
+              - "0.83"
             reactnavigation:
               - "true"
           adjustments:
@@ -423,7 +440,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
 
       - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-native-integration-new-arch-full"
@@ -471,7 +489,9 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.82"
+          - "0.83"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (Old Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-old-arch-full"
@@ -518,7 +538,9 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
+         
 
       - label: ":bitbar: :mac: RN {{matrix.reactnative}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch-full"
@@ -566,7 +588,9 @@ steps:
               - "0.74"
               - "0.76"
               - "0.78"
-              - "0.79"
+              - "0.80"
+              - "0.82"
+              - "0.83"
             reactnavigation:
               - "true"
           adjustments:
@@ -620,7 +644,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
 
       - label: ":bitbar: :mac: RN {{matrix}} native integration iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-native-integration-new-arch-full"
@@ -668,4 +693,6 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.82"
+          - "0.83"

--- a/.buildkite/react-native-pipeline.full.yml
+++ b/.buildkite/react-native-pipeline.full.yml
@@ -90,7 +90,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "{{matrix.java}}"
-          NODE_VERSION: {{matrix.node}}
+          NODE_VERSION: "{{matrix.node}}"
           RN_VERSION: "{{matrix.reactnative}}"
           NOTIFIER_VERSION: "8.0.0"
           BUILD_ANDROID: "true"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -7,30 +7,30 @@ steps:
       #
       # Test fixtures
       #
-      - label: ':android: Build RN {{matrix}} test fixture APK (Old Arch)'
-        key: "build-react-native-android-fixture-old-arch"
-        timeout_in_minutes: 30
-        agents:
-          queue: macos-15
-        env:
-          JAVA_VERSION: "17"
-          NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: "8.0.0"
-          RCT_NEW_ARCH_ENABLED: "0"
-          BUILD_ANDROID: "true"
-          REACT_NAVIGATION: "true"
-        artifact_paths:
-          - "test/react-native/features/fixtures/generated/old-arch/**/reactnative.apk"
-        commands:
-          - bundle install
-          - node test/react-native/scripts/generate-react-native-fixture.js
-        matrix:
-          - "0.80"
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
+      # - label: ':android: Build RN {{matrix}} test fixture APK (Old Arch)'
+      #   key: "build-react-native-android-fixture-old-arch"
+      #   timeout_in_minutes: 30
+      #   agents:
+      #     queue: macos-15
+      #   env:
+      #     JAVA_VERSION: "17"
+      #     NODE_VERSION: "18"
+      #     RN_VERSION: "{{matrix}}"
+      #     NOTIFIER_VERSION: "8.0.0"
+      #     RCT_NEW_ARCH_ENABLED: "0"
+      #     BUILD_ANDROID: "true"
+      #     REACT_NAVIGATION: "true"
+      #   artifact_paths:
+      #     - "test/react-native/features/fixtures/generated/old-arch/**/reactnative.apk"
+      #   commands:
+      #     - bundle install
+      #     - node test/react-native/scripts/generate-react-native-fixture.js
+      #   matrix:
+      #     - "0.80"
+      #   retry:
+      #     automatic:
+      #       - exit_status: "*"
+      #         limit: 1
 
       - label: ':android: Build RN {{matrix}} test fixture APK (New Arch)'
         key: "build-react-native-android-fixture-new-arch"
@@ -51,36 +51,36 @@ steps:
           - bundle install
           - node test/react-native/scripts/generate-react-native-fixture.js
         matrix:
-          - "0.80"
+          - "0.84"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: ':android: Build RN {{matrix}} native integration test fixture APK (Old Arch)'
-        key: "build-react-native-android-fixture-native-integration-old-arch"
-        timeout_in_minutes: 30
-        agents:
-          queue: macos-15
-        env:
-          JAVA_VERSION: "17"
-          NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
-          NOTIFIER_VERSION: "8.0.0"
-          RCT_NEW_ARCH_ENABLED: "0"
-          BUILD_ANDROID: "true"
-          NATIVE_INTEGRATION: "1"
-        artifact_paths:
-          - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/reactnative.apk"
-        commands:
-          - bundle install
-          - node test/react-native/scripts/generate-react-native-fixture.js
-        matrix:
-          - "0.80"
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
+      # - label: ':android: Build RN {{matrix}} native integration test fixture APK (Old Arch)'
+      #   key: "build-react-native-android-fixture-native-integration-old-arch"
+      #   timeout_in_minutes: 30
+      #   agents:
+      #     queue: macos-15
+      #   env:
+      #     JAVA_VERSION: "17"
+      #     NODE_VERSION: "18"
+      #     RN_VERSION: "{{matrix}}"
+      #     NOTIFIER_VERSION: "8.0.0"
+      #     RCT_NEW_ARCH_ENABLED: "0"
+      #     BUILD_ANDROID: "true"
+      #     NATIVE_INTEGRATION: "1"
+      #   artifact_paths:
+      #     - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/reactnative.apk"
+      #   commands:
+      #     - bundle install
+      #     - node test/react-native/scripts/generate-react-native-fixture.js
+      #   matrix:
+      #     - "0.80"
+      #   retry:
+      #     automatic:
+      #       - exit_status: "*"
+      #         limit: 1
 
       - label: ':android: Build RN {{matrix}} native integration test fixture APK (New Arch)'
         key: "build-react-native-android-fixture-native-integration-new-arch"
@@ -101,36 +101,36 @@ steps:
           - bundle install
           - node test/react-native/scripts/generate-react-native-fixture.js
         matrix:
-          - "0.80"
+          - "0.84"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
-        key: "build-react-native-ios-fixture-old-arch"
-        timeout_in_minutes: 30
-        agents:
-          queue: "macos-15"
-        env:
-          NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
-          NOTIFIER_VERSION: "8.0.0"
-          BUILD_IOS: "true"
-          XCODE_VERSION: "16.2.0"
-          REACT_NAVIGATION: "true"
-        artifact_paths:
-          - "test/react-native/features/fixtures/generated/old-arch/**/output/reactnative.ipa"
-        commands:
-          - bundle install
-          - node test/react-native/scripts/generate-react-native-fixture.js
-        matrix:
-          - "0.80"
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
+      # - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
+      #   key: "build-react-native-ios-fixture-old-arch"
+      #   timeout_in_minutes: 30
+      #   agents:
+      #     queue: "macos-15"
+      #   env:
+      #     NODE_VERSION: "18"
+      #     RN_VERSION: "{{matrix}}"
+      #     RCT_NEW_ARCH_ENABLED: "0"
+      #     NOTIFIER_VERSION: "8.0.0"
+      #     BUILD_IOS: "true"
+      #     XCODE_VERSION: "16.2.0"
+      #     REACT_NAVIGATION: "true"
+      #   artifact_paths:
+      #     - "test/react-native/features/fixtures/generated/old-arch/**/output/reactnative.ipa"
+      #   commands:
+      #     - bundle install
+      #     - node test/react-native/scripts/generate-react-native-fixture.js
+      #   matrix:
+      #     - "0.80"
+      #   retry:
+      #     automatic:
+      #       - exit_status: "*"
+      #         limit: 1
 
       - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
         key: "build-react-native-ios-fixture-new-arch"
@@ -151,36 +151,36 @@ steps:
           - bundle install
           - node test/react-native/scripts/generate-react-native-fixture.js
         matrix:
-          - "0.80"
+          - "0.84"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 #
-      - label: ':mac: Build RN {{matrix}} native integration test fixture ipa (Old Arch)'
-        key: "build-react-native-ios-fixture-native-integration-old-arch"
-        timeout_in_minutes: 30
-        agents:
-          queue: "macos-15"
-        env:
-          NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
-          NOTIFIER_VERSION: "8.0.0"
-          BUILD_IOS: "true"
-          XCODE_VERSION: "16.2.0"
-          NATIVE_INTEGRATION: "1"
-        artifact_paths:
-          - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/output/reactnative.ipa"
-        commands:
-          - bundle install
-          - node test/react-native/scripts/generate-react-native-fixture.js
-        matrix:
-          - "0.80"
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
+      # - label: ':mac: Build RN {{matrix}} native integration test fixture ipa (Old Arch)'
+      #   key: "build-react-native-ios-fixture-native-integration-old-arch"
+      #   timeout_in_minutes: 30
+      #   agents:
+      #     queue: "macos-15"
+      #   env:
+      #     NODE_VERSION: "18"
+      #     RN_VERSION: "{{matrix}}"
+      #     RCT_NEW_ARCH_ENABLED: "0"
+      #     NOTIFIER_VERSION: "8.0.0"
+      #     BUILD_IOS: "true"
+      #     XCODE_VERSION: "16.2.0"
+      #     NATIVE_INTEGRATION: "1"
+      #   artifact_paths:
+      #     - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/output/reactnative.ipa"
+      #   commands:
+      #     - bundle install
+      #     - node test/react-native/scripts/generate-react-native-fixture.js
+      #   matrix:
+      #     - "0.80"
+      #   retry:
+      #     automatic:
+      #       - exit_status: "*"
+      #         limit: 1
 
       - label: ':mac: Build RN {{matrix}} native integration test fixture ipa (New Arch)'
         key: "build-react-native-ios-fixture-native-integration-new-arch"
@@ -201,7 +201,7 @@ steps:
           - bundle install
           - node test/react-native/scripts/generate-react-native-fixture.js
         matrix:
-          - "0.80"
+          - "0.84"
         retry:
           automatic:
             - exit_status: "*"
@@ -210,47 +210,47 @@ steps:
         #
         # End-to-end tests
         #
-      - label: ":bitbar: :android: RN {{matrix}} Android 13 (Old Arch) end-to-end tests"
-        depends_on: "build-react-native-android-fixture-old-arch"
-        timeout_in_minutes: 20
-        plugins:
-          artifacts#v1.9.0:
-            download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk"
-            upload:
-              - "./test/react-native/maze_output/failed/*"
-              - "./test/react-native/maze_output/maze_output.zip"
-          docker-compose#v4.7.0:
-            pull: react-native-maze-runner
-            run: react-native-maze-runner
-            service-ports: true
-            command:
-              - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
-              - --farm=bb
-              - --device=ANDROID_13
-              - --a11y-locator
-              - --fail-fast
-              - --appium-version=1.22
-              - --no-tunnel
-              - --aws-public-ip
-          test-collector#v1.10.2:
-            files: "reports/TEST-*.xml"
-            format: "junit"
-            branch: "^main|next$$"
-            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-        env:
-          RN_VERSION: "{{matrix}}"
-          REACT_NAVIGATION: "true"
-        retry:
-          manual:
-            permit_on_passed: true
-          automatic:
-            - exit_status: 103  # Appium session failed
-              limit: 2
-        concurrency: 25
-        concurrency_group: "bitbar"
-        concurrency_method: eager
-        matrix:
-          - "0.80"
+      # - label: ":bitbar: :android: RN {{matrix}} Android 13 (Old Arch) end-to-end tests"
+      #   depends_on: "build-react-native-android-fixture-old-arch"
+      #   timeout_in_minutes: 20
+      #   plugins:
+      #     artifacts#v1.9.0:
+      #       download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk"
+      #       upload:
+      #         - "./test/react-native/maze_output/failed/*"
+      #         - "./test/react-native/maze_output/maze_output.zip"
+      #     docker-compose#v4.7.0:
+      #       pull: react-native-maze-runner
+      #       run: react-native-maze-runner
+      #       service-ports: true
+      #       command:
+      #         - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
+      #         - --farm=bb
+      #         - --device=ANDROID_13
+      #         - --a11y-locator
+      #         - --fail-fast
+      #         - --appium-version=1.22
+      #         - --no-tunnel
+      #         - --aws-public-ip
+      #     test-collector#v1.10.2:
+      #       files: "reports/TEST-*.xml"
+      #       format: "junit"
+      #       branch: "^main|next$$"
+      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+      #   env:
+      #     RN_VERSION: "{{matrix}}"
+      #     REACT_NAVIGATION: "true"
+      #   retry:
+      #     manual:
+      #       permit_on_passed: true
+      #     automatic:
+      #       - exit_status: 103  # Appium session failed
+      #         limit: 2
+      #   concurrency: 25
+      #   concurrency_group: "bitbar"
+      #   concurrency_method: eager
+      #   matrix:
+      #     - "0.80"
 
       - label: ":bitbar: :android: RN {{matrix}} Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
@@ -293,50 +293,50 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.84"
 
-      - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (Old Arch) end-to-end tests"
-        depends_on: "build-react-native-android-fixture-native-integration-old-arch"
-        timeout_in_minutes: 20
-        plugins:
-          artifacts#v1.9.0:
-            download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk"
-            upload:
-              - "./test/react-native/maze_output/failed/*"
-              - "./test/react-native/maze_output/maze_output.zip"
-          docker-compose#v4.7.0:
-            pull: react-native-maze-runner
-            run: react-native-maze-runner
-            service-ports: true
-            command:
-              - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk
-              - --farm=bb
-              - --device=ANDROID_13
-              - --a11y-locator
-              - --fail-fast
-              - --appium-version=1.22
-              - --no-tunnel
-              - --aws-public-ip
-              - --tags=@native_integration
-          test-collector#v1.10.2:
-            files: "reports/TEST-*.xml"
-            format: "junit"
-            branch: "^main|next$$"
-            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-        env:
-          NATIVE_INTEGRATION: "1"
-          RN_VERSION: "{{matrix}}"
-        retry:
-          manual:
-            permit_on_passed: true
-          automatic:
-            - exit_status: 103  # Appium session failed
-              limit: 2
-        concurrency: 25
-        concurrency_group: "bitbar"
-        concurrency_method: eager
-        matrix:
-          - "0.80"
+      # - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (Old Arch) end-to-end tests"
+      #   depends_on: "build-react-native-android-fixture-native-integration-old-arch"
+      #   timeout_in_minutes: 20
+      #   plugins:
+      #     artifacts#v1.9.0:
+      #       download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk"
+      #       upload:
+      #         - "./test/react-native/maze_output/failed/*"
+      #         - "./test/react-native/maze_output/maze_output.zip"
+      #     docker-compose#v4.7.0:
+      #       pull: react-native-maze-runner
+      #       run: react-native-maze-runner
+      #       service-ports: true
+      #       command:
+      #         - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk
+      #         - --farm=bb
+      #         - --device=ANDROID_13
+      #         - --a11y-locator
+      #         - --fail-fast
+      #         - --appium-version=1.22
+      #         - --no-tunnel
+      #         - --aws-public-ip
+      #         - --tags=@native_integration
+      #     test-collector#v1.10.2:
+      #       files: "reports/TEST-*.xml"
+      #       format: "junit"
+      #       branch: "^main|next$$"
+      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+      #   env:
+      #     NATIVE_INTEGRATION: "1"
+      #     RN_VERSION: "{{matrix}}"
+      #   retry:
+      #     manual:
+      #       permit_on_passed: true
+      #     automatic:
+      #       - exit_status: 103  # Appium session failed
+      #         limit: 2
+      #   concurrency: 25
+      #   concurrency_group: "bitbar"
+      #   concurrency_method: eager
+      #   matrix:
+      #     - "0.80"
 
       - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-native-integration-new-arch"
@@ -380,49 +380,49 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.84"
 
-      - label: ":bitbar: :mac: RN {{matrix}} iOS (Old Arch) end-to-end tests"
-        depends_on: "build-react-native-ios-fixture-old-arch"
-        timeout_in_minutes: 20
-        plugins:
-          artifacts#v1.9.0:
-            download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa"
-            upload:
-              - "./test/react-native/maze_output/failed/*"
-              - "./test/react-native/maze_output/maze_output.zip"
-          docker-compose#v4.12.0:
-            pull: react-native-maze-runner
-            run: react-native-maze-runner
-            service-ports: true
-            command:
-              - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
-              - --farm=bb
-              - --device=IOS_14|IOS_15|IOS_16|IOS_17|IOS_18|IOS_26
-              - --a11y-locator
-              - --fail-fast
-              - --appium-version=1.22
-              - --no-tunnel
-              - --aws-public-ip
-          test-collector#v1.10.2:
-            files: "reports/TEST-*.xml"
-            format: "junit"
-            branch: "^main|next$$"
-            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-        env:
-          RN_VERSION: "{{matrix}}"
-          REACT_NAVIGATION: "true"
-        retry:
-          manual:
-            permit_on_passed: true
-          automatic:
-            - exit_status: 103  # Appium session failed
-              limit: 2
-        concurrency: 25
-        concurrency_group: "bitbar"
-        concurrency_method: eager
-        matrix:
-          - "0.80"
+      #  - label: ":bitbar: :mac: RN {{matrix}} iOS (Old Arch) end-to-end tests"
+      #   depends_on: "build-react-native-ios-fixture-old-arch"
+      #   timeout_in_minutes: 20
+      #   plugins:
+      #     artifacts#v1.9.0:
+      #       download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa"
+      #       upload:
+      #         - "./test/react-native/maze_output/failed/*"
+      #         - "./test/react-native/maze_output/maze_output.zip"
+      #     docker-compose#v4.12.0:
+      #       pull: react-native-maze-runner
+      #       run: react-native-maze-runner
+      #       service-ports: true
+      #       command:
+      #         - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
+      #         - --farm=bb
+      #         - --device=IOS_14|IOS_15|IOS_16|IOS_17|IOS_18|IOS_26
+      #         - --a11y-locator
+      #         - --fail-fast
+      #         - --appium-version=1.22
+      #         - --no-tunnel
+      #         - --aws-public-ip
+      #     test-collector#v1.10.2:
+      #       files: "reports/TEST-*.xml"
+      #       format: "junit"
+      #       branch: "^main|next$$"
+      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+      #   env:
+      #     RN_VERSION: "{{matrix}}"
+      #     REACT_NAVIGATION: "true"
+      #   retry:
+      #     manual:
+      #       permit_on_passed: true
+      #     automatic:
+      #       - exit_status: 103  # Appium session failed
+      #         limit: 2
+      #   concurrency: 25
+      #   concurrency_group: "bitbar"
+      #   concurrency_method: eager
+      #   matrix:
+      #     - "0.80"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"
@@ -465,50 +465,50 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.84"
 
-      - label: ":bitbar: :mac: RN {{matrix}} native integration iOS (Old Arch) end-to-end tests"
-        depends_on: "build-react-native-ios-fixture-native-integration-old-arch"
-        timeout_in_minutes: 20
-        plugins:
-          artifacts#v1.9.0:
-            download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa"
-            upload:
-              - "./test/react-native/maze_output/failed/*"
-              - "./test/react-native/maze_output/maze_output.zip"
-          docker-compose#v4.12.0:
-            pull: react-native-maze-runner
-            run: react-native-maze-runner
-            service-ports: true
-            command:
-              - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa
-              - --farm=bb
-              - --device=IOS_14|IOS_15|IOS_16|IOS_17|IOS_18|IOS_26
-              - --a11y-locator
-              - --fail-fast
-              - --appium-version=1.22
-              - --no-tunnel
-              - --aws-public-ip
-              - --tags=@native_integration
-          test-collector#v1.10.2:
-            files: "reports/TEST-*.xml"
-            format: "junit"
-            branch: "^main|next$$"
-            api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-        env:
-          NATIVE_INTEGRATION: "1"
-          RN_VERSION: "{{matrix}}"
-        retry:
-          manual:
-            permit_on_passed: true
-          automatic:
-            - exit_status: 103  # Appium session failed
-              limit: 2
-        concurrency: 25
-        concurrency_group: "bitbar"
-        concurrency_method: eager
-        matrix:
-          - "0.80"
+      # - label: ":bitbar: :mac: RN {{matrix}} native integration iOS (Old Arch) end-to-end tests"
+      #   depends_on: "build-react-native-ios-fixture-native-integration-old-arch"
+      #   timeout_in_minutes: 20
+      #   plugins:
+      #     artifacts#v1.9.0:
+      #       download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa"
+      #       upload:
+      #         - "./test/react-native/maze_output/failed/*"
+      #         - "./test/react-native/maze_output/maze_output.zip"
+      #     docker-compose#v4.12.0:
+      #       pull: react-native-maze-runner
+      #       run: react-native-maze-runner
+      #       service-ports: true
+      #       command:
+      #         - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa
+      #         - --farm=bb
+      #         - --device=IOS_14|IOS_15|IOS_16|IOS_17|IOS_18|IOS_26
+      #         - --a11y-locator
+      #         - --fail-fast
+      #         - --appium-version=1.22
+      #         - --no-tunnel
+      #         - --aws-public-ip
+      #         - --tags=@native_integration
+      #     test-collector#v1.10.2:
+      #       files: "reports/TEST-*.xml"
+      #       format: "junit"
+      #       branch: "^main|next$$"
+      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
+      #   env:
+      #     NATIVE_INTEGRATION: "1"
+      #     RN_VERSION: "{{matrix}}"
+      #   retry:
+      #     manual:
+      #       permit_on_passed: true
+      #     automatic:
+      #       - exit_status: 103  # Appium session failed
+      #         limit: 2
+      #   concurrency: 25
+      #   concurrency_group: "bitbar"
+      #   concurrency_method: eager
+      #   matrix:
+      #     - "0.80"
 
       - label: ":bitbar: :mac: RN {{matrix}} native integration iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-native-integration-new-arch"
@@ -552,4 +552,4 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.84"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -39,7 +39,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
@@ -89,7 +89,7 @@ steps:
           queue: macos-15
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           NOTIFIER_VERSION: "8.0.0"
           RCT_NEW_ARCH_ENABLED: "1"
@@ -138,7 +138,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           NOTIFIER_VERSION: "8.0.0"
@@ -188,7 +188,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           NOTIFIER_VERSION: "8.0.0"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -4,34 +4,7 @@ agents:
 steps:
   - group: "React Native Tests"
     steps:
-      #
-      # Test fixtures
-      #
-      # - label: ':android: Build RN {{matrix}} test fixture APK (Old Arch)'
-      #   key: "build-react-native-android-fixture-old-arch"
-      #   timeout_in_minutes: 30
-      #   agents:
-      #     queue: macos-15
-      #   env:
-      #     JAVA_VERSION: "17"
-      #     NODE_VERSION: "18"
-      #     RN_VERSION: "{{matrix}}"
-      #     NOTIFIER_VERSION: "8.0.0"
-      #     RCT_NEW_ARCH_ENABLED: "0"
-      #     BUILD_ANDROID: "true"
-      #     REACT_NAVIGATION: "true"
-      #   artifact_paths:
-      #     - "test/react-native/features/fixtures/generated/old-arch/**/reactnative.apk"
-      #   commands:
-      #     - bundle install
-      #     - node test/react-native/scripts/generate-react-native-fixture.js
-      #   matrix:
-      #     - "0.80"
-      #   retry:
-      #     automatic:
-      #       - exit_status: "*"
-      #         limit: 1
-
+   
       - label: ':android: Build RN {{matrix}} test fixture APK (New Arch)'
         key: "build-react-native-android-fixture-new-arch"
         timeout_in_minutes: 30
@@ -57,30 +30,7 @@ steps:
             - exit_status: "*"
               limit: 1
 
-      # - label: ':android: Build RN {{matrix}} native integration test fixture APK (Old Arch)'
-      #   key: "build-react-native-android-fixture-native-integration-old-arch"
-      #   timeout_in_minutes: 30
-      #   agents:
-      #     queue: macos-15
-      #   env:
-      #     JAVA_VERSION: "17"
-      #     NODE_VERSION: "18"
-      #     RN_VERSION: "{{matrix}}"
-      #     NOTIFIER_VERSION: "8.0.0"
-      #     RCT_NEW_ARCH_ENABLED: "0"
-      #     BUILD_ANDROID: "true"
-      #     NATIVE_INTEGRATION: "1"
-      #   artifact_paths:
-      #     - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/reactnative.apk"
-      #   commands:
-      #     - bundle install
-      #     - node test/react-native/scripts/generate-react-native-fixture.js
-      #   matrix:
-      #     - "0.80"
-      #   retry:
-      #     automatic:
-      #       - exit_status: "*"
-      #         limit: 1
+  
 
       - label: ':android: Build RN {{matrix}} native integration test fixture APK (New Arch)'
         key: "build-react-native-android-fixture-native-integration-new-arch"
@@ -107,30 +57,7 @@ steps:
             - exit_status: "*"
               limit: 1
 
-      # - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
-      #   key: "build-react-native-ios-fixture-old-arch"
-      #   timeout_in_minutes: 30
-      #   agents:
-      #     queue: "macos-15"
-      #   env:
-      #     NODE_VERSION: "18"
-      #     RN_VERSION: "{{matrix}}"
-      #     RCT_NEW_ARCH_ENABLED: "0"
-      #     NOTIFIER_VERSION: "8.0.0"
-      #     BUILD_IOS: "true"
-      #     XCODE_VERSION: "16.2.0"
-      #     REACT_NAVIGATION: "true"
-      #   artifact_paths:
-      #     - "test/react-native/features/fixtures/generated/old-arch/**/output/reactnative.ipa"
-      #   commands:
-      #     - bundle install
-      #     - node test/react-native/scripts/generate-react-native-fixture.js
-      #   matrix:
-      #     - "0.80"
-      #   retry:
-      #     automatic:
-      #       - exit_status: "*"
-      #         limit: 1
+  
 
       - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
         key: "build-react-native-ios-fixture-new-arch"
@@ -156,31 +83,7 @@ steps:
           automatic:
             - exit_status: "*"
               limit: 1
-#
-      # - label: ':mac: Build RN {{matrix}} native integration test fixture ipa (Old Arch)'
-      #   key: "build-react-native-ios-fixture-native-integration-old-arch"
-      #   timeout_in_minutes: 30
-      #   agents:
-      #     queue: "macos-15"
-      #   env:
-      #     NODE_VERSION: "18"
-      #     RN_VERSION: "{{matrix}}"
-      #     RCT_NEW_ARCH_ENABLED: "0"
-      #     NOTIFIER_VERSION: "8.0.0"
-      #     BUILD_IOS: "true"
-      #     XCODE_VERSION: "16.2.0"
-      #     NATIVE_INTEGRATION: "1"
-      #   artifact_paths:
-      #     - "test/react-native/features/fixtures/generated/native-integration/old-arch/**/output/reactnative.ipa"
-      #   commands:
-      #     - bundle install
-      #     - node test/react-native/scripts/generate-react-native-fixture.js
-      #   matrix:
-      #     - "0.80"
-      #   retry:
-      #     automatic:
-      #       - exit_status: "*"
-      #         limit: 1
+
 
       - label: ':mac: Build RN {{matrix}} native integration test fixture ipa (New Arch)'
         key: "build-react-native-ios-fixture-native-integration-new-arch"
@@ -207,50 +110,7 @@ steps:
             - exit_status: "*"
               limit: 1
 
-        #
-        # End-to-end tests
-        #
-      # - label: ":bitbar: :android: RN {{matrix}} Android 13 (Old Arch) end-to-end tests"
-      #   depends_on: "build-react-native-android-fixture-old-arch"
-      #   timeout_in_minutes: 20
-      #   plugins:
-      #     artifacts#v1.9.0:
-      #       download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk"
-      #       upload:
-      #         - "./test/react-native/maze_output/failed/*"
-      #         - "./test/react-native/maze_output/maze_output.zip"
-      #     docker-compose#v4.7.0:
-      #       pull: react-native-maze-runner
-      #       run: react-native-maze-runner
-      #       service-ports: true
-      #       command:
-      #         - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
-      #         - --farm=bb
-      #         - --device=ANDROID_13
-      #         - --a11y-locator
-      #         - --fail-fast
-      #         - --appium-version=1.22
-      #         - --no-tunnel
-      #         - --aws-public-ip
-      #     test-collector#v1.10.2:
-      #       files: "reports/TEST-*.xml"
-      #       format: "junit"
-      #       branch: "^main|next$$"
-      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-      #   env:
-      #     RN_VERSION: "{{matrix}}"
-      #     REACT_NAVIGATION: "true"
-      #   retry:
-      #     manual:
-      #       permit_on_passed: true
-      #     automatic:
-      #       - exit_status: 103  # Appium session failed
-      #         limit: 2
-      #   concurrency: 25
-      #   concurrency_group: "bitbar"
-      #   concurrency_method: eager
-      #   matrix:
-      #     - "0.80"
+       
 
       - label: ":bitbar: :android: RN {{matrix}} Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
@@ -295,48 +155,7 @@ steps:
         matrix:
           - "0.84"
 
-      # - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (Old Arch) end-to-end tests"
-      #   depends_on: "build-react-native-android-fixture-native-integration-old-arch"
-      #   timeout_in_minutes: 20
-      #   plugins:
-      #     artifacts#v1.9.0:
-      #       download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk"
-      #       upload:
-      #         - "./test/react-native/maze_output/failed/*"
-      #         - "./test/react-native/maze_output/maze_output.zip"
-      #     docker-compose#v4.7.0:
-      #       pull: react-native-maze-runner
-      #       run: react-native-maze-runner
-      #       service-ports: true
-      #       command:
-      #         - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/reactnative.apk
-      #         - --farm=bb
-      #         - --device=ANDROID_13
-      #         - --a11y-locator
-      #         - --fail-fast
-      #         - --appium-version=1.22
-      #         - --no-tunnel
-      #         - --aws-public-ip
-      #         - --tags=@native_integration
-      #     test-collector#v1.10.2:
-      #       files: "reports/TEST-*.xml"
-      #       format: "junit"
-      #       branch: "^main|next$$"
-      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-      #   env:
-      #     NATIVE_INTEGRATION: "1"
-      #     RN_VERSION: "{{matrix}}"
-      #   retry:
-      #     manual:
-      #       permit_on_passed: true
-      #     automatic:
-      #       - exit_status: 103  # Appium session failed
-      #         limit: 2
-      #   concurrency: 25
-      #   concurrency_group: "bitbar"
-      #   concurrency_method: eager
-      #   matrix:
-      #     - "0.80"
+     
 
       - label: ":bitbar: :android: RN {{matrix}} native integration Android 13 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-native-integration-new-arch"
@@ -382,47 +201,7 @@ steps:
         matrix:
           - "0.84"
 
-      #  - label: ":bitbar: :mac: RN {{matrix}} iOS (Old Arch) end-to-end tests"
-      #   depends_on: "build-react-native-ios-fixture-old-arch"
-      #   timeout_in_minutes: 20
-      #   plugins:
-      #     artifacts#v1.9.0:
-      #       download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa"
-      #       upload:
-      #         - "./test/react-native/maze_output/failed/*"
-      #         - "./test/react-native/maze_output/maze_output.zip"
-      #     docker-compose#v4.12.0:
-      #       pull: react-native-maze-runner
-      #       run: react-native-maze-runner
-      #       service-ports: true
-      #       command:
-      #         - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
-      #         - --farm=bb
-      #         - --device=IOS_14|IOS_15|IOS_16|IOS_17|IOS_18|IOS_26
-      #         - --a11y-locator
-      #         - --fail-fast
-      #         - --appium-version=1.22
-      #         - --no-tunnel
-      #         - --aws-public-ip
-      #     test-collector#v1.10.2:
-      #       files: "reports/TEST-*.xml"
-      #       format: "junit"
-      #       branch: "^main|next$$"
-      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-      #   env:
-      #     RN_VERSION: "{{matrix}}"
-      #     REACT_NAVIGATION: "true"
-      #   retry:
-      #     manual:
-      #       permit_on_passed: true
-      #     automatic:
-      #       - exit_status: 103  # Appium session failed
-      #         limit: 2
-      #   concurrency: 25
-      #   concurrency_group: "bitbar"
-      #   concurrency_method: eager
-      #   matrix:
-      #     - "0.80"
+     
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"
@@ -467,48 +246,7 @@ steps:
         matrix:
           - "0.84"
 
-      # - label: ":bitbar: :mac: RN {{matrix}} native integration iOS (Old Arch) end-to-end tests"
-      #   depends_on: "build-react-native-ios-fixture-native-integration-old-arch"
-      #   timeout_in_minutes: 20
-      #   plugins:
-      #     artifacts#v1.9.0:
-      #       download: "test/react-native/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa"
-      #       upload:
-      #         - "./test/react-native/maze_output/failed/*"
-      #         - "./test/react-native/maze_output/maze_output.zip"
-      #     docker-compose#v4.12.0:
-      #       pull: react-native-maze-runner
-      #       run: react-native-maze-runner
-      #       service-ports: true
-      #       command:
-      #         - --app=/app/features/fixtures/generated/native-integration/old-arch/{{matrix}}/output/reactnative.ipa
-      #         - --farm=bb
-      #         - --device=IOS_14|IOS_15|IOS_16|IOS_17|IOS_18|IOS_26
-      #         - --a11y-locator
-      #         - --fail-fast
-      #         - --appium-version=1.22
-      #         - --no-tunnel
-      #         - --aws-public-ip
-      #         - --tags=@native_integration
-      #     test-collector#v1.10.2:
-      #       files: "reports/TEST-*.xml"
-      #       format: "junit"
-      #       branch: "^main|next$$"
-      #       api-token-env-name: "REACT_NATIVE_PERFORMANCE_BUILDKITE_ANALYTICS_TOKEN"
-      #   env:
-      #     NATIVE_INTEGRATION: "1"
-      #     RN_VERSION: "{{matrix}}"
-      #   retry:
-      #     manual:
-      #       permit_on_passed: true
-      #     automatic:
-      #       - exit_status: 103  # Appium session failed
-      #         limit: 2
-      #   concurrency: 25
-      #   concurrency_group: "bitbar"
-      #   concurrency_method: eager
-      #   matrix:
-      #     - "0.80"
+     
 
       - label: ":bitbar: :mac: RN {{matrix}} native integration iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-native-integration-new-arch"

--- a/test/react-native/scripts/utils/android-utils.js
+++ b/test/react-native/scripts/utils/android-utils.js
@@ -9,8 +9,17 @@ const { replaceInFile, appendToFileIfNotExists } = require('./file-utils')
 function configureAndroidProject (fixtureDir, isNewArchEnabled, reactNativeVersion) {
   // set android:usesCleartextTraffic="true" in AndroidManifest.xml
   const androidManifestPath = `${fixtureDir}/android/app/src/main/AndroidManifest.xml`
-  replaceInFile(androidManifestPath, '<application', '<application android:usesCleartextTraffic="true" android:largeHeap="true"')
-
+  //replaceInFile(androidManifestPath, '<application', '<application android:usesCleartextTraffic="true" android:largeHeap="true"')
+        let androidManifestContents = fs.readFileSync(androidManifestPath, 'utf8')
+         // RN 0.82+ uses a manifest placeholder that's autoconfigured by the RN gradle plugin
+    // eslint-disable-next-line no-template-curly-in-string
+    if (androidManifestContents.includes('${usesCleartextTraffic}')) {
+      // eslint-disable-next-line no-template-curly-in-string
+      androidManifestContents = androidManifestContents.replace('${usesCleartextTraffic}', 'true')
+    } else {
+      androidManifestContents = androidManifestContents.replace('<application', '<application android:usesCleartextTraffic="true" android:largeHeap="true"')
+    }
+        fs.writeFileSync(androidManifestPath, androidManifestContents)
   // enable/disable the new architecture in gradle.properties
   const gradlePropertiesPath = `${fixtureDir}/android/gradle.properties`
   replaceInFile(gradlePropertiesPath, /newArchEnabled\s*=\s*(true|false)/, `newArchEnabled=${isNewArchEnabled}`)


### PR DESCRIPTION
# Goal

Bugsnag performance SDK support react native updated version 0.84

## Changeset

updated buildkite yml file(support react native latest version and also updated the version of node) and made changes inside android-utils.js for new arch

## Testing

Done local testing as well as buildkite test cases