### PR TITLE
Pin react-native-file-access to v3

### DIFF
--- a/.buildkite/expo-pipeline.full.yml
+++ b/.buildkite/expo-pipeline.full.yml
@@ -15,6 +15,7 @@ steps:
         env:
           JAVA_VERSION: "17"
           EXPO_VERSION: "{{matrix}}"
+          EAS_BUILD_NO_EXPO_GO_WARNING: true
           BUILD_ANDROID: 1
         artifact_paths: test/react-native/features/fixtures/generated/expo/**/test-fixture/output.apk
         commands:
@@ -30,6 +31,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
+          EAS_BUILD_NO_EXPO_GO_WARNING: true
           EXPO_VERSION: "{{matrix}}"
           XCODE_VERSION: "16.2.0"
           BUILD_IOS: 1

--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -13,6 +13,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
+          EAS_BUILD_NO_EXPO_GO_WARNING: true
           JAVA_VERSION: "17"
           EXPO_VERSION: "{{matrix}}"
           BUILD_ANDROID: 1
@@ -29,6 +30,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
+          EAS_BUILD_NO_EXPO_GO_WARNING: true
           EXPO_VERSION: "{{matrix}}"
           BUILD_IOS: 1
         artifact_paths: test/react-native/features/fixtures/generated/expo/**/test-fixture/output.ipa

--- a/test/react-native/scripts/utils/dependency-utils.js
+++ b/test/react-native/scripts/utils/dependency-utils.js
@@ -131,7 +131,7 @@ function getExpoDependencies() {
   return [
     '@bugsnag/react-native',
     '@react-native-community/netinfo',
-    'react-native-file-access',
+    'react-native-file-access@^3.2.0',
     'expo-build-properties',
     'expo-constants'
   ]


### PR DESCRIPTION
## Goal

Pin the installed version of `react-native-file-access` to resolve issues building expo test fixtures